### PR TITLE
fix: look for 422 for invalid requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Prism can be forced to return different HTTP responses by specifying the status 
 string:
 
 ```bash
-curl http://127.0.0.1:4010/pets/123?__code=404
+curl -v http://127.0.0.1:4010/pets/123?__code=404
 
 HTTP/1.1 404 Not Found
 content-type: application/json
@@ -99,19 +99,19 @@ This will generate an error, conforming the [application/problem+json][rfc7807] 
 ```
 HTTP/1.1 422 Unprocessable Entity
 content-type: application/problem+json
-content-length: 279
-Date: Wed, 08 May 2019 19:22:27 GMT
+content-length: 274
+Date: Thu, 09 May 2019 16:36:38 GMT
 Connection: keep-alive
 
 {
+   "detail" : "Your request body is not valid: [{\"path\":[\"body\"],\"code\":\"required\",\"message\":\"should have required property 'name'\",\"severity\":0}]",
+   "type" : "https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY",
    "title" : "Invalid request body payload",
-   "detail" : "Your request body is not valid: [{\"path\":[\"body\"],\"code\":\"required\",\"message\":\"should have required property 'photoUrls'\",\"severity\":0}]",
-   "status" : 422,
-   "type" : "https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY"
+   "status" : 422
 }
 ```
 
-This error shows the request is missing a required property `photoUrls` from the HTTP request body.
+This error shows the request is missing a required property `name` from the HTTP request body.
 
 ## FAQ
 

--- a/packages/http/src/__tests__/fixtures/index.ts
+++ b/packages/http/src/__tests__/fixtures/index.ts
@@ -127,7 +127,7 @@ export const httpOperations: IHttpOperation[] = [
         headers: [],
       },
       {
-        code: '400',
+        code: '422',
         contents: [
           {
             mediaType: 'application/json',
@@ -217,7 +217,7 @@ export const httpOperations: IHttpOperation[] = [
         ],
       },
       {
-        code: '400',
+        code: '422',
         headers: [],
         contents: [
           {

--- a/packages/http/src/mocker/__tests__/__snapshots__/functional.spec.ts.snap
+++ b/packages/http/src/mocker/__tests__/__snapshots__/functional.spec.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`http mocker request is invalid returns 400 and static error response 1`] = `
+exports[`http mocker request is invalid returns 422 and static error response 1`] = `
 Object {
   "body": "[{\\"message\\":\\"error\\"}]",
   "headers": Object {
     "Content-type": "application/json",
   },
-  "statusCode": 400,
+  "statusCode": 422,
 }
 `;
 

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -219,7 +219,7 @@ describe('http mocker', () => {
   });
 
   describe('request is invalid', () => {
-    test('returns 400 and static error response', async () => {
+    test('returns 422 and static error response', async () => {
       const response = await mocker.mock({
         resource: httpOperations[0],
         input: httpRequests[1],
@@ -228,7 +228,7 @@ describe('http mocker', () => {
       expect(response).toMatchSnapshot();
     });
 
-    test('returns 400 and dynamic error response', async () => {
+    test('returns 422 and dynamic error response', async () => {
       if (!httpOperations[1].responses[1].contents[0].schema) {
         throw new Error('Missing test');
       }

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -32,11 +32,14 @@ function findResponseByStatusCode(
     return candidate;
   }
 
+  return createResponseFromDefault(statusCode, responses);
+}
+
+function createResponseFromDefault(statusCode: string, responses: IHttpOperationResponse[]) {
   const defaultResponse = responses.find(response => response.code === 'default');
   if (defaultResponse) {
     return Object.assign({}, defaultResponse, { code: statusCode });
   }
-
   return undefined;
 }
 

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -32,8 +32,7 @@ function findResponseByStatusCode(
   if (candidate) {
     return candidate;
   }
-  if (useDefault)
-    return createResponseFromDefault(statusCode, responses);
+  if (useDefault) return createResponseFromDefault(statusCode, responses);
   return undefined;
 }
 

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -15,7 +15,7 @@ function findHttpContentByMediaType(response: IHttpOperationResponse, mediaType:
 }
 
 function findLowest2xx(httpResponses: IHttpOperationResponse[]): IHttpOperationResponse | undefined {
-  const generic2xxResponse = findResponseByStatusCode(httpResponses, '2XX');
+  const generic2xxResponse = findResponseByStatusCode(httpResponses, '2XX', true);
   const sorted2xxResponses = httpResponses
     .filter(response => response.code.match(/2\d\d/))
     .sort((a: IHttpOperationResponse, b: IHttpOperationResponse) => Number(a.code) - Number(b.code));
@@ -26,13 +26,15 @@ function findLowest2xx(httpResponses: IHttpOperationResponse[]): IHttpOperationR
 function findResponseByStatusCode(
   responses: IHttpOperationResponse[],
   statusCode: string,
+  useDefault: boolean,
 ): IHttpOperationResponse | undefined {
   const candidate = responses.find(response => response.code.toLowerCase() === statusCode.toLowerCase());
   if (candidate) {
     return candidate;
   }
-
-  return createResponseFromDefault(statusCode, responses);
+  if (useDefault)
+    return createResponseFromDefault(statusCode, responses);
+  return undefined;
 }
 
 function createResponseFromDefault(statusCode: string, responses: IHttpOperationResponse[]) {
@@ -213,7 +215,7 @@ const helpers = {
     code: string,
   ): IHttpNegotiationResult {
     // find response by provided status code
-    const responseByForcedStatusCode = findResponseByStatusCode(httpOperation.responses, code);
+    const responseByForcedStatusCode = findResponseByStatusCode(httpOperation.responses, code, true);
     if (responseByForcedStatusCode) {
       try {
         // try to negotiate
@@ -250,7 +252,7 @@ const helpers = {
   negotiateOptionsForInvalidRequest(httpResponses: IHttpOperationResponse[]): IHttpNegotiationResult {
     // currently only try to find a 400 response, but we may want to support other cases in the future
     const code = '400';
-    const response = findResponseByStatusCode(httpResponses, code);
+    const response = findResponseByStatusCode(httpResponses, code, false);
     // TODO: what if no 400 response is defined?
     if (!response) {
       throw new Error('No 400 response defined');

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -250,12 +250,12 @@ const helpers = {
   },
 
   negotiateOptionsForInvalidRequest(httpResponses: IHttpOperationResponse[]): IHttpNegotiationResult {
-    // currently only try to find a 400 response, but we may want to support other cases in the future
-    const code = '400';
+    // currently only try to find a 422 response, but we may want to support other cases in the future
+    const code = '422';
     const response = findResponseByStatusCode(httpResponses, code, false);
-    // TODO: what if no 400 response is defined?
+    // TODO: what if no 422 response is defined?
     if (!response) {
-      throw new Error('No 400 response defined');
+      throw new Error('No 422 response defined');
     }
     // find first response with any static examples
     const responseWithExamples = response.contents.find(content => !!content.examples && content.examples.length !== 0);
@@ -275,7 +275,7 @@ const helpers = {
         schema: responseWithSchema.schema,
       };
     } else {
-      throw new Error('Request invalid but mock data corrupted. Neither schema nor example defined for 400 response.');
+      throw new Error('Request invalid but mock data corrupted. Neither schema nor example defined for 422 response.');
     }
   },
 };

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -149,6 +149,54 @@ describe('NegotiatorHelpers', () => {
     });
 
     describe('and no 422 response exists', () => {
+      test('but a 400 response exists', async () => {
+        httpOperation = anHttpOperation(httpOperation)
+          .withResponses([
+            {
+              code: '400',
+              headers: [],
+              contents: [
+                {
+                  mediaType: chance.string(),
+                  examples: [
+                    { key: chance.string(), value: '', externalValue: '' },
+                    { key: chance.string(), value: '', externalValue: '' },
+                  ],
+                  encodings: [],
+                },
+              ],
+            },
+          ])
+          .instance();
+
+        const actualConfig = helpers.negotiateOptionsForInvalidRequest(httpOperation.responses);
+        expect(actualConfig).toHaveProperty('code', '400');
+      });
+
+      test('but a default response exists', async () => {
+        httpOperation = anHttpOperation(httpOperation)
+          .withResponses([
+            {
+              code: 'default',
+              headers: [],
+              contents: [
+                {
+                  mediaType: chance.string(),
+                  examples: [
+                    { key: chance.string(), value: '', externalValue: '' },
+                    { key: chance.string(), value: '', externalValue: '' },
+                  ],
+                  encodings: [],
+                },
+              ],
+            },
+          ])
+          .instance();
+
+        const actualConfig = helpers.negotiateOptionsForInvalidRequest(httpOperation.responses);
+        expect(actualConfig).toHaveProperty('code', '422');
+      });
+
       test('should return an error', async () => {
         expect(() => {
           helpers.negotiateOptionsForInvalidRequest(httpOperation.responses);

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -44,8 +44,8 @@ describe('NegotiatorHelpers', () => {
   });
 
   describe('negotiateOptionsForInvalidRequest()', () => {
-    describe('and 400 response exists', () => {
-      const actualCode = '400';
+    describe('and 422 response exists', () => {
+      const actualCode = '422';
       const actualMediaType = chance.string();
       const actualExampleKey = chance.string();
 
@@ -143,16 +143,16 @@ describe('NegotiatorHelpers', () => {
 
           expect(() => {
             helpers.negotiateOptionsForInvalidRequest(httpOperation.responses);
-          }).toThrow('Request invalid but mock data corrupted. Neither schema nor example defined for 400 response.');
+          }).toThrow('Request invalid but mock data corrupted. Neither schema nor example defined for 422 response.');
         });
       });
     });
 
-    describe('and no 400 response exists', () => {
+    describe('and no 422 response exists', () => {
       test('should return an error', async () => {
         expect(() => {
           helpers.negotiateOptionsForInvalidRequest(httpOperation.responses);
-        }).toThrow('No 400 response defined');
+        }).toThrow('No 422 response defined');
       });
     });
   });

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -32,20 +32,20 @@ export interface IHttpConfig extends IPrismConfig {
 
   validate?: {
     request?:
-      | boolean
-      | {
-          hijack?: boolean;
-          headers?: boolean;
-          query?: boolean;
-          body?: boolean;
-        };
+    | boolean
+    | {
+      hijack?: boolean;
+      headers?: boolean;
+      query?: boolean;
+      body?: boolean;
+    };
 
     response?:
-      | boolean
-      | {
-          headers?: boolean;
-          body?: boolean;
-        };
+    | boolean
+    | {
+      headers?: boolean;
+      body?: boolean;
+    };
   };
 }
 
@@ -85,6 +85,7 @@ export type ProblemJson = {
 
 export class ProblemJsonError extends Error {
   public static fromTemplate(template: Omit<ProblemJson, 'detail'>, detail?: string): ProblemJsonError {
+    Error.captureStackTrace(this, ProblemJsonError);
     return new ProblemJsonError(
       `https://stoplight.io/prism/errors#${template.type}`,
       template.title,

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -32,20 +32,20 @@ export interface IHttpConfig extends IPrismConfig {
 
   validate?: {
     request?:
-    | boolean
-    | {
-      hijack?: boolean;
-      headers?: boolean;
-      query?: boolean;
-      body?: boolean;
-    };
+      | boolean
+      | {
+          hijack?: boolean;
+          headers?: boolean;
+          query?: boolean;
+          body?: boolean;
+        };
 
     response?:
-    | boolean
-    | {
-      headers?: boolean;
-      body?: boolean;
-    };
+      | boolean
+      | {
+          headers?: boolean;
+          body?: boolean;
+        };
   };
 }
 


### PR DESCRIPTION
This PR will make sure Prims will look for `422` responses in the document for invalid requests first; if not defined, Prism will generate one and not use the `default` response, if defined.

This replace the following behaviour: look for `400` response and if not defined, use the `default` response and, if not defined, then throw a `422`