### PR TITLE
fix: running `prism` cli threw exception [SL-2021]

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "../tsconfig.build.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "target": "es2017"
   },
   "include": ["src"],
   "references": [

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module":"commonjs",
-    "moduleResolution": "node"
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2017"
   }
 }


### PR DESCRIPTION
- Class constructor Command cannot be invoked without 'new'

SL-2021