### PR TITLE
refactor: get rid of node-tmp

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "indipendent": true
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,7 +17,7 @@ $ npm install -g @stoplight/prism-cli
 $ prism COMMAND
 running command...
 $ prism (-v|--version|version)
-@stoplight/prism-cli/3.0.0-alpha.5 darwin-x64 node-v12.1.0
+@stoplight/prism-cli/3.0.0-alpha.6 darwin-x64 node-v12.1.0
 $ prism --help [COMMAND]
 USAGE
   $ prism COMMAND
@@ -61,7 +61,7 @@ OPTIONS
   -p, --port=port  (required) [default: 4010] Port that Prism will run on.
 ```
 
-_See code: [src/commands/mock.ts](https://github.com/stoplightio/prism/blob/v3.0.0-alpha.5/src/commands/mock.ts)_
+_See code: [src/commands/mock.ts](https://github.com/stoplightio/prism/blob/v3.0.0-alpha.6/src/commands/mock.ts)_
 <!-- commandsstop -->
 
 ## Development

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,8 @@
   "scripts": {
     "prepack": "oclif-dev manifest",
     "version": "oclif-dev readme && git add README.md",
-    "cli": "node -r tsconfig-paths/register bin/run"
+    "cli": "node -r tsconfig-paths/register bin/run",
+    "cli:debug": "node --inspect-brk -r tsconfig-paths/register bin/run"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./bin/run"
@@ -10,11 +10,11 @@
     "@oclif/command": "^1.0.0",
     "@oclif/config": "^1.12.12",
     "@oclif/plugin-help": "^2.0.0",
-    "@stoplight/prism-core": "^3.0.0-alpha.5",
-    "@stoplight/prism-http-server": "^3.0.0-alpha.5",
+    "@stoplight/prism-core": "^3.0.0-alpha.6",
+    "@stoplight/prism-http-server": "^3.0.0-alpha.6",
     "signale": "^1.4.0",
-    "urijs": "^1.19.1",
-    "tslib": "^1.0.0"
+    "tslib": "^1.0.0",
+    "urijs": "^1.19.1"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,8 +13,8 @@
     "@stoplight/prism-core": "^3.0.0-alpha.5",
     "@stoplight/prism-http-server": "^3.0.0-alpha.5",
     "signale": "^1.4.0",
-    "tslib": "^1.0.0",
-    "urijs": "^1.19.1"
+    "urijs": "^1.19.1",
+    "tslib": "^1.0.0"
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,12 +20,10 @@
     "axios": "^0.18.0",
     "lodash": "^4.0.0",
     "mobx": "^5.0.0",
-    "tmp": "^0.1.0",
     "tslib": "^1.9.0"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.123",
-    "@types/tmp": "^0.1.0"
+    "@types/lodash": "^4.14.123"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/core/src/loaders/http/httpLoader.ts
+++ b/packages/core/src/loaders/http/httpLoader.ts
@@ -1,8 +1,6 @@
 import { FilesystemNodeType } from '@stoplight/graphite/backends/filesystem';
 import { IHttpOperation } from '@stoplight/types';
 import axios from 'axios';
-import { trimStart } from 'lodash';
-import { extname } from 'path';
 import { IHttpLoaderOpts } from '../../types';
 import { GraphFacade } from '../../utils/graphFacade';
 
@@ -10,13 +8,14 @@ export class HttpLoader {
   constructor(private graphFacade: GraphFacade = new GraphFacade()) {}
 
   public async load(opts?: IHttpLoaderOpts): Promise<IHttpOperation[]> {
-    if (!opts || !opts.url) return [];
+    if (!opts) return [];
+    if (!opts.url) return [];
 
     const response = await axios({ url: opts.url, transformResponse: d => d });
 
     await this.graphFacade.createRawNode(response.data, {
       type: FilesystemNodeType.File,
-      language: trimStart(extname(opts.url), '.'),
+      path: opts.url,
     });
 
     return this.graphFacade.httpOperations;

--- a/packages/core/src/loaders/http/httpLoader.ts
+++ b/packages/core/src/loaders/http/httpLoader.ts
@@ -1,12 +1,10 @@
+import { FilesystemNodeType } from '@stoplight/graphite/backends/filesystem';
 import { IHttpOperation } from '@stoplight/types';
 import axios from 'axios';
-import * as fs from 'fs';
+import { trimStart } from 'lodash';
 import { extname } from 'path';
-import * as tmp from 'tmp';
 import { IHttpLoaderOpts } from '../../types';
 import { GraphFacade } from '../../utils/graphFacade';
-
-tmp.setGracefulCleanup();
 
 export class HttpLoader {
   constructor(private graphFacade: GraphFacade = new GraphFacade()) {}
@@ -14,11 +12,13 @@ export class HttpLoader {
   public async load(opts?: IHttpLoaderOpts): Promise<IHttpOperation[]> {
     if (!opts || !opts.url) return [];
 
-    const filePath = tmp.tmpNameSync({ postfix: extname(opts.url) });
     const response = await axios({ url: opts.url, transformResponse: d => d });
-    fs.writeFileSync(filePath, response.data, 'utf8');
 
-    await this.graphFacade.createFilesystemNode(filePath);
+    await this.graphFacade.createRawNode(response.data, {
+      type: FilesystemNodeType.File,
+      language: trimStart(extname(opts.url), '.'),
+    });
+
     return this.graphFacade.httpOperations;
   }
 }

--- a/packages/core/src/loaders/http/httpLoader.ts
+++ b/packages/core/src/loaders/http/httpLoader.ts
@@ -8,8 +8,7 @@ export class HttpLoader {
   constructor(private graphFacade: GraphFacade = new GraphFacade()) {}
 
   public async load(opts?: IHttpLoaderOpts): Promise<IHttpOperation[]> {
-    if (!opts) return [];
-    if (!opts.url) return [];
+    if (!opts || !opts.url) return [];
 
     const response = await axios({ url: opts.url, transformResponse: d => d });
 

--- a/packages/core/src/utils/__tests__/graphFacade.int.ts
+++ b/packages/core/src/utils/__tests__/graphFacade.int.ts
@@ -24,10 +24,11 @@ describe('graphFacade', () => {
 
   describe('createRawNode()', () => {
     test('httpOperations should return filtered nodes', async () => {
-      await graphFacade.createRawNode(
-        JSON.stringify(require('../../../../cli/src/samples/no-refs-petstore.oas2.json')),
-        { type: FilesystemNodeType.File, language: 'json' },
-      );
+      const path = '../../../../http/src/__tests__/fixtures/no-refs-petstore.oas2.json';
+      await graphFacade.createRawNode(JSON.stringify(require(path)), {
+        type: FilesystemNodeType.File,
+        path: require.resolve(path),
+      });
 
       expect(graphFacade.httpOperations.length).toBeGreaterThan(0);
     });

--- a/packages/core/src/utils/__tests__/graphFacade.int.ts
+++ b/packages/core/src/utils/__tests__/graphFacade.int.ts
@@ -1,3 +1,4 @@
+import { FilesystemNodeType } from '@stoplight/graphite/backends/filesystem';
 import { isAbsolute, resolve } from 'path';
 import { GraphFacade } from '../graphFacade';
 
@@ -16,6 +17,17 @@ describe('graphFacade', () => {
       expect(isAbsolute(path)).toBe(true);
 
       await graphFacade.createFilesystemNode(path);
+
+      expect(graphFacade.httpOperations.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('createRawNode()', () => {
+    test('httpOperations should return filtered nodes', async () => {
+      await graphFacade.createRawNode(
+        JSON.stringify(require('../../../../cli/src/samples/no-refs-petstore.oas2.json')),
+        { type: FilesystemNodeType.File, language: 'json' },
+      );
 
       expect(graphFacade.httpOperations.length).toBeGreaterThan(0);
     });

--- a/packages/core/src/utils/graphFacade.ts
+++ b/packages/core/src/utils/graphFacade.ts
@@ -60,12 +60,12 @@ export class GraphFacade {
     await this.graphite.scheduler.drain();
   }
 
-  public async createRawNode(raw: string, { type, language }: Pick<ISourceNode, 'type' | 'language'>) {
+  public async createRawNode(raw: string, { type, path }: Pick<ISourceNode, 'type' | 'path'>) {
     this.graphite.graph.addNode({
       category: NodeCategory.Source,
       type,
-      language,
-      path: '/',
+      language: filenameToLanguage(path),
+      path: '/' + path,
       data: { raw },
     });
 

--- a/packages/core/src/utils/graphFacade.ts
+++ b/packages/core/src/utils/graphFacade.ts
@@ -5,7 +5,7 @@ import {
   FilesystemNodeType,
 } from '@stoplight/graphite/backends/filesystem';
 import { filenameToLanguage } from '@stoplight/graphite/backends/filesystem/utils';
-import { NodeCategory } from '@stoplight/graphite/graph/nodes';
+import { ISourceNode, NodeCategory } from '@stoplight/graphite/graph/nodes';
 import { createGraphite } from '@stoplight/graphite/graphite';
 import { createOas2HttpPlugin } from '@stoplight/graphite/plugins/http/oas2';
 import { createOas3HttpPlugin } from '@stoplight/graphite/plugins/http/oas3';
@@ -29,8 +29,8 @@ export class GraphFacade {
       createJsonPlugin(),
       createYamlPlugin(),
       createOas2Plugin(),
-      createOas2HttpPlugin(),
       createOas3Plugin(),
+      createOas2HttpPlugin(),
       createOas3HttpPlugin(),
     );
     this.fsBackend = createFileSystemBackend(graphite, fs);
@@ -56,6 +56,18 @@ export class GraphFacade {
       });
       this.fsBackend.readFile(resourceFile);
     }
+
+    await this.graphite.scheduler.drain();
+  }
+
+  public async createRawNode(raw: string, { type, language }: Pick<ISourceNode, 'type' | 'language'>) {
+    this.graphite.graph.addNode({
+      category: NodeCategory.Source,
+      type,
+      language,
+      path: '/',
+      data: { raw },
+    });
 
     await this.graphite.scheduler.drain();
   }

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.0.0-alpha.5",
-    "@stoplight/prism-http": "^3.0.0-alpha.5",
+    "@stoplight/prism-core": "^3.0.0-alpha.6",
+    "@stoplight/prism-http": "^3.0.0-alpha.6",
     "fastify": "^2.3.0",
     "tslib": "^1.9.0"
   }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "3.0.0-alpha.5",
+  "version": "3.0.0-alpha.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -16,7 +16,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.0.0-alpha.5",
+    "@stoplight/prism-core": "^3.0.0-alpha.6",
     "ajv": "^6.0.0",
     "ajv-oai": "^1.0.0",
     "axios": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,11 +1341,6 @@
   resolved "https://registry.yarnpkg.com/@types/swagger-schema-official/-/swagger-schema-official-2.0.15.tgz#5591141e8e3e2e81a4b49c3a3d2321d1367d4ebc"
   integrity sha512-ZQKcczZbsfVKf+QKViMvjGni1BADoWCjnimkUc3l4zV/d0sM4cj+Hbtg9gjwUaPhi4m3Q8ne62B+fYubUIPqZQ==
 
-"@types/tmp@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
-  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
-
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -7227,13 +7222,6 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
-
-tmp@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
-  dependencies:
-    rimraf "^2.6.3"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
Gets rid of `node-tmp` entirely and uses Graphite to init the stuff from memory