### PR TITLE
fix: SL-2030 disabled fastify's body serializing

### DIFF
--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -41,7 +41,7 @@ describe('server', () => {
       url: '/user/username',
     });
 
-    expect(Object.keys(JSON.parse(JSON.parse(response.payload)))).toEqual(['id', 'username']);
+    expect(Object.keys(JSON.parse(response.payload))).toEqual(['id', 'username']);
     expect(response.statusCode).toBe(201);
   });
 

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -79,6 +79,8 @@ const replyHandler = <LoaderInput>(
         }
 
         if (output.body) {
+          // body is already serialized
+          reply.serializer((payload: any) => payload);
           reply.send(output.body);
         }
       }


### PR DESCRIPTION
Issue: https://stoplightio.atlassian.net/browse/SL-2030

Disabled default fastify's body serialization. Prism has already taken care of it.