### PR TITLE
fix: make sure http download works

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
     "@oclif/plugin-help": "^2.0.0",
     "@stoplight/prism-core": "^3.0.0-pre.2",
     "@stoplight/prism-http-server": "^3.0.0-pre.2",
+    "tmp": "^0.1.0",
     "tslib": "^1.0.0"
   },
   "devDependencies": {
@@ -19,6 +20,7 @@
     "@oclif/tslint": "^3.0.0",
     "@types/chai": "^4.0.0",
     "@types/node": "^12.0.0",
+    "@types/tmp": "^0.1.0",
     "globby": "^9.0.0",
     "ts-node": "^8.0.0",
     "tsconfig-paths": "^3.0.0",

--- a/packages/core/src/loaders/http/httpLoader.ts
+++ b/packages/core/src/loaders/http/httpLoader.ts
@@ -1,10 +1,12 @@
-import { FilesystemNodeType } from '@stoplight/graphite/backends/filesystem';
 import { IHttpOperation } from '@stoplight/types';
 import axios from 'axios';
-import { trimStart } from 'lodash';
+import * as fs from 'fs';
 import { extname } from 'path';
+import * as tmp from 'tmp';
 import { IHttpLoaderOpts } from '../../types';
 import { GraphFacade } from '../../utils/graphFacade';
+
+tmp.setGracefulCleanup();
 
 export class HttpLoader {
   constructor(private graphFacade: GraphFacade = new GraphFacade()) {}
@@ -12,13 +14,11 @@ export class HttpLoader {
   public async load(opts?: IHttpLoaderOpts): Promise<IHttpOperation[]> {
     if (!opts || !opts.url) return [];
 
+    const filePath = tmp.tmpNameSync({ postfix: extname(opts.url) });
     const response = await axios({ url: opts.url, transformResponse: d => d });
+    fs.writeFileSync(filePath, response.data, 'utf8');
 
-    await this.graphFacade.createRawNode(response.data, {
-      type: FilesystemNodeType.File,
-      language: trimStart(extname(opts.url), '.'),
-    });
-
+    await this.graphFacade.createFilesystemNode(filePath);
     return this.graphFacade.httpOperations;
   }
 }

--- a/packages/core/src/utils/__tests__/graphFacade.int.ts
+++ b/packages/core/src/utils/__tests__/graphFacade.int.ts
@@ -1,4 +1,3 @@
-import { FilesystemNodeType } from '@stoplight/graphite/backends/filesystem';
 import { isAbsolute, resolve } from 'path';
 import { GraphFacade } from '../graphFacade';
 
@@ -17,17 +16,6 @@ describe('graphFacade', () => {
       expect(isAbsolute(path)).toBe(true);
 
       await graphFacade.createFilesystemNode(path);
-
-      expect(graphFacade.httpOperations.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('createRawNode()', () => {
-    test('httpOperations should return filtered nodes', async () => {
-      await graphFacade.createRawNode(
-        JSON.stringify(require('../../../../cli/src/samples/no-refs-petstore.oas2.json')),
-        { type: FilesystemNodeType.File, language: 'json' },
-      );
 
       expect(graphFacade.httpOperations.length).toBeGreaterThan(0);
     });

--- a/packages/core/src/utils/graphFacade.ts
+++ b/packages/core/src/utils/graphFacade.ts
@@ -4,7 +4,7 @@ import {
   FileSystemBackend,
   FilesystemNodeType,
 } from '@stoplight/graphite/backends/filesystem';
-import { ISourceNode, NodeCategory } from '@stoplight/graphite/graph/nodes';
+import { NodeCategory } from '@stoplight/graphite/graph/nodes';
 import { createGraphite } from '@stoplight/graphite/graphite';
 import { createOas2HttpPlugin } from '@stoplight/graphite/plugins/http/oas2';
 import { createOas3HttpPlugin } from '@stoplight/graphite/plugins/http/oas3';
@@ -28,8 +28,8 @@ export class GraphFacade {
       createJsonPlugin(),
       createYamlPlugin(),
       createOas2Plugin(),
-      createOas3Plugin(),
       createOas2HttpPlugin(),
+      createOas3Plugin(),
       createOas3HttpPlugin(),
     );
     this.fsBackend = createFileSystemBackend(graphite, fs);
@@ -55,18 +55,6 @@ export class GraphFacade {
       });
       this.fsBackend.readFile(resourceFile);
     }
-
-    await this.graphite.scheduler.drain();
-  }
-
-  public async createRawNode(raw: string, { type, language }: Pick<ISourceNode, 'type' | 'language'>) {
-    this.graphite.graph.addNode({
-      category: NodeCategory.Source,
-      type,
-      language,
-      path: '/',
-      data: { raw },
-    });
 
     await this.graphite.scheduler.drain();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,6 +1342,11 @@
   resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.15.tgz#5591141e8e3e2e81a4b49c3a3d2321d1367d4ebc"
   integrity sha512-ZQKcczZbsfVKf+QKViMvjGni1BADoWCjnimkUc3l4zV/d0sM4cj+Hbtg9gjwUaPhi4m3Q8ne62B+fYubUIPqZQ==
 
+"@types/tmp@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
+  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
+
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -7224,6 +7229,13 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
This PR fixes the "spec download from internet experience".

Unfortunately I had to change a little bit the mechanism because apparently Graphite has some problems with initialising stuff from memory directly and I've been trying to debug it for the whole day, without no luck.

I want to get this out, so I decided to introduce a little bit of technical debt which can easily be repaired in order to get this out. Given this is confined in the CLI only (In a non future breaking way) and not in Prism itself, it should not be a big deal.