### PR TITLE
feat: change install script to select v2 only tags SS-31

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ elif [ "$UNAME" = "Linux" ] ; then
   fi
 fi
 
-LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*"v2.*",'  | sed 's/[," ]//g' | cut -d ':' -f 2)
 URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
 SRC=$(pwd)/prism_$PLATFORM
 DEST=/usr/local/bin/prism

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ elif [ "$UNAME" = "Linux" ] ; then
   fi
 fi
 
-LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*"v2.*",'  | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*"v2.*",' | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
 URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
 SRC=$(pwd)/prism_$PLATFORM
 DEST=/usr/local/bin/prism


### PR DESCRIPTION
This PR modifies the grep expression used to understand the latest tag to make sure only the `v2` ones get selected — so we can release pre-release tags for v3 without having the risk of making messes with people willing to install Prism.