### PR TITLE
SL-169: initial http server package implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,10 +70,10 @@
       "node_modules"
     ],
     "moduleNameMapper": {
-      "@stoplight/prism-core/(.*)": "<rootDir>/packages/core/src/$1",
-      "@stoplight/prism-cli/(.*)": "<rootDir>/packages/cli/src/$1",
-      "@stoplight/prism-http/(.*)": "<rootDir>/packages/http/src/$1",
-      "@stoplight/prism-http-server/(.*)": "<rootDir>/packages/http-server/src/$1"
+      "@stoplight/prism-core(.*)": "<rootDir>/packages/core/src$1",
+      "@stoplight/prism-cli(.*)": "<rootDir>/packages/cli/src$1",
+      "@stoplight/prism-http(.*)": "<rootDir>/packages/http/src$1",
+      "@stoplight/prism-http-server(.*)": "<rootDir>/packages/http-server/src$1"
     }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,29 +16,11 @@ import {
   PrismConfigFactory,
 } from './types';
 
-export {
-  filesystemLoader,
-  IDisposable,
-  IFilesystemLoaderOpts,
-  IForwarder,
-  ILoader,
-  IMocker,
-  IPrism,
-  IPrismComponents,
-  IPrismConfig,
-  IPrismInput,
-  IPrismOutput,
-  IRouter,
-  IValidation,
-  IValidator,
-  PrismConfigFactory,
-};
-
 export function factory<Resource, Input, Output, Config, LoadOpts>(
   defaultComponents: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
 ): (
   customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
-) => ((opts: LoadOpts) => IPrism<Resource, Input, Output, Config, LoadOpts>) {
+) => ((opts?: LoadOpts) => IPrism<Resource, Input, Output, Config, LoadOpts>) {
   return customComponents => {
     const components: Partial<
       IPrismComponents<Resource, Input, Output, Config, LoadOpts>
@@ -151,3 +133,21 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
     };
   };
 }
