### PR TITLE
Fixed CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,26 @@
-## Link to a related Jira task
+PR Title
 
-<!-- Put a link here -->
+## Checklist
 
-## Change summary
+- [ ] Tests have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
 
-<!--
-  Tell your reviewers why you are requesting this chance.
-  What was the problem/request and how you solved it.
-  Try to describe it in a non-technical matter so that it's easy to scan and understand w/o
-  going into details.
-  -->
+## What kind of change does this PR introduce
 
+Bug fix, feature, or docs update
+
+## What is the current behavior
+
+You can also link to an open issue here.
+
+## If this is a feature change, what is the new behavior
+
+It can now make a nice cup of tea.
+
+## Does this PR introduce a breaking change
+
+What changes might users need to make in their application due to this PR?
+
+### Other information
+
+(e.g. detailed explanation, related issues, links for us to have context, eg. Stack Overflow, issues outside of the repo, forum, etc.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 ## Setup
 
 1. Clone the repository
-2. Run `yarn` and `yarn build`
+2. Run `yarn`
 3. Reference the bin directly, for example `./packages/cli/bin/run mock openapi.yaml`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 ## Setup
 
 1. Clone the repository
-2. Run `yarn setup` and `yarn build`
-3. Reference the bin directly, for example `./packages/cli/bin/run serve ...`
+2. Run `yarn` and `yarn build`
+3. Reference the bin directly, for example `./packages/cli/bin/run mock openapi.yaml`


### PR DESCRIPTION
The instructions here were out of date, `yarn setup` does not exit.

Also took this opportunity to improve the PR template to match Spectral a bit more.