### PR TITLE
SL-1619 - Prism forwarder can work without an API in place

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,30 @@
 
 <a href="https://codeclimate.com/github/stoplightio/prism/test_coverage"><img src="https://api.codeclimate.com/v1/badges/f5e363a7eb5b8f4e570f/test_coverage" /></a>
 
-## Use cases
+## What's up?
+
+Prism is a set of packages that, given an API Description Document, can
+
+1. Spin up a mock server and respond according to the provided API Description Document
+2. Act as a proxy and forward your request to an upstream server
+3. Validate all the requests passing through against the provided API Description Document
+
+## How's that?
+
+Prims is a multi-package repository so divided:
+
+- `core:` basic interfaces and abstraction for API Description Documents
+- `http:` A Prism implementation to work with HTTP Requests
+- `http-server:` A _Fastify_ instance that uses Prism to validate/mock/respond and forward to http requests
+- `cli:` A CLI to spin up servers locally easily
+
+Look at the relative repositories' README for the specific documentation.
+
+## Examples
 
 ### Run a mock server locally to test requests
 
-```
-spec
+```yml
   - path: /
     server: http://x.com/v1
   - path: /
@@ -21,18 +39,16 @@ spec
 ```
 
 **w/o server validation**
+```bash
 
-`prism run --spec spec --port 3000`
+prism run --spec spec --port 3000
 
+curl localhost:3000/a # - ok
+curl localhost:3000/b # - ok
+curl localhost:3000/v1/ # - error: no such path exists
+curl localhost:3000/v2/ # - error: no such path exists
 
-`curl localhost:3000/a` - ok
-
-`curl localhost:3000/b` - ok
-
-`curl localhost:3000/v1/` - error: no such path exists
-
-`curl localhost:3000/v2/` - error: no such path exists
-
+```
 **w/ server validation**
 
 `curl localhost:3000/a?__server=http://x.com` - ok
@@ -103,11 +119,7 @@ spec
 
 ### Use in code
 
-```
-app.namespace('/v1').get('/', (req, res) => {
-  return prism.process({ baseUrl: 'http://x.com/v1', path: '/' });
-});
-```
+**To be defined**
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "setup": "yarn",
     "fmt": "prettier --write \"packages/*/src/**/*.{ts,js}\"",
-    "lint": "tslint packages/*/src/**/*.{ts}",
+    "lint": "tslint -p packages/tsconfig.json",
     "build": "tsc --build ./packages/tsconfig.build.json",
     "build.watch": "tsc --build --watch ./packages/tsconfig.build.json",
     "test": "yarn lint && yarn test.fast",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,6 @@
   "files": [
     "/bin",
     "/lib",
-    "/npm-shrinkwrap.json",
     "/oclif.manifest.json"
   ],
   "license": "UNLICENSED",

--- a/packages/cli/src/__tests__/serve.spec.ts
+++ b/packages/cli/src/__tests__/serve.spec.ts
@@ -1,7 +1,0 @@
-import Serve from '../commands/serve';
-
-describe('serve', () => {
-  test.skip('testName', () => {
-    return Serve.run();
-  });
-});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,3 @@
 # Prism Core
 
-TBD
+This package contains base abstract interfaces. Generally, you do not want to look at this repository, as there's nothing more than philosophycal reasonments that aren't exactly that pragmatic.

--- a/packages/core/src/__tests__/factory.spec.ts
+++ b/packages/core/src/__tests__/factory.spec.ts
@@ -102,25 +102,5 @@ describe('graph', () => {
         expect(configMergerStub).toHaveBeenCalledWith(input, defaultConfig);
       });
     });
