### PR TITLE
no need for createServer to be async

### DIFF
--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -3,64 +3,64 @@ import { IHttpOperation } from '@stoplight/types';
 import { createServer } from '../server';
 import { IPrismHttpServer } from '../types';
 
-describe('server', async () => {
+describe('server', () => {
   let server: IPrismHttpServer<IHttpOperation[]>;
+
   beforeAll(async () => {
-    server = await createServer<IHttpOperation[]>(
-      [
-        {
-          id: '1',
-          method: 'get',
-          path: '/',
-          servers: [{ url: 'http://localhost:3000' }],
-          responses: [
-            {
-              code: '200',
-              content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
-            },
-          ],
-        },
-        {
-          id: '1',
-          method: 'post',
-          path: '/todos',
-          servers: [{ url: 'http://localhost:3000' }],
-          responses: [
-            {
-              code: '201',
-              content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
-            },
-            {
-              code: '401',
-              content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
-            },
-          ],
-        },
-      ],
+    const operations = [
       {
-        components: {
-          // TODO: once validator is implemented, don't unset it here
-          validator: undefined,
+        id: '1',
+        method: 'get',
+        path: '/',
+        servers: [{ url: 'http://localhost:3000' }],
+        responses: [
+          {
+            code: '200',
+            content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+          },
+        ],
+      },
+      {
+        id: '1',
+        method: 'post',
+        path: '/todos',
+        servers: [{ url: 'http://localhost:3000' }],
+        responses: [
+          {
+            code: '201',
+            content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+          },
+          {
+            code: '401',
+            content: [{ mediaType: 'application/json', schema: { type: 'string' } }],
+          },
+        ],
+      },
+    ];
 
-          // set a custom loader for testing to mock back some HttpOperations
-          loader: {
-            load: async opts => {
-              if (!opts) {
-                return [];
-              }
+    server = createServer<IHttpOperation[]>(operations, {
+      components: {
+        // TODO: once validator is implemented, don't unset it here
+        validator: undefined,
 
-              return opts;
-            },
+        // set a custom loader for testing to mock back some HttpOperations
+        loader: {
+          load: async ops => {
+            if (!ops) {
+              return [];
+            }
+
+            return ops;
           },
         },
-      }
-    );
+      },
+    });
+
+    await server.prism.load(operations);
   });
 
-  afterAll(() => {
-    server.fastify.close(() => {
-      // close
-    });
+  afterAll(async () => {
+    await new Promise(resolve => server.fastify.close(resolve));
   });
 
   test('should mock back root path', async () => {

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -6,10 +6,10 @@ import { IncomingMessage, Server, ServerResponse } from 'http';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
 import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
 
-export const createServer = async <LoaderInput>(
+export const createServer = <LoaderInput>(
   loaderInput: LoaderInput,
   opts: IPrismHttpServerOpts<LoaderInput>
-): Promise<IPrismHttpServer<LoaderInput>> => {
+): IPrismHttpServer<LoaderInput> => {
   const server = fastify<Server, IncomingMessage, ServerResponse>();
 
   const { components } = opts;
@@ -18,7 +18,6 @@ export const createServer = async <LoaderInput>(
     ...components,
   });
 
-  await prism.load(loaderInput);
   server.all('*', {}, replyHandler<LoaderInput>(prism));
 
   const prismServer: IPrismHttpServer<LoaderInput> = {
@@ -31,6 +30,13 @@ export const createServer = async <LoaderInput>(
     },
 
     listen: async (...args) => {
+      try {
+        await prism.load(loaderInput);
+      } catch (e) {
+        console.error('Error loading data into prism.', e);
+        throw e;
+      }
+
       return server.listen(...args);
     },
   };


### PR DESCRIPTION
async `createServer` feels unnecessary. `.listen()` is already async, and we don't need to load before listening. 