### PR TITLE
Invalid Request - Missing Params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dist
 # IDE
 .idea
 lib
+
+# TypeScript
+packages/*/tsconfig.build.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "lint": "tslint -p packages/tsconfig.json",
     "build": "tsc --build ./packages/tsconfig.build.json",
     "build.watch": "tsc --build --watch ./packages/tsconfig.build.json",
-    "test": "yarn lint && yarn test.fast",
+    "test": "yarn test.fast",
+    "test.update": "yarn test --updateSnapshot",
     "test.fast": "jest --env=node --maxWorkers=2",
-    "test.coverage": "yarn test --coverage",
-    "test.watch": "yarn test --watchAll",
-    "test.update": "yarn test.fast --updateSnapshot"
+    "test.prod": "yarn lint && jest --env=node --maxWorkers=2",
+    "test.coverage": "yarn test.prod --coverage",
+    "test.watch": "yarn test --watchAll"
   },
   "devDependencies": {
     "@stoplight/types": "4.x.x",

--- a/packages/http/src/__tests__/__snapshots__/http-prism-instance.spec.ts.snap
+++ b/packages/http/src/__tests__/__snapshots__/http-prism-instance.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Http Prism Instance function tests returns correct response for an existing route 1`] = `
+exports[`Http Prism Instance function tests when { mock: true } and spec file "no-refs-petstore-minimal.oas2.json" is loaded returns correct response for an existing route 1`] = `
 Object {
   "input": Object {
     "method": "get",

--- a/packages/http/src/__tests__/__snapshots__/http-prism-instance.spec.ts.snap
+++ b/packages/http/src/__tests__/__snapshots__/http-prism-instance.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Http Prism Instance function tests given correct route should return correct response 1`] = `
+exports[`Http Prism Instance function tests returns correct response for an existing route 1`] = `
 Object {
   "input": Object {
     "method": "get",
@@ -22,42 +22,6 @@ Object {
   },
   "validations": Object {
     "input": Array [],
-    "output": Array [],
-  },
-}
-`;
-
-exports[`Http Prism Instance function tests given route with invalid param should return a validation error 1`] = `
-Object {
-  "input": Object {
-    "method": "get",
-    "url": Object {
-      "path": "/pet/findByStatus",
-    },
-  },
-  "output": Object {
-    "body": "ERROR: Your request is not valid.
-We cannot generate a sensible response because your '400'
-response has neither example nor schema or is not defined.
-Here is the original validation result instead: [{\\"path\\":[\\"query\\",\\"status\\"],\\"name\\":\\"required\\",\\"summary\\":\\"\\",\\"message\\":\\"Missing status query param\\",\\"severity\\":\\"error\\"}]",
-    "headers": Object {
-      "Content-type": "text/plain",
-    },
-    "statusCode": 400,
-  },
-  "validations": Object {
-    "input": Array [
-      Object {
-        "message": "Missing status query param",
-        "name": "required",
-        "path": Array [
-          "query",
-          "status",
-        ],
-        "severity": "error",
-        "summary": "",
-      },
-    ],
     "output": Array [],
   },
 }

--- a/packages/http/src/__tests__/fixtures/index.ts
+++ b/packages/http/src/__tests__/fixtures/index.ts
@@ -3,6 +3,7 @@ import { HttpParamStyles, IHttpOperation } from '@stoplight/types';
 
 import { IHttpMethod, IHttpRequest, IHttpResponse } from '../../types';
 
+// TODO DEBT: These fixtures dont have names, so its hard to tell what they are about
 export const httpOperations: IHttpOperation[] = [
   {
     id: 'todos',

--- a/packages/http/src/__tests__/fixtures/required-parameters.oas2.json
+++ b/packages/http/src/__tests__/fixtures/required-parameters.oas2.json
@@ -1,0 +1,85 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Required Params API",
+    "version": "1.0"
+  },
+  "host": "example.com",
+  "paths": {
+    "/query": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "parameters": [
+          {
+            "in": "query",
+            "name": "a_required_param",
+            "type": "string",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/header": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Required header param",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "a_required_header",
+            "type": "string",
+            "required": true
+          }
+        ]
+      }
+    },
+    "/body": {
+      "post": {
+        "summary": "Required body param",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "a_required_body": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "a_required_body"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ]
+}

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -18,7 +18,7 @@ describe('Http Prism Instance function tests', () => {
     });
   });
 
-  test('given incorrect route should throw error', () => {
+  it('errors given incorrect route', () => {
     return expect(
       prism.process({
         method: 'get',
@@ -29,7 +29,7 @@ describe('Http Prism Instance function tests', () => {
     ).rejects.toThrowError('Route not resolved, none path matched');
   });
 
-  test('given correct route should return correct response', async () => {
+  it('returns correct response for an existing route', async () => {
     const response = await prism.process({
       method: 'get',
       url: {
@@ -50,17 +50,44 @@ describe('Http Prism Instance function tests', () => {
     expect(omit(response, 'output.body')).toMatchSnapshot();
   });
 
-  test('given route with invalid param should return a validation error', async () => {
+  it('returns validation error for with invalid param', async () => {
     const response = await prism.process({
       method: 'get',
       url: {
         path: '/pet/findByStatus',
       },
     });
-    expect(response).toMatchSnapshot();
+    expect(response).toEqual({
+      input: {
+        method: 'get',
+        url: {
+          path: '/pet/findByStatus',
+        },
+      },
+      output: {
+        body:
+          '{"errors":[{"path":["query","status"],"name":"required","summary":"","message":"Missing status query param","severity":"error"}]}',
+        headers: {
+          'Content-type': 'application/json',
+        },
+        statusCode: 500,
+      },
+      validations: {
+        input: [
+          {
+            path: ['query', 'status'],
+            name: 'required',
+            summary: '',
+            message: 'Missing status query param',
+            severity: 'error',
+          },
+        ],
+        output: [],
+      },
+    });
   });
 
-  test('should support collection format multi', async () => {
+  it('should support collection format multi', async () => {
     const response = await prism.process({
       method: 'get',
       url: {
@@ -76,7 +103,7 @@ describe('Http Prism Instance function tests', () => {
     });
   });
 
-  test('support param in body', async () => {
+  it('support param in body', async () => {
     const response = await prism.process({
       method: 'post',
       url: {
@@ -97,7 +124,7 @@ describe('Http Prism Instance function tests', () => {
     });
   });
 
-  test("should forward the request correctly even if resources haven't been provided", async () => {
+  it("should forward the request correctly even if resources haven't been provided", async () => {
     // Recreate Prism with no loaded document
     prism = createInstance(undefined, { forwarder, router: undefined, mocker: undefined });
 
@@ -123,7 +150,7 @@ describe('Http Prism Instance function tests', () => {
     });
   });
 
-  test('loads spec provided in yaml', async () => {
+  it('loads spec provided in yaml', async () => {
     prism = createInstance();
     await prism.load({
       path: relative(process.cwd(), resolve(__dirname, 'fixtures', 'petstore.oas2.yaml')),
@@ -132,7 +159,7 @@ describe('Http Prism Instance function tests', () => {
     expect(prism.resources).toHaveLength(5);
   });
 
-  test('returns stringified static example when one defined in spec', async () => {
+  it('returns stringified static example when one defined in spec', async () => {
     prism = createInstance();
     await prism.load({
       path: relative(process.cwd(), resolve(__dirname, 'fixtures', 'static-examples.oas2.json')),

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -35,6 +35,8 @@ describe('Http Prism Instance function tests', () => {
     );
   });
 
+  // TODO Write test with invalid Schema and catch AJV error
+
   it('returns stringified static example when one defined in spec', async () => {
     prism = createInstance();
     await prism.load({
@@ -52,143 +54,269 @@ describe('Http Prism Instance function tests', () => {
     expect(typeof response.output!.body).toBe('string');
   });
 
-  describe('when { mock: true } and spec file "no-refs-petstore-minimal.oas2.json" is loaded', () => {
-    beforeAll(async () => {
+  describe('when { mock: true }', () => {
+    beforeEach(async () => {
       prism = createInstance({ mock: true }, {});
-      await prism.load({
-        path: resolve(__dirname, 'fixtures', 'no-refs-petstore-minimal.oas2.json')
-      });
     });
 
-    it('errors given incorrect route', () => {
-      return expect(
-        prism.process({
+    describe('and spec file "required-parameters.oas2.json" is loaded', () => {
+      beforeEach(async () => {
+        await prism.load({
+          path: resolve(__dirname, 'fixtures', 'required-parameters.oas2.json'),
+        });
+      });
+
+      it('returns validation errors array explaining the query param is missing', async () => {
+        const response = await prism.process({
           method: 'get',
           url: {
-            path: '/invalid-route',
+            path: '/query',
           },
-        })
-      ).rejects.toThrowError('Route not resolved, none path matched');
+        });
+        expect(response.validations.input).toHaveLength(1);
+
+        const parsedBody = JSON.parse(response!.output!.body);
+        expect(parsedBody).toEqual(
+          expect.objectContaining({
+            errors: [
+              expect.objectContaining({
+                message: 'Missing a_required_param query param',
+                name: 'required',
+                path: ['query', 'a_required_param'],
+              }),
+            ],
+          })
+        );
+      });
+
+      it('returns the mock when query string is provided', async () => {
+        const response = await prism.process({
+          method: 'get',
+          url: {
+            path: '/query',
+            query: {
+              a_required_param: 'value',
+            },
+          },
+        });
+        expect(response.validations.input).toHaveLength(0);
+      });
+
+      describe('and requesting an endpoint which requires a header', () => {
+        it('returns validation errors array when header is missing', async () => {
+          const response = await prism.process({
+            method: 'get',
+            url: {
+              path: '/header',
+            },
+          });
+          expect(response.validations.input).toHaveLength(1);
+
+          const parsedBody = JSON.parse(response!.output!.body);
+          expect(parsedBody).toEqual(
+            expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'Missing a_required_header header param',
+                  name: 'required',
+                  path: ['header', 'a_required_header'],
+                }),
+              ],
+            })
+          );
+        });
+
+        it('returns the mock when header string is provided', async () => {
+          const response = await prism.process({
+            method: 'get',
+            headers: {
+              a_required_header: 'value',
+            },
+            url: {
+              path: '/header',
+            },
+          });
+          expect(response.validations.input).toHaveLength(0);
+        });
+      });
+
+      describe('and requesting an endpoint which requires a body param', () => {
+        it('returns validation errors array when body param is missing', async () => {
+          const response = await prism.process({
+            method: 'post',
+            url: {
+              path: '/body',
+            },
+          });
+          expect(response.validations.input).toHaveLength(1);
+
+          const parsedBody = JSON.parse(response!.output!.body);
+          expect(parsedBody).toEqual(
+            expect.objectContaining({
+              errors: [
+                expect.objectContaining({
+                  message: 'Missing a_required_body body param',
+                  name: 'required',
+                  path: ['body', 'a_required_body'],
+                }),
+              ],
+            })
+          );
+        });
+
+        it('returns the mock when body string is provided', async () => {
+          const response = await prism.process({
+            method: 'get',
+            url: {
+              path: '/body',
+            },
+            body: '{"a_required_body":"value"}',
+            headers: {
+              'Content-type': 'application/json',
+            },
+          });
+          expect(response.validations.input).toHaveLength(0);
+        });
+      });
     });
 
-    it('returns correct response for an existing route', async () => {
-      const response = await prism.process({
-        method: 'get',
-        url: {
-          path: '/pet/findByStatus',
-          query: {
-            status: ['available', 'pending'],
-          },
-        },
+    describe('and spec file "no-refs-petstore-minimal.oas2.json" is loaded', () => {
+      beforeEach(async () => {
+        await prism.load({
+          path: resolve(__dirname, 'fixtures', 'no-refs-petstore-minimal.oas2.json'),
+        });
       });
-      const parsedBody = JSON.parse(response!.output!.body);
-      expect(parsedBody.length).toBeGreaterThan(0);
-      parsedBody.forEach((element: any) => {
-        expect(typeof element.name).toEqual('string');
-        expect(Array.isArray(element.photoUrls)).toBeTruthy();
-        expect(element.photoUrls.length).toBeGreaterThan(0);
-      });
-      // because body is generated randomly
-      expect(omit(response, 'output.body')).toMatchSnapshot();
-    });
 
-    it('returns validation error for with invalid param', async () => {
-      const response = await prism.process({
-        method: 'get',
-        url: {
-          path: '/pet/findByStatus',
-        },
+      it('errors given incorrect route', () => {
+        return expect(
+          prism.process({
+            method: 'get',
+            url: {
+              path: '/invalid-route',
+            },
+          })
+        ).rejects.toThrowError('Route not resolved, none path matched');
       });
-      expect(response).toEqual({
-        input: {
+
+      it('returns correct response for an existing route', async () => {
+        const response = await prism.process({
+          method: 'get',
+          url: {
+            path: '/pet/findByStatus',
+            query: {
+              status: ['available', 'pending'],
+            },
+          },
+        });
+        const parsedBody = JSON.parse(response!.output!.body);
+        expect(parsedBody.length).toBeGreaterThan(0);
+        parsedBody.forEach((element: any) => {
+          expect(typeof element.name).toEqual('string');
+          expect(Array.isArray(element.photoUrls)).toBeTruthy();
+          expect(element.photoUrls.length).toBeGreaterThan(0);
+        });
+        // because body is generated randomly
+        expect(omit(response, 'output.body')).toMatchSnapshot();
+      });
+
+      it('returns validation error for with invalid param', async () => {
+        const response = await prism.process({
           method: 'get',
           url: {
             path: '/pet/findByStatus',
           },
-        },
-        output: {
-          body:
-            '{"errors":[{"path":["query","status"],"name":"required","summary":"","message":"Missing status query param","severity":"error"}]}',
-          headers: {
-            'Content-type': 'application/json',
-          },
-          statusCode: 500,
-        },
-        validations: {
-          input: [
-            {
-              path: ['query', 'status'],
-              name: 'required',
-              summary: '',
-              message: 'Missing status query param',
-              severity: 'error',
+        });
+        expect(response).toEqual({
+          input: {
+            method: 'get',
+            url: {
+              path: '/pet/findByStatus',
             },
-          ],
-          output: [],
-        },
-      });
-    });
-
-    it('should support collection format multi', async () => {
-      const response = await prism.process({
-        method: 'get',
-        url: {
-          path: '/pet/findByStatus',
-          query: {
-            status: ['sold', 'available'],
           },
-        },
-      });
-      expect(response.validations).toEqual({
-        input: [],
-        output: [],
-      });
-    });
-
-    it('support param in body', async () => {
-      const response = await prism.process({
-        method: 'post',
-        url: {
-          path: '/store/order',
-        },
-        body: {
-          id: 1,
-          petId: 2,
-          quantity: 3,
-          shipDate: '12-01-2018',
-          status: 'placed',
-          complete: true,
-        },
-      });
-      expect(response.validations).toEqual({
-        input: [],
-        output: [],
-      });
-    });
-
-    it("should forward the request correctly even if resources haven't been provided", async () => {
-      // Recreate Prism with no loaded document
-      prism = createInstance(undefined, { forwarder, router: undefined, mocker: undefined });
-
-      const response = await prism.process({
-        method: 'post',
-        url: {
-          path: '/store/order',
-          baseUrl: 'https://petstore.swagger.io',
-        },
-        body: {
-          id: 1,
-          petId: 2,
-          quantity: 3,
-          shipDate: '12-01-2018',
-          status: 'placed',
-          complete: true,
-        },
+          output: {
+            body:
+              '{"errors":[{"path":["query","status"],"name":"required","summary":"","message":"Missing status query param","severity":"error"}]}',
+            headers: {
+              'Content-type': 'application/json',
+            },
+            statusCode: 500,
+          },
+          validations: {
+            input: [
+              {
+                path: ['query', 'status'],
+                name: 'required',
+                summary: '',
+                message: 'Missing status query param',
+                severity: 'error',
+              },
+            ],
+            output: [],
+          },
+        });
       });
 
-      expect(response.validations).toEqual({
-        input: [],
-        output: [],
+      it('should support collection format multi', async () => {
+        const response = await prism.process({
+          method: 'get',
+          url: {
+            path: '/pet/findByStatus',
+            query: {
+              status: ['sold', 'available'],
+            },
+          },
+        });
+        expect(response.validations).toEqual({
+          input: [],
+          output: [],
+        });
+      });
+
+      it('support param in body', async () => {
+        const response = await prism.process({
+          method: 'post',
+          url: {
+            path: '/store/order',
+          },
+          body: {
+            id: 1,
+            petId: 2,
+            quantity: 3,
+            shipDate: '12-01-2018',
+            status: 'placed',
+            complete: true,
+          },
+        });
+        expect(response.validations).toEqual({
+          input: [],
+          output: [],
+        });
+      });
+
+      it("should forward the request correctly even if resources haven't been provided", async () => {
+        // Recreate Prism with no loaded document
+        prism = createInstance(undefined, { forwarder, router: undefined, mocker: undefined });
+
+        const response = await prism.process({
+          method: 'post',
+          url: {
+            path: '/store/order',
+            baseUrl: 'https://petstore.swagger.io',
+          },
+          body: {
+            id: 1,
+            petId: 2,
+            quantity: 3,
+            shipDate: '12-01-2018',
+            status: 'placed',
+            complete: true,
+          },
+        });
+
+        expect(response.validations).toEqual({
+          input: [],
+          output: [],
+        });
       });
     });
   });

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -1,168 +1,44 @@
 import { IPrism } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types/http-spec';
 import { omit } from 'lodash';
-import { relative, resolve } from 'path';
+import { resolve } from 'path';
 import { createInstance, IHttpConfig, IHttpRequest, IHttpResponse } from '../';
 import { forwarder } from '../forwarder';
 
 describe('Http Prism Instance function tests', () => {
   let prism: IPrism<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, { path: string }>;
 
-  beforeAll(async () => {
-    prism = createInstance({ mock: true }, {});
+  it('loads spec provided in yaml', async () => {
+    prism = createInstance();
     await prism.load({
-      path: relative(
-        process.cwd(),
-        resolve(__dirname, 'fixtures', 'no-refs-petstore-minimal.oas2.json')
-      ),
+      path: resolve(__dirname, 'fixtures', 'petstore.oas2.yaml'),
     });
+    expect(prism.resources).toHaveLength(3);
   });
 
-  it('errors given incorrect route', () => {
-    return expect(
-      prism.process({
-        method: 'get',
-        url: {
-          path: '/invalid-route',
-        },
-      })
-    ).rejects.toThrowError('Route not resolved, none path matched');
-  });
-
-  it('returns correct response for an existing route', async () => {
-    const response = await prism.process({
-      method: 'get',
-      url: {
-        path: '/pet/findByStatus',
-        query: {
-          status: ['available', 'pending'],
-        },
-      },
+  // TODO is this wanted or expected? We removed similar functionality from the CLI
+  it('loading two specs merges them in together...', async () => {
+    prism = createInstance();
+    await prism.load({
+      path: resolve(__dirname, 'fixtures', 'petstore.oas2.yaml'),
     });
-    const parsedBody = JSON.parse(response!.output!.body);
-    expect(parsedBody.length).toBeGreaterThan(0);
-    parsedBody.forEach((element: any) => {
-      expect(typeof element.name).toEqual('string');
-      expect(Array.isArray(element.photoUrls)).toBeTruthy();
-      expect(element.photoUrls.length).toBeGreaterThan(0);
+    await prism.load({
+      path: resolve(__dirname, 'fixtures', 'no-refs-petstore-minimal.oas2.json'),
     });
-    // because body is generated randomly
-    expect(omit(response, 'output.body')).toMatchSnapshot();
-  });
-
-  it('returns validation error for with invalid param', async () => {
-    const response = await prism.process({
-      method: 'get',
-      url: {
-        path: '/pet/findByStatus',
-      },
-    });
-    expect(response).toEqual({
-      input: {
-        method: 'get',
-        url: {
-          path: '/pet/findByStatus',
-        },
-      },
-      output: {
-        body:
-          '{"errors":[{"path":["query","status"],"name":"required","summary":"","message":"Missing status query param","severity":"error"}]}',
-        headers: {
-          'Content-type': 'application/json',
-        },
-        statusCode: 500,
-      },
-      validations: {
-        input: [
-          {
-            path: ['query', 'status'],
-            name: 'required',
-            summary: '',
-            message: 'Missing status query param',
-            severity: 'error',
-          },
-        ],
-        output: [],
-      },
-    });
-  });
-
-  it('should support collection format multi', async () => {
-    const response = await prism.process({
-      method: 'get',
-      url: {
-        path: '/pet/findByStatus',
-        query: {
-          status: ['sold', 'available'],
-        },
-      },
-    });
-    expect(response.validations).toEqual({
-      input: [],
-      output: [],
-    });
-  });
-
-  it('support param in body', async () => {
-    const response = await prism.process({
-      method: 'post',
-      url: {
-        path: '/store/order',
-      },
-      body: {
-        id: 1,
-        petId: 2,
-        quantity: 3,
-        shipDate: '12-01-2018',
-        status: 'placed',
-        complete: true,
-      },
-    });
-    expect(response.validations).toEqual({
-      input: [],
-      output: [],
-    });
-  });
-
-  it("should forward the request correctly even if resources haven't been provided", async () => {
-    // Recreate Prism with no loaded document
-    prism = createInstance(undefined, { forwarder, router: undefined, mocker: undefined });
-
-    const response = await prism.process({
-      method: 'post',
-      url: {
-        path: '/store/order',
-        baseUrl: 'https://petstore.swagger.io',
-      },
-      body: {
-        id: 1,
-        petId: 2,
-        quantity: 3,
-        shipDate: '12-01-2018',
-        status: 'placed',
-        complete: true,
-      },
-    });
-
-    expect(response.validations).toEqual({
-      input: [],
-      output: [],
-    });
+    expect(prism.resources).toHaveLength(5);
   });
 
   it('loads spec provided in yaml', async () => {
     prism = createInstance();
-    await prism.load({
-      path: relative(process.cwd(), resolve(__dirname, 'fixtures', 'petstore.oas2.yaml')),
-    });
-
-    expect(prism.resources).toHaveLength(5);
+    expect(prism.load({ path: 'doesnt-exist.yaml' })).rejects.toThrowError(
+      'Non-existing path to spec supplied: doesnt-exist.yaml'
+    );
   });
 
   it('returns stringified static example when one defined in spec', async () => {
     prism = createInstance();
     await prism.load({
-      path: relative(process.cwd(), resolve(__dirname, 'fixtures', 'static-examples.oas2.json')),
+      path: resolve(__dirname, 'fixtures', 'static-examples.oas2.json'),
     });
 
     const response = await prism.process({
@@ -174,5 +50,146 @@ describe('Http Prism Instance function tests', () => {
 
     expect(response.output).toBeDefined();
     expect(typeof response.output!.body).toBe('string');
+  });
+
+  describe('when { mock: true } and spec file "no-refs-petstore-minimal.oas2.json" is loaded', () => {
+    beforeAll(async () => {
+      prism = createInstance({ mock: true }, {});
+      await prism.load({
+        path: resolve(__dirname, 'fixtures', 'no-refs-petstore-minimal.oas2.json')
+      });
+    });
+
+    it('errors given incorrect route', () => {
+      return expect(
+        prism.process({
+          method: 'get',
+          url: {
+            path: '/invalid-route',
+          },
+        })
+      ).rejects.toThrowError('Route not resolved, none path matched');
+    });
+
+    it('returns correct response for an existing route', async () => {
+      const response = await prism.process({
+        method: 'get',
+        url: {
+          path: '/pet/findByStatus',
+          query: {
+            status: ['available', 'pending'],
+          },
+        },
+      });
+      const parsedBody = JSON.parse(response!.output!.body);
+      expect(parsedBody.length).toBeGreaterThan(0);
+      parsedBody.forEach((element: any) => {
+        expect(typeof element.name).toEqual('string');
+        expect(Array.isArray(element.photoUrls)).toBeTruthy();
+        expect(element.photoUrls.length).toBeGreaterThan(0);
+      });
+      // because body is generated randomly
+      expect(omit(response, 'output.body')).toMatchSnapshot();
+    });
+
+    it('returns validation error for with invalid param', async () => {
+      const response = await prism.process({
+        method: 'get',
+        url: {
+          path: '/pet/findByStatus',
+        },
+      });
+      expect(response).toEqual({
+        input: {
+          method: 'get',
+          url: {
+            path: '/pet/findByStatus',
+          },
+        },
+        output: {
+          body:
+            '{"errors":[{"path":["query","status"],"name":"required","summary":"","message":"Missing status query param","severity":"error"}]}',
+          headers: {
+            'Content-type': 'application/json',
+          },
+          statusCode: 500,
+        },
+        validations: {
+          input: [
+            {
+              path: ['query', 'status'],
+              name: 'required',
+              summary: '',
+              message: 'Missing status query param',
+              severity: 'error',
+            },
+          ],
+          output: [],
+        },
+      });
+    });
+
+    it('should support collection format multi', async () => {
+      const response = await prism.process({
+        method: 'get',
+        url: {
+          path: '/pet/findByStatus',
+          query: {
+            status: ['sold', 'available'],
+          },
+        },
+      });
+      expect(response.validations).toEqual({
+        input: [],
+        output: [],
+      });
+    });
+
+    it('support param in body', async () => {
+      const response = await prism.process({
+        method: 'post',
+        url: {
+          path: '/store/order',
+        },
+        body: {
+          id: 1,
+          petId: 2,
+          quantity: 3,
+          shipDate: '12-01-2018',
+          status: 'placed',
+          complete: true,
+        },
+      });
+      expect(response.validations).toEqual({
+        input: [],
+        output: [],
+      });
+    });
+
+    it("should forward the request correctly even if resources haven't been provided", async () => {
+      // Recreate Prism with no loaded document
+      prism = createInstance(undefined, { forwarder, router: undefined, mocker: undefined });
+
+      const response = await prism.process({
+        method: 'post',
+        url: {
+          path: '/store/order',
+          baseUrl: 'https://petstore.swagger.io',
+        },
+        body: {
+          id: 1,
+          petId: 2,
+          quantity: 3,
+          shipDate: '12-01-2018',
+          status: 'placed',
+          complete: true,
+        },
+      });
+
+      expect(response.validations).toEqual({
+        input: [],
+        output: [],
+      });
+    });
   });
 });

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -81,7 +81,7 @@ describe('HttpMocker', () => {
         httpMocker.mock({
           input: mockInput,
         })
-      ).rejects.toThrowErrorMatchingSnapshot();
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Resource is not defined"`);
     });
 
     it('fails when called with no input', () => {
@@ -89,7 +89,7 @@ describe('HttpMocker', () => {
         httpMocker.mock({
           resource: mockResource,
         })
-      ).rejects.toThrowErrorMatchingSnapshot();
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Http request is not defined"`);
     });
 
     describe('with valid negotiator response', () => {
@@ -135,7 +135,37 @@ describe('HttpMocker', () => {
             resource: mockResource,
             input: mockInput,
           })
-        ).resolves.toMatchSnapshot();
+        ).resolves.toMatchInlineSnapshot(`
+                  Object {
+                    "body": "example value",
+                    "headers": Object {
+                      "Content-type": "test",
+                    },
+                    "statusCode": 202,
+                  }
+                `);
+      });
+
+      it('return an empty body if there is no schema or example', () => {
+        jest.spyOn(helpers, 'negotiateOptionsForValidRequest').mockImplementation(() => ({
+          code: '202',
+          mediaType: 'test',
+        }));
+
+        return expect(
+          httpMocker.mock({
+            resource: mockResource,
+            input: mockInput,
+          })
+        ).resolves.toMatchInlineSnapshot(`
+                  Object {
+                    "body": undefined,
+                    "headers": Object {
+                      "Content-type": "test",
+                    },
+                    "statusCode": 202,
+                  }
+                `);
       });
 
       it('defaults to empty mock configuration when called with boolean mock value', async () => {

--- a/packages/http/src/mocker/__tests__/__snapshots__/HttpMocker.spec.ts.snap
+++ b/packages/http/src/mocker/__tests__/__snapshots__/HttpMocker.spec.ts.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HttpMocker mock() fails when called with no input 1`] = `"Http request is not defined"`;
-
-exports[`HttpMocker mock() fails when called with no resource 1`] = `"Resource is not defined"`;
-
 exports[`HttpMocker mock() when example is of type INodeExternalExample generates a dynamic example 1`] = `
 Object {
   "body": "example value chelsea",
@@ -17,16 +13,6 @@ Object {
 exports[`HttpMocker mock() with invalid negotiator response returns static example 1`] = `
 Object {
   "body": "test value",
-  "headers": Object {
-    "Content-type": "test",
-  },
-  "statusCode": 202,
-}
-`;
-
-exports[`HttpMocker mock() with valid negotiator response returns dynamic example 1`] = `
-Object {
-  "body": "example value",
   "headers": Object {
     "Content-type": "test",
   },

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -192,7 +192,7 @@ const helpers = {
         lowest2xxResponse
       );
     }
-    throw new Error('No 2** response defined, cannot mock');
+    throw new Error('No 2xx response defined, cannot mock');
   },
 
   negotiateOptionsBySpecificCode(

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -376,7 +376,7 @@ describe('NegotiatorHelpers', () => {
 
       expect(() => {
         helpers.negotiateOptionsForDefaultCode(httpOperation, desiredOptions);
-      }).toThrow('No 2** response defined, cannot mock');
+      }).toThrow('No 2xx response defined, cannot mock');
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,7 +589,7 @@
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
 
-"@types/jest@24.0.11":
+"@types/jest@24.x.x":
   version "24.0.11"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.11.tgz#1f099bea332c228ea6505a88159bfa86a5858340"
   integrity sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==
@@ -623,7 +623,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.2.tgz#d77f9faa027cadad9c912cd47f4f8b07b0fb0864"
   integrity sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==
 
-"@types/node@11.13.0":
+"@types/node@11.13.0", "@types/node@11.x.x":
   version "11.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.0.tgz#b0df8d6ef9b5001b2be3a94d909ce3c29a80f9e1"
   integrity sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==
@@ -731,7 +731,7 @@ ajv-oai@1.x.x:
     ajv "^6.1.1"
     decimal.js "^9.0.1"
 
-ajv@6.10.0, ajv@6.x.x:
+ajv@6.x.x:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -3074,7 +3074,7 @@ jest-worker@^24.6.0:
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
 
-jest@^24.6.0:
+jest@24.x.x:
   version "24.6.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.6.0.tgz#133e46c3f92450402e5b6737f5a07620c3f8201e"
   integrity sha512-09Y/1FUQIGRVY2hdt0VpiL5mH0MGKeNM+Rhd1qWUZEBI/HwI6upHQR5XxlTm5d0BpXvhB/8bDpHu5ehL7JGi1g==
@@ -3589,7 +3589,7 @@ mkdirp@0.x, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mobx@^5.9.4:
+mobx@5.x.x:
   version "5.9.4"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.9.4.tgz#1dee92aba33f67b7baeeb679e3bd376a12e55812"
   integrity sha512-L9JjTX2rtQUAhCIgnHokfntNOsF14uioT9LqStf6Mya+16j56ZBe21E8Y9V59tfr2aH2kLQPD10qtCJXBuTAxw==
@@ -4922,7 +4922,7 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
 
-ts-jest@24.0.1:
+ts-jest@24.x.x:
   version "24.0.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.1.tgz#77258061cc354c3fa8616b8ac03baa0f8580f854"
   integrity sha512-mgNZmYPuGBNgYpUzchI7vdSr6zATQI0TrSyzREnXHuPCvlW8T1DQ/fdscgx4ivS5vAMUGUaoxGdWIVHC5I8imw==
@@ -5104,7 +5104,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.4.1:
+typescript@3.x.x, typescript@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
   integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==


### PR DESCRIPTION
Added a bunch more integration tests, and used a failing sample specification as a fixture for a few more. 

This PR also moves a lot of snapshots to inline, and tries to remove them altogether in other instances. All done in an attempt to improve readability, and effectiveness of our test suite.

Hidden in here is also a change that will return a JSON 500 error if the incoming request is missing a required header, query param, or body param. 

_We are going to have a biiiig old chat about if we should be doing "500 Prism is panicking because we dunno what response to give" or "Hey we saw that you like 400s so we put a 400 in your response" or something else. Will update this PR with the outcome of that chat._