### PR TITLE
Prism should read yml files too SO-200

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This error shows the request is missing a required property `name` from the HTTP
 - [ ] Forwarding proxy with validation
 - [ ] Recording traffic to spec file
 - [ ] Data Persistence (turn Prism into a sandbox server)
-- [ ] Support files ending with `.yml` and extension-less files
+- [x] Support files ending with `.yml` and extension-less files
 
 ## FAQs
 

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -19,17 +19,21 @@ export default class Server extends Command {
     } = this.parse(Server);
 
     const server = createServer(spec, { mock: true });
-    const address = await server.listen(port);
+    try {
+      const address = await server.listen(port);
 
-    if (server.prism.resources.length === 0) {
-      signaleInteractiveInstance.fatal('No operations found in the current file.');
-      this.exit(1);
+      if (server.prism.resources.length === 0) {
+        signaleInteractiveInstance.fatal('No operations found in the current file.');
+        this.exit(1);
+      }
+
+      signaleInteractiveInstance.success(`Prism is listening on ${address}`);
+
+      server.prism.resources.forEach(resource => {
+        signale.note(`${resource.method.toUpperCase().padEnd(10)} ${address}${resource.path}`);
+      });
+    } catch (e) {
+      signaleInteractiveInstance.fatal(e.message);
     }
-
-    signaleInteractiveInstance.success(`Prism is listening on ${address}`);
-
-    server.prism.resources.forEach(resource => {
-      signale.note(`${resource.method.toUpperCase().padEnd(10)} ${address}${resource.path}`);
-    });
   }
 }

--- a/packages/core/src/utils/graphFacade.ts
+++ b/packages/core/src/utils/graphFacade.ts
@@ -4,6 +4,7 @@ import {
   FileSystemBackend,
   FilesystemNodeType,
 } from '@stoplight/graphite/backends/filesystem';
+import { filenameToLanguage } from '@stoplight/graphite/backends/filesystem/utils';
 import { NodeCategory } from '@stoplight/graphite/graph/nodes';
 import { createGraphite } from '@stoplight/graphite/graphite';
 import { createOas2HttpPlugin } from '@stoplight/graphite/plugins/http/oas2';
@@ -14,7 +15,7 @@ import { createOas3Plugin } from '@stoplight/graphite/plugins/oas3';
 import { createYamlPlugin } from '@stoplight/graphite/plugins/yaml';
 import { IHttpOperation } from '@stoplight/types';
 import * as fs from 'fs';
-import { extname, resolve } from 'path';
+import { resolve } from 'path';
 
 import { compact } from 'lodash';
 
@@ -47,12 +48,10 @@ export class GraphFacade {
       });
       this.fsBackend.readdir(fsPath);
     } else if (stat.isFile()) {
-      const language = extname(resourceFile).slice(1);
-
       this.graphite.graph.addNode({
         category: NodeCategory.Source,
         type: FilesystemNodeType.File,
-        language: transformLanguage(language),
+        language: filenameToLanguage(resourceFile),
         path: resourceFile,
       });
       this.fsBackend.readFile(resourceFile);
@@ -65,9 +64,4 @@ export class GraphFacade {
     const nodes = this.graphite.graph.virtualNodes.filter(node => node.type === 'http_operation');
     return compact(nodes.map<IHttpOperation>(node => node.data as IHttpOperation));
   }
-}
-
-function transformLanguage(lang: string) {
-  if (lang === 'yml') return 'yaml';
-  return lang;
 }

--- a/packages/core/src/utils/graphFacade.ts
+++ b/packages/core/src/utils/graphFacade.ts
@@ -37,8 +37,8 @@ export class GraphFacade {
 
   public async createFilesystemNode(fsPath: string) {
     const resourceFile = resolve(fsPath);
-    const language = extname(resourceFile).slice(1);
     const stat = fs.lstatSync(resourceFile);
+
     if (stat.isDirectory()) {
       this.graphite.graph.addNode({
         category: NodeCategory.Source,
@@ -47,10 +47,12 @@ export class GraphFacade {
       });
       this.fsBackend.readdir(fsPath);
     } else if (stat.isFile()) {
+      const language = extname(resourceFile).slice(1);
+
       this.graphite.graph.addNode({
         category: NodeCategory.Source,
         type: FilesystemNodeType.File,
-        language,
+        language: transformLanguage(language),
         path: resourceFile,
       });
       this.fsBackend.readFile(resourceFile);
@@ -63,4 +65,9 @@ export class GraphFacade {
     const nodes = this.graphite.graph.virtualNodes.filter(node => node.type === 'http_operation');
     return compact(nodes.map<IHttpOperation>(node => node.data as IHttpOperation));
   }
+}
+
+function transformLanguage(lang: string) {
+  if (lang === 'yml') return 'yaml';
+  return lang;
 }


### PR DESCRIPTION
1. Correctly reveals yml files as yaml for graphite
2. Handles startup exceptions and prints them out
3. Updates the README