### PR TITLE
405 —  Method not allowed — SO-184

### DIFF
--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -4,6 +4,7 @@ import { omit } from 'lodash';
 import { relative, resolve } from 'path';
 import { createInstance, IHttpConfig, IHttpRequest, IHttpResponse } from '../';
 import { forwarder } from '../forwarder';
+import { NO_PATH_MATCHED_ERROR } from '../router/errors';
 
 describe('Http Prism Instance function tests', () => {
   let prism: IPrism<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig, { path: string }>;
@@ -38,7 +39,7 @@ describe('Http Prism Instance function tests', () => {
           path: '/invalid-route',
         },
       })
-    ).rejects.toThrowError('Route not resolved, none path matched');
+    ).rejects.toThrowError(NO_PATH_MATCHED_ERROR);
   });
 
   test('given correct route should return correct response', async () => {

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -1,11 +1,10 @@
 import { IHttpOperation, IServer } from '@stoplight/types';
 import { Chance } from 'chance';
 import {
+  NO_PATH_MATCHED_ERROR,
   NO_RESOURCE_PROVIDED_ERROR,
   NO_SERVER_CONFIGURATION_PROVIDED_ERROR,
-  NONE_METHOD_MATCHED_ERROR,
-  NONE_PATH_MATCHED_ERROR,
-  NONE_SERVER_MATCHED_ERROR,
+  NO_SERVER_MATCHED_ERROR,
 } from '../errors';
 import { router } from '../index';
 import { pickOneHttpMethod, pickSetOfHttpMethods, randomPath } from './utils';
@@ -99,7 +98,7 @@ describe('http router', () => {
               },
             },
           })
-        ).toThrow(NONE_METHOD_MATCHED_ERROR);
+        ).toThrow(NO_PATH_MATCHED_ERROR);
       });
 
       describe('given matched methods', () => {
@@ -126,7 +125,7 @@ describe('http router', () => {
                 },
               },
             })
-          ).toThrow(NONE_PATH_MATCHED_ERROR);
+          ).toThrow(NO_PATH_MATCHED_ERROR);
         });
 
         test('given a concrete matching server and matched concrete path should match', async () => {
@@ -252,7 +251,7 @@ describe('http router', () => {
                 },
               },
             })
-          ).toThrow(NONE_PATH_MATCHED_ERROR);
+          ).toThrow(NO_PATH_MATCHED_ERROR);
         });
 
         test('given a concrete servers and mixed paths should match concrete path', async () => {
@@ -378,7 +377,7 @@ describe('http router', () => {
                 },
               },
             })
-          ).toThrowError(NONE_SERVER_MATCHED_ERROR);
+          ).toThrowError(NO_SERVER_MATCHED_ERROR);
         });
 
         test('given empty baseUrl and empty server url it should match', async () => {

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -1,6 +1,8 @@
+import { IHttpMethod } from '@stoplight/prism-http';
 import { IHttpOperation, IServer } from '@stoplight/types';
 import { Chance } from 'chance';
 import {
+  NO_METHOD_MATCHED_ERROR,
   NO_PATH_MATCHED_ERROR,
   NO_RESOURCE_PROVIDED_ERROR,
   NO_SERVER_CONFIGURATION_PROVIDED_ERROR,
@@ -415,6 +417,25 @@ describe('http router', () => {
 
           expect(resource).toBe(expectedResource);
         });
+      });
+
+      test('should not match when the method does not exist', () => {
+        const method: IHttpMethod = 'get';
+        const path = randomPath({ includeTemplates: false });
+        const url = 'concrete.com';
+
+        return expect(() =>
+          router.route({
+            resources: [createResource(method, path, [{ url }])],
+            input: {
+              method: 'post',
+              url: {
+                baseUrl: url,
+                path,
+              },
+            },
+          })
+        ).toThrowError(NO_METHOD_MATCHED_ERROR);
       });
     });
   });

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -3,14 +3,23 @@ import { Chance } from 'chance';
 import defaults = require('lodash/defaults');
 
 const chance = new Chance();
