### PR TITLE
fix: error serialisation SO-195

### DIFF
--- a/packages/core/src/utils/graphFacade.ts
+++ b/packages/core/src/utils/graphFacade.ts
@@ -66,7 +66,7 @@ export class GraphFacade {
       language,
       path: '/',
       data: { raw },
-    } as ISourceNode);
+    });
 
     await this.graphite.scheduler.drain();
   }

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -3,12 +3,12 @@ import { createServer } from '../';
 import { IPrismHttpServer } from '../types';
 
 function checkErrorPayloadShape(payload: string) {
-  const parsedPayload = JSON.parse(payload)
+  const parsedPayload = JSON.parse(payload);
 
-  expect(parsedPayload).toHaveProperty('name')
-  expect(parsedPayload).toHaveProperty('title')
-  expect(parsedPayload).toHaveProperty('status')
-  expect(parsedPayload).toHaveProperty('detail')
+  expect(parsedPayload).toHaveProperty('name');
+  expect(parsedPayload).toHaveProperty('title');
+  expect(parsedPayload).toHaveProperty('status');
+  expect(parsedPayload).toHaveProperty('detail');
 }
 
 describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', file => {

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -2,6 +2,15 @@ import { relative, resolve } from 'path';
 import { createServer } from '../';
 import { IPrismHttpServer } from '../types';
 
+function checkErrorPayloadShape(payload: string) {
+  const parsedPayload = JSON.parse(payload)
+
+  expect(parsedPayload).toHaveProperty('name')
+  expect(parsedPayload).toHaveProperty('title')
+  expect(parsedPayload).toHaveProperty('status')
+  expect(parsedPayload).toHaveProperty('detail')
+}
+
 describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', file => {
   let server: IPrismHttpServer<{}>;
 
@@ -37,6 +46,7 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
       url: '/pets/123',
     });
     expect(response.statusCode).toBe(500);
+    checkErrorPayloadShape(response.payload);
   });
 
   test('will return requested response using the __code property', async () => {
@@ -68,6 +78,7 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
     });
 
     expect(response.statusCode).toBe(422);
+    checkErrorPayloadShape(response.payload);
   });
 
   test.skip('should automagically provide the parameters when not provided in the query string and a default is defined', async () => {
@@ -137,6 +148,7 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
       },
     });
     expect(response.statusCode).toBe(422);
+    checkErrorPayloadShape(response.payload);
   });
 
   test('will return the default response when using the __code property with a non existing code', async () => {
@@ -146,9 +158,6 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
     });
 
     expect(response.statusCode).toBe(499);
-    const payload = JSON.parse(response.payload);
-    expect(payload).toHaveProperty('code');
-    expect(payload).toHaveProperty('message');
   });
 
   test('will return 500 with error when an undefined code is requested and there is no default response', async () => {
@@ -158,6 +167,7 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
     });
 
     expect(response.statusCode).toBe(500);
+    checkErrorPayloadShape(response.payload);
   });
 });
 

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -5,7 +5,7 @@ import { IPrismHttpServer } from '../types';
 function checkErrorPayloadShape(payload: string) {
   const parsedPayload = JSON.parse(payload);
 
-  expect(parsedPayload).toHaveProperty('name');
+  expect(parsedPayload).toHaveProperty('type');
   expect(parsedPayload).toHaveProperty('title');
   expect(parsedPayload).toHaveProperty('status');
   expect(parsedPayload).toHaveProperty('detail');

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -82,10 +82,10 @@ const replyHandler = <LoaderInput>(
         .serializer(JSON.stringify)
         .code(status)
         .send({
-          name: e.name || 'UNKNOWN',
+          name: e.name && e.name !== 'Error' ? e.name : 'UNKNOWN',
           title: e.message,
           status,
-          detail: e.detail,
+          detail: e.detail || '',
         });
     }
   };

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,5 +1,5 @@
 import { configMergerFactory } from '@stoplight/prism-core';
-import { createInstance, IHttpMethod, TPrismHttpInstance } from '@stoplight/prism-http';
+import { createInstance, IHttpMethod, ProblemJsonError, TPrismHttpInstance } from '@stoplight/prism-http';
 import * as fastify from 'fastify';
 import { IncomingMessage, Server, ServerResponse } from 'http';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
@@ -81,12 +81,7 @@ const replyHandler = <LoaderInput>(
         .type('application/problem+json')
         .serializer(JSON.stringify)
         .code(status)
-        .send({
-          name: e.name && e.name !== 'Error' ? e.name : 'UNKNOWN',
-          title: e.message,
-          status,
-          detail: e.detail || '',
-        });
+        .send(ProblemJsonError.fromPlainError(e));
     }
   };
 };

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,5 +1,5 @@
 import { configMergerFactory } from '@stoplight/prism-core';
-import { createInstance, IHttpMethod, ProblemJsonError, TPrismHttpInstance } from '@stoplight/prism-http';
+import { createInstance, IHttpMethod, TPrismHttpInstance } from '@stoplight/prism-http';
 import * as fastify from 'fastify';
 import { IncomingMessage, Server, ServerResponse } from 'http';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