-
-    // test.skip('calls router to find the resource match', () => {
-    //   // TODO
-    // });
-
-    // test.skip('runs validator on input', () => {
-    //   // TODO
-    // });
-
-    // test.skip('calls mocker if config mock property is truthy', () => {
-    //   // TODO
-    // });
-
-    // test.skip('calls forwarder if config mock property is falsy', () => {
-    //   // TODO
-    // });
-
-    // test.skip('runs validator on output', () => {
-    //   // TODO
-    // });
   });
 });

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -4,8 +4,8 @@ import { IPrism, IPrismComponents, IPrismConfig, IValidation } from './types';
 export function factory<Resource, Input, Output, Config, LoadOpts>(
   defaultComponents: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
 ): (
-    customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
-  ) => IPrism<Resource, Input, Output, Config, LoadOpts> {
+  customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
+) => IPrism<Resource, Input, Output, Config, LoadOpts> {
   const prism = (
     customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
   ) => {

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -4,8 +4,8 @@ import { IPrism, IPrismComponents, IPrismConfig, IValidation } from './types';
 export function factory<Resource, Input, Output, Config, LoadOpts>(
   defaultComponents: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
 ): (
-  customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
-) => IPrism<Resource, Input, Output, Config, LoadOpts> {
+    customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
+  ) => IPrism<Resource, Input, Output, Config, LoadOpts> {
   const prism = (
     customComponents?: Partial<IPrismComponents<Resource, Input, Output, Config, LoadOpts>>
   ) => {
@@ -36,7 +36,7 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
         // find the correct resource
         let resource: Resource | undefined;
         if (components.router) {
-          resource = await components.router.route(
+          resource = components.router.route(
             { resources, input, config: configObj },
             defaultComponents.router
           );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -50,7 +50,7 @@ export interface IRouter<Resource, Input, Config> {
   route: (
     opts: { resources: Resource[]; input: Input; config?: Config },
     defaultRouter?: IRouter<Resource, Input, Config>
-  ) => Promise<Resource>;
+  ) => Resource;
 }
 
 export interface IForwarder<Resource, Input, Config, Output> {

--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -15,9 +15,7 @@ describe('server', () => {
     });
   });
 
-  afterAll(async () => {
-    await new Promise(res => server.fastify.close(res));
-  });
+  afterAll(() => new Promise(res => server.fastify.close(res)));
 
   test('should mock back /pet/:petId', async () => {
     const response = await server.fastify.inject({

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -3,6 +3,7 @@ import { IHttpOperation } from '@stoplight/types/http-spec';
 import { omit } from 'lodash';
 import { relative, resolve } from 'path';
 import { createInstance, IHttpConfig, IHttpRequest, IHttpResponse } from '../';
+import { forwarder } from '../forwarder';
 
 describe('Http Prism Instance function tests', () => {
   let prism: IPrism<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, { path: string }>;
@@ -96,15 +97,15 @@ describe('Http Prism Instance function tests', () => {
     });
   });
 
-  test('should route correclty even if no document has been loaded', ()=>{
-    beforeAll(()=>{
-      prism = createInstance();
-    });
+  test("should forward the request correclty even if resources haven't been provided", async () => {
+    // Recreate Prism with no loaded document
+    prism = createInstance({ forwarder, router: undefined, mocker: undefined });
 
     const response = await prism.process({
       method: 'post',
       url: {
         path: '/store/order',
+        baseUrl: 'https://petstore.swagger.io',
       },
       body: {
         id: 1,
@@ -115,11 +116,10 @@ describe('Http Prism Instance function tests', () => {
         complete: true,
       },
     });
+
     expect(response.validations).toEqual({
       input: [],
       output: [],
     });
   });
-
-  })
 });

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -95,4 +95,31 @@ describe('Http Prism Instance function tests', () => {
       output: [],
     });
   });
+
+  test('should route correclty even if no document has been loaded', ()=>{
+    beforeAll(()=>{
+      prism = createInstance();
+    });
+
+    const response = await prism.process({
+      method: 'post',
+      url: {
+        path: '/store/order',
+      },
+      body: {
+        id: 1,
+        petId: 2,
+        quantity: 3,
+        shipDate: '12-01-2018',
+        status: 'placed',
+        complete: true,
+      },
+    });
+    expect(response.validations).toEqual({
+      input: [],
+      output: [],
+    });
+  });
+
+  })
 });

--- a/packages/http/src/forwarder/HttpForwarder.ts
+++ b/packages/http/src/forwarder/HttpForwarder.ts
@@ -7,21 +7,17 @@ export class HttpForwarder
   implements IForwarder<IHttpOperation, IHttpRequest, IHttpConfig, IHttpResponse> {
   public async forward(opts: {
     resource?: IHttpOperation;
-    // todo: IHttpRequest should be enough
     input: IPrismInput<IHttpRequest>;
   }): Promise<IHttpResponse> {
-    if (!opts.resource) {
-      throw new Error('Missing spec');
-    }
-    if (!opts.resource.servers || opts.resource.servers.length === 0) {
-      throw new Error('Server list is missing in spec');
-    }
-
     const inputData = opts.input.data;
 
     const response = await axios({
       method: inputData.method,
-      url: this.resolveServerUrl(opts.resource.servers[0]) + inputData.url.path,
+      baseURL:
+        opts.resource && opts.resource.servers && opts.resource.servers.length > 0
+          ? this.resolveServerUrl(opts.resource.servers[0])
+          : inputData.url.baseUrl,
+      url: inputData.url.path,
       params: inputData.url.query,
       responseType: 'text',
       data: inputData.body,

--- a/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
+++ b/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
@@ -35,7 +35,8 @@ describe('HttpForwarder', () => {
 
           expect(axios.default).toHaveBeenCalledWith({
             method: 'get',
-            url: 'http://api.example.com/todos',
+            url: '/todos',
+            baseURL: 'http://api.example.com',
             responseType: 'text',
             validateStatus: expect.any(Function),
           });
@@ -79,7 +80,7 @@ describe('HttpForwarder', () => {
           });
 
           expect(axios.default).toHaveBeenCalledWith(
-            expect.objectContaining({ url: 'http://api.example.com/todos' })
+            expect.objectContaining({ baseURL: 'http://api.example.com', url: '/todos' })
           );
         });
 
@@ -101,7 +102,7 @@ describe('HttpForwarder', () => {
           });
 
           expect(axios.default).toHaveBeenCalledWith(
-            expect.objectContaining({ url: 'http://api.example.com/todos' })
+            expect.objectContaining({ baseURL: 'http://api.example.com', url: '/todos' })
           );
         });
       });

--- a/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
+++ b/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
@@ -11,8 +11,7 @@ describe('HttpForwarder', () => {
   });
 
   describe('forward()', () => {
-
-    describe('parameters haven\' been provided', () => {
+    describe("parameters haven' been provided", () => {
       it('proxies request correctly', async () => {
         jest.spyOn(axios, 'default').mockImplementation(() => ({
           status: 200,
@@ -27,7 +26,6 @@ describe('HttpForwarder', () => {
         request.data.url.baseUrl = 'http://api.example.com';
 
         await forwarder.forward({ input: request });
-
 
         expect(axios.default).toHaveBeenCalledWith({
           method: 'get',

--- a/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
+++ b/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
@@ -12,6 +12,33 @@ describe('HttpForwarder', () => {
 
   describe('forward()', () => {
 
+    describe('parameters haven\' been provided', () => {
+      it('proxies request correctly', async () => {
+        jest.spyOn(axios, 'default').mockImplementation(() => ({
+          status: 200,
+          headers: {
+            'Content-type': 'application/json',
+          },
+          data: '[{},{}]',
+          statusText: 'ok',
+        }));
+
+        const request = Object.assign({}, httpRequests[0]);
+        request.data.url.baseUrl = 'http://api.example.com';
+
+        await forwarder.forward({ input: request });
+
+
+        expect(axios.default).toHaveBeenCalledWith({
+          method: 'get',
+          url: '/todos',
+          baseURL: 'http://api.example.com',
+          responseType: 'text',
+          validateStatus: expect.any(Function),
+        });
+      });
+    });
+
     describe('parameters are valid', () => {
       describe('server url has no variables', () => {
         it('proxies request correctly', async () => {

--- a/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
+++ b/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
@@ -11,31 +11,6 @@ describe('HttpForwarder', () => {
   });
 
   describe('forward()', () => {
-    describe('parameters are invalid', () => {
-      it('throws error when resource is missing', async () => {
-        return expect(
-          forwarder.forward({ input: httpRequests[0] })
-        ).rejects.toThrowErrorMatchingSnapshot();
-      });
-
-      it('throws error when server list is missing', async () => {
-        return expect(
-          forwarder.forward({
-            resource: Object.assign({}, httpOperations[0], { servers: undefined }),
-            input: httpRequests[0],
-          })
-        ).rejects.toThrowErrorMatchingSnapshot();
-      });
-
-      it('throws error when server list is empty', async () => {
-        return expect(
-          forwarder.forward({
-            resource: Object.assign({}, httpOperations[0], { servers: [] }),
-            input: httpRequests[0],
-          })
-        ).rejects.toThrowErrorMatchingSnapshot();
-      });
-    });
 
     describe('parameters are valid', () => {
       describe('server url has no variables', () => {

--- a/packages/http/src/forwarder/__tests__/__snapshots__/HttpForwarder.spec.ts.snap
+++ b/packages/http/src/forwarder/__tests__/__snapshots__/HttpForwarder.spec.ts.snap
@@ -1,11 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HttpForwarder forward() parameters are invalid throws error when resource is missing 1`] = `"Missing spec"`;
-
-exports[`HttpForwarder forward() parameters are invalid throws error when server list is empty 1`] = `"Server list is missing in spec"`;
-
-exports[`HttpForwarder forward() parameters are invalid throws error when server list is missing 1`] = `"Server list is missing in spec"`;
-
 exports[`HttpForwarder forward() parameters are valid server url has no variables proxies request correctly 1`] = `
 Object {
   "body": "[{},{}]",

--- a/packages/http/src/forwarder/__tests__/functional.spec.ts
+++ b/packages/http/src/forwarder/__tests__/functional.spec.ts
@@ -1,4 +1,3 @@
-import { IHttpMethod } from '@stoplight/prism-http';
 import * as axios from 'axios';
 
 import { httpOperations } from '../../__tests__/fixtures';
@@ -31,7 +30,7 @@ describe('HttpForwarder', () => {
         input: {
           validations: { input: [] },
           data: {
-            method: 'post' as IHttpMethod,
+            method: 'post',
             url: { path: '/files' },
             headers: {
               expect: '100-continue',

--- a/packages/http/src/forwarder/__tests__/index.spec.ts
+++ b/packages/http/src/forwarder/__tests__/index.spec.ts
@@ -1,5 +1,0 @@
-describe('http forwarder', () => {
-  test.skip('works', () => {
-    // TODO
-  });
-});

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -27,16 +27,18 @@ function createResource(method: string, path: string, servers: IServer[]): IHttp
 describe('http router', () => {
   describe('route()', () => {
     test('should return null if no resources given', () => {
-      expect(() => router.route({
-        resources: [],
-        input: {
-          method: pickOneHttpMethod(),
-          url: {
-            baseUrl: '',
-            path: '',
+      expect(() =>
+        router.route({
+          resources: [],
+          input: {
+            method: pickOneHttpMethod(),
+            url: {
+              baseUrl: '',
+              path: '',
+            },
           },
-        },
-      })).toThrow(NO_RESOURCE_PROVIDED_ERROR);
+        })
+      ).toThrow(NO_RESOURCE_PROVIDED_ERROR);
     });
 
     describe('given a resource', () => {
@@ -44,54 +46,60 @@ describe('http router', () => {
         const method = pickOneHttpMethod();
         const path = randomPath();
 
-        return expect(() => router.route({
-          resources: [createResource(method, path, [])],
-          input: {
-            method,
-            url: {
-              baseUrl: '',
-              path,
+        return expect(() =>
+          router.route({
+            resources: [createResource(method, path, [])],
+            input: {
+              method,
+              url: {
+                baseUrl: '',
+                path,
+              },
             },
-          },
-        })).toThrow(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
+          })
+        ).toThrow(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
       });
 
       test('should not match if no servers arrays provided', () => {
         const method = pickOneHttpMethod();
         const path = randomPath();
 
-        return expect(() => router.route({
-          resources: [createResource(method, path, [])],
-          input: {
-            method,
-            url: {
-              baseUrl: '',
-              path,
+        return expect(() =>
+          router.route({
+            resources: [createResource(method, path, [])],
+            input: {
+              method,
+              url: {
+                baseUrl: '',
+                path,
+              },
             },
-          },
-        })).toThrow(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
+          })
+        ).toThrow(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
       });
 
       test('given a concrete matching server and unmatched methods should not match', () => {
         const url = chance.url();
         const [resourceMethod, requestMethod] = pickSetOfHttpMethods(2);
 
-        return expect(() => router.route({
-          resources: [
-            createResource(resourceMethod, randomPath(), [
-              {
-                url,
+        return expect(() =>
+          router.route({
+            resources: [
+              createResource(resourceMethod, randomPath(), [
+                {
+                  url,
+                },
+              ]),
+            ],
+            input: {
+              method: requestMethod,
+              url: {
+                baseUrl: url,
+                path: '/',
               },
-            ]),
-          ],
-          input: {
-            method: requestMethod,
-            url: {
-              baseUrl: url,
-              path: '/',
             },
-          },
-        })).toThrow(NONE_METHOD_MATCHED_ERROR);
+          })
+        ).toThrow(NONE_METHOD_MATCHED_ERROR);
       });
 
       describe('given matched methods', () => {
@@ -101,22 +109,24 @@ describe('http router', () => {
           const url = chance.url();
           const path = randomPath({ trailingSlash: false });
 
-          return expect(() => router.route({
-            resources: [
-              createResource(method, path, [
-                {
-                  url,
+          return expect(() =>
+            router.route({
+              resources: [
+                createResource(method, path, [
+                  {
+                    url,
+                  },
+                ]),
+              ],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: `${path}${randomPath()}`,
                 },
-              ]),
-            ],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path: `${path}${randomPath()}`,
               },
-            },
-          })).toThrow(NONE_PATH_MATCHED_ERROR);
+            })
+          ).toThrow(NONE_PATH_MATCHED_ERROR);
         });
 
         test('given a concrete matching server and matched concrete path should match', async () => {
@@ -231,16 +241,18 @@ describe('http router', () => {
             },
           ]);
 
-          return expect(() => router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path: requestPath,
+          return expect(() =>
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: requestPath,
+                },
               },
-            },
-          })).toThrow(NONE_PATH_MATCHED_ERROR);
+            })
+          ).toThrow(NONE_PATH_MATCHED_ERROR);
         });
 
         test('given a concrete servers and mixed paths should match concrete path', async () => {
@@ -336,16 +348,18 @@ describe('http router', () => {
           const path = randomPath({ includeTemplates: false });
           const url = 'concrete.com';
 
-          return expect(() => router.route({
-            resources: [createResource(method, path, [{ url }])],
-            input: {
-              method,
-              url: {
-                baseUrl: '',
-                path,
+          return expect(() =>
+            router.route({
+              resources: [createResource(method, path, [{ url }])],
+              input: {
+                method,
+                url: {
+                  baseUrl: '',
+                  path,
+                },
               },
-            },
-          })).toThrow(NONE_SERVER_MATCHED_ERROR);
+            })
+          ).toThrow(NONE_SERVER_MATCHED_ERROR);
         });
 
         test('given empty baseUrl and empty server url it should match', async () => {

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -27,7 +27,7 @@ function createResource(method: string, path: string, servers: IServer[]): IHttp
 describe('http router', () => {
   describe('route()', () => {
     test('should return null if no resources given', () => {
-      const resourcePromise = router.route({
+      expect(() => router.route({
         resources: [],
         input: {
           method: pickOneHttpMethod(),
@@ -36,16 +36,15 @@ describe('http router', () => {
             path: '',
           },
         },
-      });
-
-      return expect(resourcePromise).rejects.toBe(NO_RESOURCE_PROVIDED_ERROR);
+      })).toThrow(NO_RESOURCE_PROVIDED_ERROR);
     });
 
     describe('given a resource', () => {
       test('should not match if no server defined', () => {
         const method = pickOneHttpMethod();
         const path = randomPath();
-        const resourcePromise = router.route({
+
+        return expect(() => router.route({
           resources: [createResource(method, path, [])],
           input: {
             method,
@@ -54,15 +53,14 @@ describe('http router', () => {
               path,
             },
           },
-        });
-
-        return expect(resourcePromise).rejects.toBe(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
+        })).toThrow(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
       });
 
       test('should not match if no servers arrays provided', () => {
         const method = pickOneHttpMethod();
         const path = randomPath();
-        const resourcePromise = router.route({
+
+        return expect(() => router.route({
           resources: [createResource(method, path, [])],
           input: {
             method,
@@ -71,15 +69,14 @@ describe('http router', () => {
               path,
             },
           },
-        });
-
-        return expect(resourcePromise).rejects.toBe(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
+        })).toThrow(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
       });
 
       test('given a concrete matching server and unmatched methods should not match', () => {
         const url = chance.url();
         const [resourceMethod, requestMethod] = pickSetOfHttpMethods(2);
-        const resourcePromise = router.route({
+
+        return expect(() => router.route({
           resources: [
             createResource(resourceMethod, randomPath(), [
               {
@@ -94,9 +91,7 @@ describe('http router', () => {
               path: '/',
             },
           },
-        });
-
-        return expect(resourcePromise).rejects.toBe(NONE_METHOD_MATCHED_ERROR);
+        })).toThrow(NONE_METHOD_MATCHED_ERROR);
       });
 
       describe('given matched methods', () => {
@@ -105,7 +100,8 @@ describe('http router', () => {
         test('given a concrete matching server unmatched path should not match', () => {
           const url = chance.url();
           const path = randomPath({ trailingSlash: false });
-          const resourcePromise = router.route({
+
+          return expect(() => router.route({
             resources: [
               createResource(method, path, [
                 {
@@ -120,9 +116,7 @@ describe('http router', () => {
                 path: `${path}${randomPath()}`,
               },
             },
-          });
-
-          return expect(resourcePromise).rejects.toBe(NONE_PATH_MATCHED_ERROR);
+          })).toThrow(NONE_PATH_MATCHED_ERROR);
         });
 
         test('given a concrete matching server and matched concrete path should match', async () => {
@@ -133,7 +127,7 @@ describe('http router', () => {
               url,
             },
           ]);
-          const resource = await router.route({
+          const resource = router.route({
             resources: [expectedResource],
             input: {
               method,
@@ -160,7 +154,8 @@ describe('http router', () => {
               },
             },
           ]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [expectedResource],
             input: {
               method,
@@ -187,7 +182,8 @@ describe('http router', () => {
               },
             },
           ]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [expectedResource],
             input: {
               method,
@@ -210,7 +206,8 @@ describe('http router', () => {
               url,
             },
           ]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [expectedResource],
             input: {
               method,
@@ -233,7 +230,8 @@ describe('http router', () => {
               url,
             },
           ]);
-          const resourcePromise = router.route({
+
+          return expect(() => router.route({
             resources: [expectedResource],
             input: {
               method,
@@ -242,9 +240,7 @@ describe('http router', () => {
                 path: requestPath,
               },
             },
-          });
-
-          return expect(resourcePromise).rejects.toBe(NONE_PATH_MATCHED_ERROR);
+          })).toThrow(NONE_PATH_MATCHED_ERROR);
         });
 
         test('given a concrete servers and mixed paths should match concrete path', async () => {
@@ -253,7 +249,8 @@ describe('http router', () => {
           const url = 'concrete.com';
           const resourceWithConcretePath = createResource(method, concretePath, [{ url }]);
           const resourceWithTemplatedPath = createResource(method, templatedPath, [{ url }]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [resourceWithTemplatedPath, resourceWithConcretePath],
             input: {
               method,
@@ -273,7 +270,8 @@ describe('http router', () => {
           const url = 'concrete.com';
           const firstResource = createResource(method, templatedPathA, [{ url }]);
           const secondResource = createResource(method, templatedPathB, [{ url }]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [firstResource, secondResource],
             input: {
               method,
@@ -294,10 +292,12 @@ describe('http router', () => {
             { url },
             { url: '{template}', variables: { template: { default: url, enum: [url] } } },
           ]);
+
           const resourceWithTemplatedMatch = createResource(method, path, [
             { url: '{template}', variables: { template: { default: url, enum: [url] } } },
           ]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [resourceWithConcreteMatch, resourceWithTemplatedMatch],
             input: {
               method,
@@ -317,7 +317,8 @@ describe('http router', () => {
           const url = 'concrete.com';
           const resourceWithMatchingPath = createResource(method, matchingPath, [{ url }]);
           const resourceWithNonMatchingPath = createResource(method, nonMatchingPath, [{ url }]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [resourceWithNonMatchingPath, resourceWithMatchingPath],
             input: {
               method,
@@ -334,7 +335,8 @@ describe('http router', () => {
         test('given empty baseUrl and concrete server it should not match', () => {
           const path = randomPath({ includeTemplates: false });
           const url = 'concrete.com';
-          const resourcePromise = router.route({
+
+          return expect(() => router.route({
             resources: [createResource(method, path, [{ url }])],
             input: {
               method,
@@ -343,16 +345,15 @@ describe('http router', () => {
                 path,
               },
             },
-          });
-
-          return expect(resourcePromise).rejects.toBe(NONE_SERVER_MATCHED_ERROR);
+          })).toThrow(NONE_SERVER_MATCHED_ERROR);
         });
 
         test('given empty baseUrl and empty server url it should match', async () => {
           const path = randomPath({ includeTemplates: false });
           const url = '';
           const expectedResource = createResource(method, path, [{ url }]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [expectedResource],
             input: {
               method,
@@ -369,7 +370,8 @@ describe('http router', () => {
         test('given no baseUrl and a server url it should ignore servers and match by path', async () => {
           const path = randomPath({ includeTemplates: false });
           const expectedResource = createResource(method, path, [{ url: 'www.stoplight.io/v1' }]);
-          const resource = await router.route({
+
+          const resource = router.route({
             resources: [expectedResource],
             input: {
               method,

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -14,7 +14,7 @@ import { matchPath } from './matchPath';
 import { IMatch, MatchType } from './types';
 
 export const router: IRouter<IHttpOperation, IHttpRequest, IHttpConfig> = {
-  route: async ({ resources, input }) => {
+  route: ({ resources, input }) => {
     const matches = [];
     const { path: requestPath, baseUrl: requestBaseUrl } = input.url;
     const ignoreServers: boolean = requestBaseUrl === undefined;

--- a/packages/http/tsconfig.build.json
+++ b/packages/http/tsconfig.build.json
@@ -5,4 +5,10 @@
     "outDir": "lib"
   },
   "include": ["src"],
+  "references": [
+    {
+      "path": "../core/tsconfig.build.json"
+    }
+  ]
+
 }

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -1,5 +1,4 @@
 {
-  "exclude": ["**/node_modules", "**/__tests__", "**/fixtures"],
   "compilerOptions": {
     "noFallthroughCasesInSwitch": true,
     "allowUnreachableCode": false,

--- a/packages/tsconfig.build.json
+++ b/packages/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
+  "exclude": ["**/__tests__"],
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
This PR will:

1. Change the Readme a little bit so that's more informative. There's still a *LOT* of work to do, but that's a start.
2. Transform `components.router.route` to a sync function, because there's nothing async in it (I hope it's the only occurrence but there might be other)
3. Remove the need of the `IHttpOperation` instance coming from graphite. In case it is absent, it'll read the data from the request object directly. Please note that, in my opinion, the IHttpOperation should be completely removed, because the only reason it's there it's because it needs to read the server/base Url — which can be done externally. If you agree with such change, I can make that happen.
4. Add/fix/rewrite tests
5. Fix TSLint that was not running properly on the packages