### PR TITLE
fix: SL-2191 mock switch fix

### DIFF
--- a/packages/http-server/src/__tests__/__snapshots__/getHttpConfigFromRequest.spec.ts.snap
+++ b/packages/http-server/src/__tests__/__snapshots__/getHttpConfigFromRequest.spec.ts.snap
@@ -34,17 +34,9 @@ Object {
 }
 `;
 
-exports[`getHttpConfigFromRequest() given no default config and no matching query should return my own default 1`] = `
-Object {
-  "mock": true,
-}
-`;
+exports[`getHttpConfigFromRequest() given no default config and no matching query should return my own default 1`] = `Object {}`;
 
-exports[`getHttpConfigFromRequest() given no default config and no query should return my own default 1`] = `
-Object {
-  "mock": true,
-}
-`;
+exports[`getHttpConfigFromRequest() given no default config and no query should return my own default 1`] = `Object {}`;
 
 exports[`getHttpConfigFromRequest() given no default config extracts code 1`] = `
 Object {

--- a/packages/http-server/src/__tests__/server.spec.ts
+++ b/packages/http-server/src/__tests__/server.spec.ts
@@ -6,7 +6,7 @@ describe('server', () => {
   let server: IPrismHttpServer<any>;
 
   beforeAll(async () => {
-    server = createServer({}, {});
+    server = createServer({}, { components: { config: { mock: true } } });
     await server.prism.load({
       path: relative(
         process.cwd(),

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -6,7 +6,7 @@ export const getHttpConfigFromRequest: PrismConfigFactory<IHttpConfig, IHttpRequ
   defaultConfig?: PrismConfig<IHttpConfig, IHttpRequest>
 ) => {
   // For some reason this fixed the code coverage.
-  let config: IHttpConfig = { mock: true };
+  let config: IHttpConfig = {};
   if (defaultConfig) {
     config = await resolveConfig<IHttpConfig, IHttpRequest>(req, defaultConfig);
   }

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -9,7 +9,7 @@ describe('Http Prism Instance function tests', () => {
   let prism: IPrism<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, { path: string }>;
 
   beforeAll(async () => {
-    prism = createInstance();
+    prism = createInstance({ config: { mock: true } });
     await prism.load({
       path: relative(
         process.cwd(),

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -20,9 +20,7 @@ import { validator } from './validator';
 
 const createInstance = <LoaderInput>(overrides?: TPrismHttpComponents<LoaderInput>) => {
   return factory<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, LoaderInput>({
-    config: {
-      mock: true,
-    },
+    config: {},
     loader: filesystemLoaderInstance,
     router,
     forwarder,

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -32,7 +32,7 @@ export interface IHttpOperationConfig {
 }
 
 export interface IHttpConfig extends IPrismConfig {
-  mock: boolean | IHttpOperationConfig;
+  mock?: boolean | IHttpOperationConfig;
 
   security?: {
     // TODO


### PR DESCRIPTION
Issue: https://stoplightio.atlassian.net/browse/SL-2191

I made config.mock optional. When it was mandatory it was filled with default of false (e.g. while doing request without explicit __mock=?). That was always overriding what was passed to cli.