@@ -79,18 +79,14 @@ const replyHandler = <LoaderInput>(
       const status = 'status' in e ? e.status : 500;
       reply
         .type('application/problem+json')
-        .serializer((payload: unknown) => JSON.stringify(payload))
+        .serializer(JSON.stringify)
         .code(status)
-        .send(
-          ProblemJsonError.fromTemplate(
-            {
-              name: e.name || 'UNKNOWN',
-              title: e.message,
-              status,
-            },
-            e.detail,
-          ),
-        );
+        .send({
+          name: e.name || 'UNKNOWN',
+          title: e.message,
+          status,
+          detail: e.detail,
+        });
     }
   };
 };

--- a/packages/http/src/mocker/errors.ts
+++ b/packages/http/src/mocker/errors.ts
@@ -2,7 +2,7 @@ import { Omit } from '@stoplight/types';
 import { ProblemJson } from '../types';
 
 export const UNPROCESSABLE_ENTITY: Omit<ProblemJson, 'detail'> = {
-  name: 'UNPROCESSABLE_ENTITY',
+  type: 'UNPROCESSABLE_ENTITY',
   title: 'Invalid request body payload',
   status: 422,
 };

--- a/packages/http/src/router/errors.ts
+++ b/packages/http/src/router/errors.ts
@@ -3,26 +3,26 @@ import { ProblemJson } from '../types';
 
 export const NO_RESOURCE_PROVIDED_ERROR: Omit<ProblemJson, 'detail'> = {
   title: 'Route not resolved, no resource provided.',
-  name: 'NO_RESOURCE_PROVIDED_ERROR',
+  type: 'NO_RESOURCE_PROVIDED_ERROR',
   status: 404,
 };
 export const NO_PATH_MATCHED_ERROR: Omit<ProblemJson, 'detail'> = {
   title: 'Route not resolved, no path matched.',
-  name: 'NO_PATH_MATCHED_ERROR',
+  type: 'NO_PATH_MATCHED_ERROR',
   status: 404,
 };
 export const NO_SERVER_MATCHED_ERROR: Omit<ProblemJson, 'detail'> = {
   title: 'Route not resolved, no server matched.',
-  name: 'NO_SERVER_MATCHED_ERROR',
+  type: 'NO_SERVER_MATCHED_ERROR',
   status: 404,
 };
 export const NO_METHOD_MATCHED_ERROR: Omit<ProblemJson, 'detail'> = {
   title: 'Route resolved, but no path matched.',
-  name: 'NO_METHOD_MATCHED_ERROR',
+  type: 'NO_METHOD_MATCHED_ERROR',
   status: 405,
 };
 export const NO_SERVER_CONFIGURATION_PROVIDED_ERROR: Omit<ProblemJson, 'detail'> = {
   title: 'Route not resolved, no server configuration provided.',
-  name: 'NO_SERVER_CONFIGURATION_PROVIDED_ERROR',
+  type: 'NO_SERVER_CONFIGURATION_PROVIDED_ERROR',
   status: 404,
 };

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -77,7 +77,7 @@ export interface IHttpResponse {
 }
 
 export type ProblemJson = {
-  name: string;
+  type: string;
   title: string;
   status: number;
   detail: string;
@@ -86,7 +86,7 @@ export type ProblemJson = {
 export class ProblemJsonError extends Error {
   public static fromTemplate(template: Omit<ProblemJson, 'detail'>, detail?: string): ProblemJsonError {
     return new ProblemJsonError(
-      `https://stoplight.io/prism/errors#${template.name}`,
+      `https://stoplight.io/prism/errors#${template.type}`,
       template.title,
       template.status,
       detail || '',
@@ -95,7 +95,7 @@ export class ProblemJsonError extends Error {
 
   public static fromPlainError(error: Error & { detail?: string; status?: number }): ProblemJson {
     return {
-      name: error.name && error.name !== 'Error' ? error.name : 'https://stoplight.io/prism/errors#UNKNOWN',
+      type: error.name && error.name !== 'Error' ? error.name : 'https://stoplight.io/prism/errors#UNKNOWN',
       title: error.message,
       status: error.status || 500,
       detail: error.detail || '',

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -93,6 +93,15 @@ export class ProblemJsonError extends Error {
     );
   }
 
+  public static fromPlainError(error: Error & { detail?: string; status?: number }): ProblemJson {
+    return {
+      name: error.name && error.name !== 'Error' ? error.name : 'https://stoplight.io/prism/errors#UNKNOWN',
+      title: error.message,
+      status: error.status || 500,
+      detail: error.detail || '',
+    };
+  }
+
   constructor(readonly name: string, readonly message: string, readonly status: number, readonly detail: string) {
     super(message);
     Error.captureStackTrace(this, ProblemJsonError);


### PR DESCRIPTION
It turns out Fastify is a little bit too opinionated with regards to the error format; so if you use `reply.send` with an `Error` object it will copy only some particular fields and completely ignore the others, which we need for `application/problem+json`.

I've tried every possible solution, but it's scenario they just do not support. I know this is not ideal, but hopefully I'll be able to get rid of this asap

I've also modified the tests to make sure the error payload is always an `application/problem+json`