-const httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+const httpMethods: IHttpMethod[] = [
+  'get',
+  'put',
+  'post',
+  'delete',
+  'options',
+  'head',
+  'patch',
+  'trace',
+];
 
 export function pickOneHttpMethod(): IHttpMethod {
-  return chance.pickone(httpMethods) as IHttpMethod;
+  return chance.pickone(httpMethods);
 }
 
 export function pickSetOfHttpMethods(count: number = 2): IHttpMethod[] {
-  return chance.unique(pickOneHttpMethod, count) as IHttpMethod[];
+  return chance.unique(pickOneHttpMethod, count);
 }
 
 export function randomArray<T>(itemGenerator: () => T, length: number = 1): T[] {

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -1,5 +1,6 @@
 import { IHttpMethod } from '@stoplight/prism-http';
 import { Chance } from 'chance';
+import defaults = require('lodash/defaults');
 
 const chance = new Chance();
 const httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
@@ -30,19 +31,16 @@ interface IRandomPathOptions {
 }
 
 export function randomPath(opts: IRandomPathOptions = defaultRandomPathOptions): string {
-  opts = Object.assign({}, defaultRandomPathOptions, opts);
+  defaults(opts, defaultRandomPathOptions);
+
   const randomPathFragments = randomArray(
     () =>
-      opts.includeTemplates && chance.coin() === 'heads' ? `{${chance.word()}}` : chance.word(),
+      opts.includeTemplates && chance.bool() ? `{${chance.word()}}` : chance.word(),
     opts.pathFragments
   );
-  let leadingSlash = chance.pickone(['/', '']);
-  let trailingSlash = chance.pickone(['/', '']);
-  if (opts.leadingSlash !== undefined) {
-    leadingSlash = opts.leadingSlash ? '/' : '';
-  }
-  if (opts.trailingSlash !== undefined) {
-    trailingSlash = opts.trailingSlash ? '/' : '';
-  }
+
+  const leadingSlash = opts.leadingSlash ? '/' : '';
+  const trailingSlash = opts.trailingSlash ? '/' : '';
+
   return `${leadingSlash}${randomPathFragments.join('/')}${trailingSlash}`;
 }

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -34,8 +34,7 @@ export function randomPath(opts: IRandomPathOptions = defaultRandomPathOptions):
   defaults(opts, defaultRandomPathOptions);
 
   const randomPathFragments = randomArray(
-    () =>
-      opts.includeTemplates && chance.bool() ? `{${chance.word()}}` : chance.word(),
+    () => (opts.includeTemplates && chance.bool() ? `{${chance.word()}}` : chance.word()),
     opts.pathFragments
   );
 

--- a/packages/http/src/router/errors.ts
+++ b/packages/http/src/router/errors.ts
@@ -1,6 +1,6 @@
 export const NO_RESOURCE_PROVIDED_ERROR = 'Route not resolved, no resource provided.';
-export const NONE_METHOD_MATCHED_ERROR = 'Route not resolved, none method matched.';
-export const NONE_PATH_MATCHED_ERROR = 'Route not resolved, none path matched.';
-export const NONE_SERVER_MATCHED_ERROR = 'Route not resolved, none server matched.';
+export const NO_PATH_MATCHED_ERROR = 'Route not resolved, no path matched.';
+export const NO_SERVER_MATCHED_ERROR = 'Route not resolved, no server matched.';
+export const NO_SUITABLE_METHOD_ERROR = 'Route resolved, but no path matched.';
 export const NO_SERVER_CONFIGURATION_PROVIDED_ERROR =
   'Route not resolved, no server configuration provided.';

--- a/packages/http/src/router/errors.ts
+++ b/packages/http/src/router/errors.ts
@@ -1,6 +1,6 @@
 export const NO_RESOURCE_PROVIDED_ERROR = 'Route not resolved, no resource provided.';
 export const NO_PATH_MATCHED_ERROR = 'Route not resolved, no path matched.';
 export const NO_SERVER_MATCHED_ERROR = 'Route not resolved, no server matched.';
-export const NO_SUITABLE_METHOD_ERROR = 'Route resolved, but no path matched.';
+export const NO_METHOD_MATCHED_ERROR = 'Route resolved, but no path matched.';
 export const NO_SERVER_CONFIGURATION_PROVIDED_ERROR =
   'Route not resolved, no server configuration provided.';

--- a/packages/http/src/router/errors.ts
+++ b/packages/http/src/router/errors.ts
@@ -1,7 +1,6 @@
-export const NO_RESOURCE_PROVIDED_ERROR = new Error('Route not resolved, no resource provided.');
-export const NONE_METHOD_MATCHED_ERROR = new Error('Route not resolved, none method matched.');
-export const NONE_PATH_MATCHED_ERROR = new Error('Route not resolved, none path matched.');
-export const NONE_SERVER_MATCHED_ERROR = new Error('Route not resolved, none server matched.');
-export const NO_SERVER_CONFIGURATION_PROVIDED_ERROR = new Error(
-  'Route not resolved, no server configuration provided.'
-);
+export const NO_RESOURCE_PROVIDED_ERROR = 'Route not resolved, no resource provided.';
+export const NONE_METHOD_MATCHED_ERROR = 'Route not resolved, none method matched.';
+export const NONE_PATH_MATCHED_ERROR = 'Route not resolved, none path matched.';
+export const NONE_SERVER_MATCHED_ERROR = 'Route not resolved, none server matched.';
+export const NO_SERVER_CONFIGURATION_PROVIDED_ERROR =
+  'Route not resolved, no server configuration provided.';

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -79,13 +79,9 @@ export const router: IRouter<IHttpOperation, IHttpRequest, IHttpConfig> = {
 };
 
 function matchServer(servers: IServer[], requestBaseUrl: string) {
-  const serverMatches = [];
-  for (const server of servers) {
-    const tempServerMatch = matchBaseUrl(server, requestBaseUrl);
-    if (tempServerMatch !== MatchType.NOMATCH) {
-      serverMatches.push(tempServerMatch);
-    }
-  }
+  const serverMatches = servers
+    .map(server => matchBaseUrl(server, requestBaseUrl))
+    .filter(match => match !== MatchType.NOMATCH);
 
   return disambiguateServers(serverMatches);
 }

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -20,7 +20,7 @@ export const router: IRouter<IHttpOperation, IHttpRequest, IHttpConfig> = {
     const serverValidationEnabled = !!requestBaseUrl;
 
     if (!resources.length) {
-      throw NO_RESOURCE_PROVIDED_ERROR;
+      throw new Error(NO_RESOURCE_PROVIDED_ERROR);
     }
 
     let anyMethodMatched = false;
@@ -59,19 +59,19 @@ export const router: IRouter<IHttpOperation, IHttpRequest, IHttpConfig> = {
     }
 
     if (!anyMethodMatched) {
-      throw NONE_METHOD_MATCHED_ERROR;
+      throw new Error(NONE_METHOD_MATCHED_ERROR);
     }
 
     if (!anyPathMatched) {
-      throw NONE_PATH_MATCHED_ERROR;
+      throw new Error(NONE_PATH_MATCHED_ERROR);
     }
 
     if (!anyServerProvided) {
-      throw NO_SERVER_CONFIGURATION_PROVIDED_ERROR;
+      throw new Error(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
     }
 
     if (!anyServerMatched) {
-      throw NONE_SERVER_MATCHED_ERROR;
+      throw new Error(NONE_SERVER_MATCHED_ERROR);
     }
 
     return disambiguateMatches(matches);

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -3,75 +3,84 @@ import { IHttpOperation, IServer } from '@stoplight/types';
 
 import { IHttpConfig, IHttpRequest } from '../types';
 import {
+  NO_PATH_MATCHED_ERROR,
   NO_RESOURCE_PROVIDED_ERROR,
   NO_SERVER_CONFIGURATION_PROVIDED_ERROR,
-  NONE_METHOD_MATCHED_ERROR,
-  NONE_PATH_MATCHED_ERROR,
-  NONE_SERVER_MATCHED_ERROR,
+  NO_SERVER_MATCHED_ERROR,
+  NO_SUITABLE_METHOD_ERROR,
 } from './errors';
 import { matchBaseUrl } from './matchBaseUrl';
 import { matchPath } from './matchPath';
 import { IMatch, MatchType } from './types';
 
 export const router: IRouter<IHttpOperation, IHttpRequest, IHttpConfig> = {
-  route: ({ resources, input }) => {
-    const matches = [];
+  route: ({ resources, input }): IHttpOperation => {
     const { path: requestPath, baseUrl: requestBaseUrl } = input.url;
-    const serverValidationEnabled = !!requestBaseUrl;
 
     if (!resources.length) {
       throw new Error(NO_RESOURCE_PROVIDED_ERROR);
     }
 
-    let anyMethodMatched = false;
-    let anyPathMatched = false;
-    let anyServerMatched = false;
-    let anyServerProvided = false;
-
-    for (const resource of resources) {
-      if (!matchByMethod(input, resource)) continue;
-      anyMethodMatched = true;
-
+    const matches = resources.map<IMatch>(resource => {
       const pathMatch = matchPath(requestPath, resource.path);
-      if (pathMatch !== MatchType.NOMATCH) anyPathMatched = true;
+      if (pathMatch === MatchType.NOMATCH)
+        return {
+          pathMatch,
+          methodMatch: MatchType.NOMATCH,
+          resource,
+        };
+
+      const methodMatch = matchByMethod(input, resource) ? MatchType.CONCRETE : MatchType.NOMATCH;
+
+      if (methodMatch === MatchType.NOMATCH) {
+        return {
+          pathMatch,
+          methodMatch,
+          resource,
+        };
+      }
 
       const { servers = [] } = resource;
-      let serverMatch: MatchType | null = null;
 
-      if (serverValidationEnabled) {
-        if (servers.length === 0) continue;
+      if (requestBaseUrl && servers.length > 0) {
+        const serverMatch = matchServer(servers, requestBaseUrl);
 
-        anyServerProvided = true;
-        serverMatch = matchServer(servers, requestBaseUrl as string);
-        if (serverMatch) anyServerMatched = true;
-      } else {
-        anyServerMatched = true;
-        anyServerProvided = true;
-      }
-
-      if (pathMatch !== MatchType.NOMATCH) {
-        matches.push({
+        return {
           pathMatch,
+          methodMatch,
           serverMatch,
           resource,
-        });
+        };
+      }
+
+      return {
+        pathMatch,
+        methodMatch,
+        serverMatch: null,
+        resource,
+      };
+    });
+
+    if (requestBaseUrl) {
+      if (matches.every(match => match.serverMatch === null)) {
+        throw new Error(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
+      }
+
+      if (matches.every(match => !!match.serverMatch && match.serverMatch === MatchType.NOMATCH)) {
+        throw new Error(NO_SERVER_MATCHED_ERROR);
       }
     }
 
-    if (!anyMethodMatched) {
-      throw new Error(NONE_METHOD_MATCHED_ERROR);
+    if (!matches.some(match => match.pathMatch !== MatchType.NOMATCH)) {
+      throw new Error(NO_PATH_MATCHED_ERROR);
     }
 
-    if (!anyPathMatched) {
-      throw new Error(NONE_PATH_MATCHED_ERROR);
-    }
-
-    if (!anyServerProvided) {
-      throw new Error(NO_SERVER_CONFIGURATION_PROVIDED_ERROR);
-    }
-
-    if (!anyServerMatched) {
-      throw new Error(NONE_SERVER_MATCHED_ERROR);
+    if (
+      !matches.some(
+        match => match.pathMatch !== MatchType.NOMATCH && match.methodMatch !== MatchType.NOMATCH
+      )
+    ) {
+      throw new Error(NO_SUITABLE_METHOD_ERROR);
     }
 
     return disambiguateMatches(matches);
@@ -120,5 +129,5 @@ function areServerAndPath(match: IMatch, serverType: MatchType, pathType: MatchT
  */
 function disambiguateServers(serverMatches: MatchType[]): MatchType {
   const concreteMatch = serverMatches.find(serverMatch => serverMatch === MatchType.CONCRETE);
-  return concreteMatch || serverMatches[0];
+  return concreteMatch || serverMatches[0] || MatchType.NOMATCH;
 }

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -3,11 +3,11 @@ import { IHttpOperation, IServer } from '@stoplight/types';
 
 import { IHttpConfig, IHttpRequest } from '../types';
 import {
+  NO_METHOD_MATCHED_ERROR,
   NO_PATH_MATCHED_ERROR,
   NO_RESOURCE_PROVIDED_ERROR,
   NO_SERVER_CONFIGURATION_PROVIDED_ERROR,
   NO_SERVER_MATCHED_ERROR,
-  NO_SUITABLE_METHOD_ERROR,
 } from './errors';
 import { matchBaseUrl } from './matchBaseUrl';
 import { matchPath } from './matchPath';
@@ -80,7 +80,7 @@ export const router: IRouter<IHttpOperation, IHttpRequest, IHttpConfig> = {
         match => match.pathMatch !== MatchType.NOMATCH && match.methodMatch !== MatchType.NOMATCH
       )
     ) {
-      throw new Error(NO_SUITABLE_METHOD_ERROR);
+      throw new Error(NO_METHOD_MATCHED_ERROR);
     }
 
     return disambiguateMatches(matches);

--- a/packages/http/src/router/types.ts
+++ b/packages/http/src/router/types.ts
@@ -4,8 +4,9 @@ export type Nullable<T> = T | null;
 
 export interface IMatch {
   resource: IHttpOperation;
-  serverMatch: MatchType | null;
   pathMatch: MatchType;
+  methodMatch: MatchType;
+  serverMatch?: Nullable<MatchType>;
 }
 
 export enum MatchType {


### PR DESCRIPTION
This PR will make sure to throw a special exception in case the current path has been matched, but it wasn't possible to find an appropriate method.

We'll catch these exceptions and return the appropriate status codes in a follow up PR.

Highlights:

1. Dry some functions that were unexpectedly complicated and/or accumulating state over time (`matchServer`, `randomPath`)
2. Do not creare `Error` objects in place where they're not thrown, otherwise the stack trace is wrong and you have no idea where the exception happened. (This made me lose some time)
3. Refactored the `route` method to not accumulate the state over time with global `booleans`, but rather create a `matches` object and find the correct thing to do using a series of filters
4. Added tests for the new scenario.

SO-184