+
+export {
+  filesystemLoader,
+  IDisposable,
+  IFilesystemLoaderOpts,
+  IForwarder,
+  ILoader,
+  IMocker,
+  IPrism,
+  IPrismComponents,
+  IPrismConfig,
+  IPrismInput,
+  IPrismOutput,
+  IRouter,
+  IValidation,
+  IValidator,
+  PrismConfigFactory,
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
   defaultComponents: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
 ): (
   customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
-) => ((opts?: LoadOpts) => IPrism<Resource, Input, Output, Config, LoadOpts>) {
+) => (opts?: LoadOpts) => IPrism<Resource, Input, Output, Config, LoadOpts> {
   return customComponents => {
     const components: Partial<
       IPrismComponents<Resource, Input, Output, Config, LoadOpts>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,7 +42,7 @@ export interface ILoader<Options, Resource> {
 }
 
 export interface IFilesystemLoaderOpts {
-  path: string;
+  path?: string;
 }
 
 export interface IRouter<Resource, Input, Config> {
@@ -101,7 +101,7 @@ export interface IPrismInput<I> {
 
 export interface IPrismOutput<I, O> {
   input?: I;
-  data?: O;
+  output?: O;
   validations: {
     input: IValidation[];
     output: IValidation[];

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -6,9 +6,7 @@ Usage:
 import { createServer } from '@stoplight/prism-http-server';
 
 const server = createServer({
-  loaderOpts: {
-    path: './api.oas2.json',
-  },
+  path: './api.oas2.json',
 });
 
 server.listen(3000).then(() => {

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -1,3 +1,17 @@
 # Prism Server
 
-TBD
+Usage:
+
+```js
+import { createServer } from '@stoplight/prism-http-server';
+
+const server = createServer({
+  loaderOpts: {
+    path: './api.oas2.json',
+  },
+});
+
+server.listen(3000).then(() => {
+  console.log('server is listening!');
+});
+```

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@stoplight/prism-core": "0.0.0",
-    "express": "^4.16.4"
+    "@stoplight/prism-http": "0.0.0",
+    "fastify": "1.12.x"
   }
 }

--- a/packages/http-server/src/__tests__/__snapshots__/getHttpConfigFromRequest.spec.ts.snap
+++ b/packages/http-server/src/__tests__/__snapshots__/getHttpConfigFromRequest.spec.ts.snap
@@ -1,25 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getHttpConfigFromRequest() extracts code 1`] = `
+exports[`getHttpConfigFromRequest() given default config function and that function returns a mock should combine with query params 1`] = `
 Object {
-  "code": "202",
+  "mock": Object {
+    "code": "400",
+    "exampleKey": "key",
+  },
 }
 `;
 
-exports[`getHttpConfigFromRequest() extracts dynamic 1`] = `
+exports[`getHttpConfigFromRequest() given default config object that is a map and matching query should return combined 1`] = `
 Object {
-  "dynamic": true,
+  "mock": Object {
+    "code": "200",
+    "exampleKey": "bear",
+    "mediaType": "plain/text",
+  },
 }
 `;
 
-exports[`getHttpConfigFromRequest() extracts example 1`] = `
+exports[`getHttpConfigFromRequest() given default config object that is boolean and matching query should return that query 1`] = `
 Object {
-  "exampleKey": "bear",
+  "mock": Object {
+    "code": "200",
+    "exampleKey": "bear",
+  },
 }
 `;
 
-exports[`getHttpConfigFromRequest() extracts mediaType 1`] = `
+exports[`getHttpConfigFromRequest() given default config object that is boolean and no matching query params should return that config object 1`] = `
 Object {
-  "mediaType": "application/json",
+  "mock": false,
+}
+`;
+
+exports[`getHttpConfigFromRequest() given no default config and no matching query should return my own default 1`] = `
+Object {
+  "mock": true,
+}
+`;
+
+exports[`getHttpConfigFromRequest() given no default config and no query should return my own default 1`] = `
+Object {
+  "mock": true,
+}
+`;
+
+exports[`getHttpConfigFromRequest() given no default config extracts code 1`] = `
+Object {
+  "mock": Object {
+    "code": "202",
+  },
+}
+`;
+
+exports[`getHttpConfigFromRequest() given no default config extracts dynamic 1`] = `
+Object {
+  "mock": Object {
+    "dynamic": true,
+  },
+}
+`;
+
+exports[`getHttpConfigFromRequest() given no default config extracts example 1`] = `
+Object {
+  "mock": Object {
+    "exampleKey": "bear",
+  },
+}
+`;
+
+exports[`getHttpConfigFromRequest() given no default config extracts mediaType 1`] = `
+Object {
+  "mock": Object {
+    "mediaType": "application/json",
+  },
 }
 `;

--- a/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
+++ b/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
@@ -1,37 +1,116 @@
-import { IHttpRequest } from '@stoplight/prism-http';
 import { getHttpConfigFromRequest } from '../getHttpConfigFromRequest';
 
-describe('getHttpConfigFromRequest()', () => {
-  test('extracts code', () => {
-    return expect(
-      getHttpConfigFromRequest({
-        method: 'get',
-        url: { path: '/', query: { __code: '202' } },
-      } as IHttpRequest)
-    ).resolves.toMatchSnapshot();
+describe.only('getHttpConfigFromRequest()', () => {
+  describe('given no default config', () => {
+    test('and no query should return my own default', () => {
+      return expect(
+        getHttpConfigFromRequest({
+          method: 'get',
+          url: { path: '/' },
+        })
+      ).resolves.toMatchSnapshot();
+    });
+    test('and no matching query should return my own default', () => {
+      return expect(
+        getHttpConfigFromRequest({
+          method: 'get',
+          url: { path: '/', query: {} },
+        })
+      ).resolves.toMatchSnapshot();
+    });
+    test('extracts code', () => {
+      return expect(
+        getHttpConfigFromRequest({
+          method: 'get',
+          url: { path: '/', query: { __code: '202' } },
+        })
+      ).resolves.toMatchSnapshot();
+    });
+    test('extracts mediaType', () => {
+      return expect(
+        getHttpConfigFromRequest({
+          method: 'get',
+          url: { path: '/', query: { __contentType: 'application/json' } },
+        })
+      ).resolves.toMatchSnapshot();
+    });
+    test('extracts example', () => {
+      return expect(
+        getHttpConfigFromRequest({
+          method: 'get',
+          url: { path: '/', query: { __example: 'bear' } },
+        })
+      ).resolves.toMatchSnapshot();
+    });
+    test('extracts dynamic', () => {
+      return expect(
+        getHttpConfigFromRequest({
+          method: 'get',
+          url: { path: '/', query: { __dynamic: 'true' } },
+        })
+      ).resolves.toMatchSnapshot();
+    });
   });
-  test('extracts mediaType', () => {
-    return expect(
-      getHttpConfigFromRequest({
-        method: 'get',
-        url: { path: '/', query: { __contentType: 'application/json' } },
-      } as IHttpRequest)
-    ).resolves.toMatchSnapshot();
+
+  describe('given default config function', () => {
+    test('and that function returns a mock should combine with query params', () => {
+      const spy = jest.fn().mockReturnValue({
+        mock: {
+          exampleKey: 'key',
+        },
+      });
+      return expect(
+        getHttpConfigFromRequest(
+          {
+            method: 'get',
+            url: { path: '/', query: { __code: '400' } },
+          },
+          spy
+        )
+      ).resolves.toMatchSnapshot();
+    });
   });
-  test('extracts example', () => {
-    return expect(
-      getHttpConfigFromRequest({
-        method: 'get',
-        url: { path: '/', query: { __example: 'bear' } },
-      } as IHttpRequest)
-    ).resolves.toMatchSnapshot();
-  });
-  test('extracts dynamic', () => {
-    return expect(
-      getHttpConfigFromRequest({
-        method: 'get',
-        url: { path: '/', query: { __dynamic: 'true' } },
-      } as IHttpRequest)
-    ).resolves.toMatchSnapshot();
+
+  describe('given default config object', () => {
+    test('that is boolean and no matching query params should return that config object', () => {
+      return expect(
+        getHttpConfigFromRequest(
+          {
+            method: 'get',
+            url: { path: '/', query: {} },
+          },
+          { mock: false }
+        )
+      ).resolves.toMatchSnapshot();
+    });
+
+    test('that is boolean and matching query should return that query', () => {
+      return expect(
+        getHttpConfigFromRequest(
+          {
+            method: 'get',
+            url: { path: '/', query: { __code: '200', __example: 'bear' } },
+          },
+          { mock: false }
+        )
+      ).resolves.toMatchSnapshot();
+    });
+
+    test('that is a map and matching query should return combined', () => {
+      return expect(
+        getHttpConfigFromRequest(
+          {
+            method: 'get',
+            url: { path: '/', query: { __code: '200', __example: 'bear' } },
+          },
+          {
+            mock: {
+              exampleKey: 'wolf',
+              mediaType: 'plain/text',
+            },
+          }
+        )
+      ).resolves.toMatchSnapshot();
+    });
   });
 });

--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -1,0 +1,77 @@
+import { createServer } from '../server';
+
+describe('server', () => {
+  const server = createServer({
+    components: {
+      // TODO: once validator is implemented, don't unset it here
+      validator: undefined,
+
+      // set a custom loader for testing to mock back some HttpOperations
+      loader: {
+        load: async _opts => {
+          return [
+            {
+              id: '1',
+              method: 'get',
+              path: '/',
+              servers: [{ url: 'http://localhost:3000' }],
+              responses: [
+                {
+                  code: '200',
+                  content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+                },
+              ],
+            },
+            {
+              id: '1',
+              method: 'post',
+              path: '/todos',
+              servers: [{ url: 'http://localhost:3000' }],
+              responses: [
+                {
+                  code: '201',
+                  content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+                },
+                {
+                  code: '401',
+                  content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+                },
+              ],
+            },
+          ];
+        },
+      },
+    },
+  });
+
+  afterAll(server.fastify.close);
+
+  test('should mock back root path', async () => {
+    const response = await server.fastify.inject({
+      method: 'GET',
+      url: '/',
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  test('should default to 2xx', async () => {
+    const response = await server.fastify.inject({
+      method: 'POST',
+      url: '/todos',
+    });
+
+    expect(response.statusCode).toBe(201);
+  });
+
+  // TODO: this test is failing because of our weird URL handling.
+  // should just be able to pass full url into prism, and prism should break out the parts
+  test.skip('should support choosing a response code', async () => {
+    const response = await server.fastify.inject({
+      method: 'POST',
+      url: '/todos?__code=401',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+});

--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -1,48 +1,51 @@
 import { createServer } from '../server';
 
 describe('server', () => {
-  const server = createServer({
-    components: {
-      // TODO: once validator is implemented, don't unset it here
-      validator: undefined,
+  const server = createServer(
+    {},
+    {
+      components: {
+        // TODO: once validator is implemented, don't unset it here
+        validator: undefined,
 
-      // set a custom loader for testing to mock back some HttpOperations
-      loader: {
-        load: async _opts => {
-          return [
-            {
-              id: '1',
-              method: 'get',
-              path: '/',
-              servers: [{ url: 'http://localhost:3000' }],
-              responses: [
-                {
-                  code: '200',
-                  content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
-                },
-              ],
-            },
-            {
-              id: '1',
-              method: 'post',
-              path: '/todos',
-              servers: [{ url: 'http://localhost:3000' }],
-              responses: [
-                {
-                  code: '201',
-                  content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
-                },
-                {
-                  code: '401',
-                  content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
-                },
-              ],
-            },
-          ];
+        // set a custom loader for testing to mock back some HttpOperations
+        loader: {
+          load: async _opts => {
+            return [
+              {
+                id: '1',
+                method: 'get',
+                path: '/',
+                servers: [{ url: 'http://localhost:3000' }],
+                responses: [
+                  {
+                    code: '200',
+                    content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+                  },
+                ],
+              },
+              {
+                id: '1',
+                method: 'post',
+                path: '/todos',
+                servers: [{ url: 'http://localhost:3000' }],
+                responses: [
+                  {
+                    code: '201',
+                    content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+                  },
+                  {
+                    code: '401',
+                    content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+                  },
+                ],
+              },
+            ];
+          },
         },
       },
-    },
-  });
+    }
+  );
 
   afterAll(server.fastify.close);
 

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -20,30 +20,19 @@ export const getHttpConfigFromRequest: PrismConfigFactory<IHttpConfig, IHttpRequ
   const config: IHttpConfig = defaultConfig
     ? await getConfig<IHttpConfig, IHttpRequest>(req, defaultConfig)
     : { mock: true };
-  const httpOperationConfig: IHttpOperationConfig = {};
   const query = req.url.query;
-
   if (!query) {
     return config;
   }
 
   const { __code, __dynamic, __contentType, __example } = query;
 
-  if (__code) {
-    httpOperationConfig.code = __code;
-  }
-
-  if (__dynamic) {
-    httpOperationConfig.dynamic = __dynamic.toLowerCase() === 'true';
-  }
-
-  if (__contentType) {
-    httpOperationConfig.mediaType = __contentType;
-  }
-
-  if (__example) {
-    httpOperationConfig.exampleKey = __example;
-  }
+  const httpOperationConfig: IHttpOperationConfig = {
+    code: __code,
+    dynamic: __dynamic && __dynamic.toLowerCase() === 'true' ? true : false,
+    mediaType: __contentType,
+    exampleKey: __example,
+  };
 
   if (Object.keys(httpOperationConfig).length) {
     if (typeof config.mock === 'boolean') {

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -20,19 +20,30 @@ export const getHttpConfigFromRequest: PrismConfigFactory<IHttpConfig, IHttpRequ
   const config: IHttpConfig = defaultConfig
     ? await getConfig<IHttpConfig, IHttpRequest>(req, defaultConfig)
     : { mock: true };
+  const httpOperationConfig: IHttpOperationConfig = {};
   const query = req.url.query;
+
   if (!query) {
     return config;
   }
 
   const { __code, __dynamic, __contentType, __example } = query;
 
-  const httpOperationConfig: IHttpOperationConfig = {
-    code: __code,
-    dynamic: __dynamic && __dynamic.toLowerCase() === 'true' ? true : false,
-    mediaType: __contentType,
-    exampleKey: __example,
-  };
+  if (__code) {
+    httpOperationConfig.code = __code;
+  }
+
+  if (__dynamic) {
+    httpOperationConfig.dynamic = __dynamic.toLowerCase() === 'true';
+  }
+
+  if (__contentType) {
+    httpOperationConfig.mediaType = __contentType;
+  }
+
+  if (__example) {
+    httpOperationConfig.exampleKey = __example;
+  }
 
   if (Object.keys(httpOperationConfig).length) {
     if (typeof config.mock === 'boolean') {

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -1,1 +1,1 @@
-import './server';
+export * from './server';

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,21 +1,26 @@
-import { createInstance, IHttpMethod, TPrismHttpInstance } from '@stoplight/prism-http';
+import { IFilesystemLoaderOpts } from '@stoplight/prism-core';
+import { createInstance } from '@stoplight/prism-http';
+import { IHttpMethod, TPrismHttpInstance } from '@stoplight/prism-http/types';
 import * as fastify from 'fastify';
 import { IncomingMessage, Server, ServerResponse } from 'http';
 
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
 import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
 
-export const createServer = (opts: IPrismHttpServerOpts = {}): IPrismHttpServer => {
+export const createServer = <LoaderInput = IFilesystemLoaderOpts>(
+  loaderInput: LoaderInput,
+  opts: IPrismHttpServerOpts<LoaderInput> = {}
+): IPrismHttpServer<LoaderInput> => {
   const server = fastify<Server, IncomingMessage, ServerResponse>();
 
-  const prism = createInstance({
+  const prism = createInstance<LoaderInput>({
     config: getHttpConfigFromRequest,
     ...(opts.components || {}),
-  })(opts.fileLoader);
+  })(loaderInput);
 
   server.all('*', {}, replyHandler(prism));
 
-  const prismServer: IPrismHttpServer = {
+  const prismServer: IPrismHttpServer<LoaderInput> = {
     get prism() {
       return prism;
     },

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -1,15 +1,13 @@
-import { IFilesystemLoaderOpts } from '@stoplight/prism-core';
-import { TPrismHttpComponents, TPrismHttpInstance } from '@stoplight/prism-http';
+import { TPrismHttpComponents, TPrismHttpInstance } from '@stoplight/prism-http/types';
 import { FastifyInstance, ServerOptions } from 'fastify';
 
-export interface IPrismHttpServerOpts {
-  loaderOpts?: IFilesystemLoaderOpts;
+export interface IPrismHttpServerOpts<LoaderInput> {
   fastify?: ServerOptions;
-  components?: TPrismHttpComponents;
+  components?: TPrismHttpComponents<LoaderInput>;
 }
 
-export interface IPrismHttpServer {
-  readonly prism: TPrismHttpInstance;
+export interface IPrismHttpServer<LoaderInput> {
+  readonly prism: TPrismHttpInstance<LoaderInput>;
   readonly fastify: FastifyInstance;
   listen: ListenFunc;
 }

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -1,0 +1,17 @@
+import { IFilesystemLoaderOpts } from '@stoplight/prism-core';
+import { TPrismHttpComponents, TPrismHttpInstance } from '@stoplight/prism-http';
+import { FastifyInstance, ServerOptions } from 'fastify';
+
+export interface IPrismHttpServerOpts {
+  loaderOpts?: IFilesystemLoaderOpts;
+  fastify?: ServerOptions;
+  components?: TPrismHttpComponents;
+}
+
+export interface IPrismHttpServer {
+  readonly prism: TPrismHttpInstance;
+  readonly fastify: FastifyInstance;
+  listen: ListenFunc;
+}
+
+export type ListenFunc = (port: number, address?: string, backlog?: number) => Promise<string>;

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,4 +1,10 @@
-import { factory, filesystemLoader, IFilesystemLoaderOpts } from '@stoplight/prism-core';
+import {
+  factory,
+  filesystemLoader,
+  IFilesystemLoaderOpts,
+  IPrism,
+  IPrismComponents,
+} from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 
 import { forwarder } from './forwarder';
@@ -7,6 +13,18 @@ import { JSONSchemaExampleGenerator } from './mocker/generator/JSONSchemaExample
 import { router } from './router';
 import { IHttpConfig, IHttpMethod, IHttpRequest, IHttpResponse } from './types';
 import { validator } from './validator';
+
+export type TPrismHttpInstance = IPrism<
+  IHttpOperation,
+  IHttpRequest,
+  IHttpResponse,
+  IHttpConfig,
+  IFilesystemLoaderOpts
+>;
+
+export type TPrismHttpComponents = Partial<
+  IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, IFilesystemLoaderOpts>
+>;
 
 const createInstance = factory<
   IHttpOperation,

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,46 +1,32 @@
-import {
-  factory,
-  filesystemLoader,
-  IFilesystemLoaderOpts,
-  IPrism,
-  IPrismComponents,
-} from '@stoplight/prism-core';
+import { factory, filesystemLoader, IFilesystemLoaderOpts } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 
 import { forwarder } from './forwarder';
 import { HttpMocker } from './mocker';
 import { JSONSchemaExampleGenerator } from './mocker/generator/JSONSchemaExampleGenerator';
 import { router } from './router';
-import { IHttpConfig, IHttpMethod, IHttpRequest, IHttpResponse } from './types';
+import {
+  IHttpConfig,
+  IHttpMethod,
+  IHttpRequest,
+  IHttpResponse,
+  TPrismHttpComponents,
+} from './types';
 import { validator } from './validator';
 
-export type TPrismHttpInstance = IPrism<
-  IHttpOperation,
-  IHttpRequest,
-  IHttpResponse,
-  IHttpConfig,
-  IFilesystemLoaderOpts
->;
-
-export type TPrismHttpComponents = Partial<
-  IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, IFilesystemLoaderOpts>
->;
-
-const createInstance = factory<
-  IHttpOperation,
-  IHttpRequest,
-  IHttpResponse,
-  IHttpConfig,
-  IFilesystemLoaderOpts
->({
-  config: {
-    mock: true,
-  },
-  loader: filesystemLoader,
-  router,
-  forwarder,
-  validator,
-  mocker: new HttpMocker(new JSONSchemaExampleGenerator()),
-});
+const createInstance = <LoaderInput = IFilesystemLoaderOpts>(
+  overrides: TPrismHttpComponents<LoaderInput>
+) => {
+  return factory<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, LoaderInput>({
+    config: {
+      mock: true,
+    },
+    loader: filesystemLoader,
+    router,
+    forwarder,
+    validator,
+    mocker: new HttpMocker(new JSONSchemaExampleGenerator()),
+  })(overrides);
+};
 
 export { IHttpConfig, IHttpMethod, IHttpRequest, IHttpResponse, createInstance };

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -1,4 +1,5 @@
 import { JSONSchemaExampleGenerator } from '@stoplight/prism-http/mocker/generator/JSONSchemaExampleGenerator';
+import { ISchema } from '@stoplight/types/schema';
 import * as Ajv from 'ajv';
 
 import { httpOperations, httpRequests } from '../../__tests__/fixtures';
@@ -55,7 +56,7 @@ describe('http mocker', () => {
         }
 
         const ajv = new Ajv();
-        const validate = ajv.compile(httpOperations[1].responses[0].content[0].schema);
+        const validate = ajv.compile(httpOperations[1].responses[0].content[0].schema as ISchema);
 
         const response = await mocker.mock({
           resource: httpOperations[1],
@@ -95,7 +96,7 @@ describe('http mocker', () => {
       });
 
       const ajv = new Ajv();
-      const validate = ajv.compile(httpOperations[1].responses[1].content[0].schema);
+      const validate = ajv.compile(httpOperations[1].responses[1].content[0].schema as ISchema);
 
       expect(validate(JSON.parse(response.body))).toBe(true);
     });

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,4 +1,22 @@
-import { IPrismConfig } from '@stoplight/prism-core';
+import {
+  IFilesystemLoaderOpts,
+  IPrism,
+  IPrismComponents,
+  IPrismConfig,
+} from '@stoplight/prism-core';
+import { IHttpOperation } from '@stoplight/types';
+
+export type TPrismHttpInstance<LoaderInput = IFilesystemLoaderOpts> = IPrism<
+  IHttpOperation,
+  IHttpRequest,
+  IHttpResponse,
+  IHttpConfig,
+  LoaderInput
+>;
+
+export type TPrismHttpComponents<LoaderInput = IFilesystemLoaderOpts> = Partial<
+  IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, LoaderInput>
+>;
 
 // TODO: should be complete | and in the @stoplight/types repo
 export type IHttpMethod =

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -12,10 +12,10 @@ export type IHttpMethod =
   | 'trace'; // ... etc
 
 export interface IHttpOperationConfig {
-  readonly mediaType?: string;
-  readonly code?: string;
-  readonly exampleKey?: string;
-  readonly dynamic?: boolean;
+  mediaType?: string;
+  code?: string;
+  exampleKey?: string;
+  dynamic?: boolean;
 }
 
 export interface IHttpConfig extends IPrismConfig {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "target": "es5",
     "module": "commonjs",
     "importHelpers": true,
-    "lib": ["es6", "es7", "dom"],
+    "lib": ["es6", "es7"],
     "outDir": "lib",
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,14 +336,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
-  dependencies:
-    follow-redirects "^1.3.0"
-    is-buffer "^1.1.5"
-
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -825,13 +817,6 @@ data-urls@^1.0.0:
     abab "^2.0.0"
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
-
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
@@ -1340,13 +1325,6 @@ flatstr@^1.0.5, flatstr@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.8.tgz#0e849229751f2b9f6a0919f8e81e1229e84ba901"
   integrity sha512-YXblbv/vc1zuVVUtnKl1hPqqk7TalZCppnKE7Pr8FI/Rp48vzckS/4SJ4Y9O9RNiI82Vcw/FydmtqdQOg1Dpqw==
-
-follow-redirects@^1.3.0:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
-  integrity sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==
-  dependencies:
-    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,14 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.7.tgz#0e75ca9357d646ca754016ca1d68a127ad7e7300"
   integrity sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==
 
+"@types/pino@^4.16.0":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@types/pino/-/pino-4.16.1.tgz#3b4b36e707cb364dcf0903503a7f44df67294b1c"
+  integrity sha512-uYEhZ3jsuiYFsPcR34fbxVlrqzqphc+QQ3fU4rWR6PXH8ka2TKvPBjtkNqj8oBHouVGf4GCRfyPb7FG2TEtPZA==
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
 "@types/range-parser@*":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
@@ -114,13 +122,10 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
-  integrity sha1-63d99gEXI6OxTopywIBcjoZ0a9I=
-  dependencies:
-    mime-types "~2.1.18"
-    negotiator "0.6.1"
+abstract-logging@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-1.0.0.tgz#8b7deafd310559bc28f77724dd1bb30177278c1b"
+  integrity sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=
 
 acorn-globals@^4.1.0:
   version "4.3.0"
@@ -145,7 +150,7 @@ acorn@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
   integrity sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==
 
-ajv@6.5.x:
+ajv@6.5.x, ajv@^6.0.0, ajv@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
   integrity sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==
@@ -254,11 +259,6 @@ array-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
   integrity sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
 
-array-flatten@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
-  integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
-
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -318,6 +318,14 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+avvio@^5.8.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/avvio/-/avvio-5.9.0.tgz#3513709b7d6a2bd93cb20252a13a875ae54d0b0a"
+  integrity sha512-bzgrSPRdU1T/AkhEuXWAA6cJCFA3zApLk+5fkpcQt4US9YAI52AFYnsGX1HSCF2bHSltEYfk7fbffYu4WnazmA==
+  dependencies:
+    debug "^3.1.0"
+    fastq "^1.6.0"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -327,6 +335,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -514,22 +530,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-body-parser@1.18.3:
-  version "1.18.3"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
-  integrity sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=
-  dependencies:
-    bytes "3.0.0"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "~1.1.2"
-    http-errors "~1.6.3"
-    iconv-lite "0.4.23"
-    on-finished "~2.3.0"
-    qs "6.5.2"
-    raw-body "2.3.3"
-    type-is "~1.6.16"
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -599,11 +599,6 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
-bytes@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
-  integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
-
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -657,7 +652,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
@@ -772,32 +767,12 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-content-disposition@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
-  integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
-
-content-type@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
 convert-source-map@^1.4.0, convert-source-map@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
   dependencies:
     safe-buffer "~5.1.1"
-
-cookie-signature@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
-  integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
-
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -851,7 +826,14 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -884,6 +866,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -930,16 +917,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-
-depd@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
-
-destroy@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
-  integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -996,15 +973,12 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-ee-first@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
-  integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
-encodeurl@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
-  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  integrity sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+  dependencies:
+    once "^1.4.0"
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -1032,11 +1006,6 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-escape-html@~1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-  integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1113,11 +1082,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
-etag@~1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
-  integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
-
 exec-sh@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.2.tgz#2a5e7ffcbd7d0ba2755bdecb16e5a427dfbdec36"
@@ -1182,42 +1146,6 @@ expect@^23.6.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
-express@^4.16.4:
-  version "4.16.4"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
-  integrity sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==
-  dependencies:
-    accepts "~1.3.5"
-    array-flatten "1.1.1"
-    body-parser "1.18.3"
-    content-disposition "0.5.2"
-    content-type "~1.0.4"
-    cookie "0.3.1"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.2"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.1.1"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.4"
-    qs "6.5.2"
-    range-parser "~1.2.0"
-    safe-buffer "5.1.2"
-    send "0.16.2"
-    serve-static "1.13.2"
-    setprototypeof "1.1.0"
-    statuses "~1.4.0"
-    type-is "~1.6.16"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
 extend-shallow@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
@@ -1269,6 +1197,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-decode-uri-component@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.0.tgz#7ce10336aa4b26286fee93d71e6785ff0f596a33"
+  integrity sha512-WQSYVKn6tDW/3htASeUkrx5LcnuTENQIZQPCVlwdnvIJ7bYtSpoJYq38MgUJnx1CQIR1gjZ8HJxAEcN4gqugBg==
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
@@ -1284,15 +1217,59 @@ fast-diff@^1.1.1:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-json-parse@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
+  integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
+fast-json-stringify@^1.8.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-1.9.1.tgz#fc4c13fc93d54d21e0deb738e40abe31d35fd756"
+  integrity sha512-vBXDKcJtoruWZeoqq/ViqJ3VxZH5LimgBTczIPe3x6m6XAgNr7fpAdPml81K+kb+rVl4hTJa/6iMVB62Fus+1A==
+  dependencies:
+    ajv "^6.5.4"
+    deepmerge "^2.1.1"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-safe-stringify@^1.0.8, fast-safe-stringify@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz#9fe22c37fb2f7f86f06b8f004377dbf8f1ee7bc1"
+  integrity sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw==
+
+fastify@1.12.x:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-1.12.1.tgz#9c314bde2d7e9e26ad70f844414f33a97a7ddc01"
+  integrity sha512-hpOJQyUSF0WtEK7ED1PZNf99t64Gs9I7KhhwqnX9QrQZliPuY5FXYOKjfRo6H8qW/DMPEnrWyCgbajfl1zHULg==
+  dependencies:
+    "@types/pino" "^4.16.0"
+    abstract-logging "^1.0.0"
+    ajv "^6.5.4"
+    avvio "^5.8.0"
+    end-of-stream "^1.4.1"
+    fast-json-stringify "^1.8.0"
+    find-my-way "^1.15.3"
+    flatstr "^1.0.8"
+    light-my-request "^3.0.0"
+    middie "^3.1.0"
+    pino "^4.17.3"
+    proxy-addr "^2.0.3"
+    tiny-lru "^1.6.1"
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -1335,18 +1312,14 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-finalhandler@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
-  integrity sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==
+find-my-way@^1.15.3:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-1.15.4.tgz#3b1da909347022e0b5ed94ecaaabf6d99096edd6"
+  integrity sha512-3XPCOhoGMPK6ELgUHd5BuNxsL+fTNM0EIrTlcLwjT2uZq22UHL4IQt5N54PIQblk164ioZATRov9mcuA4RB3eA==
   dependencies:
-    debug "2.6.9"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    statuses "~1.4.0"
-    unpipe "~1.0.0"
+    fast-decode-uri-component "^1.0.0"
+    safe-regex "^1.1.0"
+    semver-store "^0.3.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -1362,6 +1335,18 @@ find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+flatstr@^1.0.5, flatstr@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.8.tgz#0e849229751f2b9f6a0919f8e81e1229e84ba901"
+  integrity sha512-YXblbv/vc1zuVVUtnKl1hPqqk7TalZCppnKE7Pr8FI/Rp48vzckS/4SJ4Y9O9RNiI82Vcw/FydmtqdQOg1Dpqw==
+
+follow-redirects@^1.3.0:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.9.tgz#c9ed9d748b814a39535716e531b9196a845d89c6"
+  integrity sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
@@ -1405,11 +1390,6 @@ fragment-cache@^0.2.1:
   integrity sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
   dependencies:
     map-cache "^0.2.2"
-
-fresh@0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
-  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
 fs-minipass@^1.2.5:
   version "1.2.5"
@@ -1623,16 +1603,6 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
-
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -1641,13 +1611,6 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-iconv-lite@0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
-  integrity sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
@@ -1684,7 +1647,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
@@ -2557,6 +2520,14 @@ lex-parser@0.1.x, lex-parser@~0.1.3:
   resolved "https://registry.yarnpkg.com/lex-parser/-/lex-parser-0.1.4.tgz#64c4f025f17fd53bfb45763faeb16f015a747550"
   integrity sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=
 
+light-my-request@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-3.1.0.tgz#c2bc47c329622d4282cd34764f6f4dfbcbe73144"
+  integrity sha512-ZSFO3XnQNSKsHR/E2ZMga5btdiIa3sNoT6CZIZ8Hr1VHJWBNcRRurVYpQlaJqvQqwg3aOl09QpVOnjB9ajnYHQ==
+  dependencies:
+    ajv "^6.0.0"
+    readable-stream "^3.0.0"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2630,22 +2601,12 @@ math-random@^1.0.1:
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac"
   integrity sha1-izqsWIuKZuSXXjzepn97sylgH6w=
 
-media-typer@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   integrity sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=
   dependencies:
     mimic-fn "^1.0.0"
-
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -2658,11 +2619,6 @@ merge@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
   integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
-
-methods@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
-  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
 micromatch@^2.3.11:
   version "2.3.11"
@@ -2702,22 +2658,25 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+middie@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/middie/-/middie-3.2.0.tgz#d7cf1deb78b4dd84ab5408c68271406b381bf339"
+  integrity sha512-anXJ0QJfQcgneQvcWAJBwVvNckRLI68zWNEUv/7/7z/Wb/UMFTHmugpM93T4Q75+DclC9FHdms8cTseDQEV3yA==
+  dependencies:
+    path-to-regexp "^2.0.0"
+    reusify "^1.0.2"
+
 mime-db@~1.36.0:
   version "1.36.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
   integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
-mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
   dependencies:
     mime-db "~1.36.0"
-
-mime@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
-  integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -2822,23 +2781,18 @@ needle@^2.2.1:
     iconv-lite "^0.4.4"
     sax "^1.2.4"
 
-negotiator@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
-  integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
 node-notifier@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
-  integrity sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.3.0.tgz#c77a4a7b84038733d5fb351aafd8a268bfe19a01"
+  integrity sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==
   dependencies:
     growly "^1.3.0"
-    semver "^5.4.1"
+    semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
 
@@ -2985,14 +2939,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-on-finished@~2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
-  integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
-  dependencies:
-    ee-first "1.1.1"
-
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -3099,11 +3046,6 @@ parse5@4.0.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
 
-parseurl@~1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
-  integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=
-
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -3136,10 +3078,10 @@ path-parse@^1.0.5:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+path-to-regexp@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -3171,6 +3113,25 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pino-std-serializers@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.3.0.tgz#34eeaab97c055c28e22c0542ae55978e7e427786"
+  integrity sha512-klfGoOsP6sJH7ON796G4xoUSx2fkpFgKHO4YVVO2zmz31jR+etzc/QzGJILaOIiCD6HTCFgkPx+XN8nk+ruqPw==
+
+pino@^4.17.3:
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-4.17.6.tgz#8c237f3a29f4104f89321c25037deab6a7998fb4"
+  integrity sha512-LFDwmhyWLBnmwO/2UFbWu1jEGVDzaPupaVdx0XcZ3tIAx1EDEBauzxXf2S0UcFK7oe+X9MApjH0hx9U1XMgfCA==
+  dependencies:
+    chalk "^2.4.1"
+    fast-json-parse "^1.0.3"
+    fast-safe-stringify "^1.2.3"
+    flatstr "^1.0.5"
+    pino-std-serializers "^2.0.0"
+    pump "^3.0.0"
+    quick-format-unescaped "^1.1.2"
+    split2 "^2.2.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -3230,7 +3191,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-proxy-addr@~2.0.4:
+proxy-addr@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
   integrity sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
@@ -3248,6 +3209,14 @@ psl@^1.1.24:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
 
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3258,10 +3227,17 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@6.5.2, qs@~6.5.2:
+qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+quick-format-unescaped@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz#0ca581de3174becef25ac3c2e8956342381db698"
+  integrity sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=
+  dependencies:
+    fast-safe-stringify "^1.0.8"
 
 randexp@^0.5.3:
   version "0.5.3"
@@ -3279,21 +3255,6 @@ randomatic@^3.0.0:
     is-number "^4.0.0"
     kind-of "^6.0.0"
     math-random "^1.0.1"
-
-range-parser@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
-  integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
-
-raw-body@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
-  integrity sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==
-  dependencies:
-    bytes "3.0.0"
-    http-errors "1.6.3"
-    iconv-lite "0.4.23"
-    unpipe "1.0.0"
 
 rc@^1.2.7:
   version "1.2.8"
@@ -3322,7 +3283,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.6:
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.5:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -3334,6 +3295,15 @@ readable-stream@^2.0.1, readable-stream@^2.0.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
+  integrity sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 realpath-native@^1.0.0:
   version "1.0.2"
@@ -3475,6 +3445,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+reusify@^1.0.0, reusify@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
@@ -3487,7 +3462,7 @@ rsvp@^3.3.3:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
   integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
 
-safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -3525,39 +3500,15 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0:
+semver-store@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
+  integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
+
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
-
-send@0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
-  integrity sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==
-  dependencies:
-    debug "2.6.9"
-    depd "~1.1.2"
-    destroy "~1.0.4"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    fresh "0.5.2"
-    http-errors "~1.6.2"
-    mime "1.4.1"
-    ms "2.0.0"
-    on-finished "~2.3.0"
-    range-parser "~1.2.0"
-    statuses "~1.4.0"
-
-serve-static@1.13.2:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.13.2.tgz#095e8472fd5b46237db50ce486a43f4b86c6cec1"
-  integrity sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==
-  dependencies:
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    parseurl "~1.3.2"
-    send "0.16.2"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3583,11 +3534,6 @@ set-value@^2.0.0:
     is-extendable "^0.1.1"
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
-
-setprototypeof@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
-  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -3730,6 +3676,13 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split2@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
+  integrity sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==
+  dependencies:
+    through2 "^2.0.2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -3770,16 +3723,6 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
-  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
-
-statuses@~1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
-  integrity sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==
-
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -3810,7 +3753,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@~1.1.1:
+string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
@@ -3905,6 +3848,19 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
+
+through2@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  integrity sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
+
+tiny-lru@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-1.6.1.tgz#addb5c043311d1f07cd3a81d706ae739b8efebb1"
+  integrity sha512-m8oyPnHjnQlbDk8+MCw33qRMp6+BxPxoayN9C743VToeyQ5zZV6F6vkklrYVEI0z9MQ3+jmc+22tKmvPg4gmoA==
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -4068,14 +4024,6 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.16:
-  version "1.6.16"
-  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
-  integrity sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==
-  dependencies:
-    media-typer "0.3.0"
-    mime-types "~2.1.18"
-
 typescript@3.1.x:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
@@ -4109,11 +4057,6 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^0.4.3"
 
-unpipe@1.0.0, unpipe@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
-  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
-
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -4139,7 +4082,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -4151,11 +4094,6 @@ util.promisify@^1.0.0:
   dependencies:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
-
-utils-merge@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
-  integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
 uuid@^3.3.2:
   version "3.3.2"
@@ -4169,11 +4107,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-vary@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
-  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 verror@1.10.0:
   version "1.10.0"
@@ -4303,6 +4236,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xtend@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Example end user usage in the readme. This is, for example, how the official CLI package would start up a server when needed.

- fastify as the underlying http server
- expose fastify options on creation
- expose fastify instance to end user, so they can add plugins or new routes if needed
- update the typings a bit so that instance user can specify loader input typings