### PR TITLE
SL-216 Stripping query part from url

### DIFF
--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -81,9 +81,7 @@ describe('server', () => {
     expect(response.statusCode).toBe(201);
   });
 
-  // TODO: this test is failing because of our weird URL handling.
-  // should just be able to pass full url into prism, and prism should break out the parts
-  test.skip('should support choosing a response code', async () => {
+  test('should support choosing a response code', async () => {
     const response = await server.fastify.inject({
       method: 'POST',
       url: '/todos?__code=401',

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -58,7 +58,7 @@ const replyHandler = <LoaderInput>(
       const response = await prism.process({
         method: (req.method || 'get') as IHttpMethod,
         url: {
-          path: req.url || '/',
+          path: (req.url || '/').split('?')[0],
           query: request.query,
         },
         headers: request.headers,

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -52,17 +52,22 @@ const replyHandler = <LoaderInput>(
     request: fastify.FastifyRequest<IncomingMessage>,
     reply: fastify.FastifyReply<ServerResponse>
   ) => {
-    const { req } = request;
-
     try {
+      const {
+        req: { method, url },
+        body,
+        headers,
+        query,
+      } = request;
+
       const response = await prism.process({
-        method: (req.method || 'get') as IHttpMethod,
+        method: (method ? method.toLowerCase() : 'get') as IHttpMethod,
         url: {
-          path: (req.url || '/').split('?')[0],
-          query: request.query,
+          path: (url || '/').split('?')[0],
+          query,
         },
-        headers: request.headers,
-        body: request.body,
+        headers,
+        body,
       });
 
       const { output } = response;


### PR DESCRIPTION
Issue: https://stoplightio.atlassian.net/browse/SL-216

### Notes to reviewer:
For fastify and it's request object we need to strip the query part from url. It looks better for express - there we have all necessary parameters prepared and in-place.

From the other side, we can't easily migrate to string-url solution (because of oas3 servers shape / variables / base path).

Maybe a good solution would be to support both. Url as a string and as an object. If user gets into trouble because of witchcraft he did in server list + base url + variables he can switch to `url: { path: string, basePath: string, query: {} }`. For most of the cases `url: string` will do the job.

What do you think?
@marbemac @pytlesk4 @chris-miaskowski 
