### PR TITLE
GitHub Releases and binary uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,9 @@ workflows:
             - build
       - upload_artifacts:
           type: approval
+          filters:
+            branches:
+              only: master
           requires:
             - build
             - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           name: "Publish Release artifacts on GitHub"
           command: |
             go get github.com/tcnksm/ghr
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} /tmp/cli-binaries
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} /tmp/cli-binaries
 workflows:
   version: 2
   build:
@@ -78,13 +78,17 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /^v.*/
           requires:
             - build
       - upload_artifacts:
           type: approval
           filters:
             branches:
-              only: master
+              ignore: /.*/
+            tags:
+              only: /^v.*/
           requires:
             - build
             - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,22 @@ jobs:
           command: npx pkg --out-path ./cli-binaries ./packages/cli/
       - store_artifacts:
           path: ./cli-binaries
+      - persist_to_workspace:
+          root: ./cli-binaries
       - run:
           name: Publish
           command: yarn lerna publish from-package --yes --dist-tag alpha
-
-
+  upload_artifacts:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - attach_workspace:
+          at: /tmp/cli-binaries
+      - run:
+          name: "Publish Release on GitHub"
+          command: |
+            go get github.com/tcnksm/ghr
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} /tmp/cli-binaries
 workflows:
   version: 2
   build:
@@ -69,3 +80,10 @@ workflows:
               only: develop
           requires:
             - build
+      - upload_artifacts:
+          filters:
+            branches:
+              only: develop
+          requires:
+            - build
+            - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,13 +77,11 @@ workflows:
       - publish:
           filters:
             branches:
-              only: develop
+              only: master
           requires:
             - build
       - upload_artifacts:
-          filters:
-            branches:
-              only: develop
+          type: approval
           requires:
             - build
             - publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           root: ./cli-binaries
       - run:
           name: Publish
-          command: yarn lerna publish from-package --yes --dist-tag alpha
+          command: yarn lerna publish from-package --github-release --yes --dist-tag alpha
   upload_artifacts:
     docker:
       - image: circleci/golang:1.8
@@ -65,7 +65,7 @@ jobs:
       - attach_workspace:
           at: /tmp/cli-binaries
       - run:
-          name: "Publish Release on GitHub"
+          name: "Publish Release artifacts on GitHub"
           command: |
             go get github.com/tcnksm/ghr
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} /tmp/cli-binaries

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test.coverage": "yarn test --coverage",
     "test.watch": "yarn test --watchAll",
     "test.update": "yarn test.fast --updateSnapshot",
-    "release": "lerna version prerelease --conventional-commit"
+    "release": "lerna version prerelease --preid alpha --conventional-commit"
   },
   "resolutions": {
     "jsonpath": "https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17"


### PR DESCRIPTION
1. Creates a GitHub Release when publishing the package on Npm
2. Uploads the 3 binaries in the newly created release when workflow is manually approved
3. New scheme, `3.x.x-alpha`