### PR TITLE
feat(http-forwarder): add support for timeout and cancelToken

### DIFF
--- a/packages/http/src/forwarder/HttpForwarder.ts
+++ b/packages/http/src/forwarder/HttpForwarder.ts
@@ -1,11 +1,16 @@
 import { IForwarder, IPrismInput } from '@stoplight/prism-core';
 import { IHttpOperation, IServer } from '@stoplight/types';
-import axios from 'axios';
+import axios, { CancelToken } from 'axios';
 import { URL } from 'url';
 import { IHttpConfig, IHttpNameValue, IHttpRequest, IHttpResponse } from '../types';
 
 export class HttpForwarder implements IForwarder<IHttpOperation, IHttpRequest, IHttpConfig, IHttpResponse> {
-  public async forward(opts: { resource?: IHttpOperation; input: IPrismInput<IHttpRequest> }): Promise<IHttpResponse> {
+  public async forward(opts: {
+    resource?: IHttpOperation;
+    input: IPrismInput<IHttpRequest>;
+    timeout?: number;
+    cancelToken?: CancelToken;
+  }): Promise<IHttpResponse> {
     const inputData = opts.input.data;
     const baseUrl =
       opts.resource && opts.resource.servers && opts.resource.servers.length > 0
@@ -25,6 +30,8 @@ export class HttpForwarder implements IForwarder<IHttpOperation, IHttpRequest, I
       data: inputData.body,
       headers: this.updateHostHeaders(baseUrl, inputData.headers),
       validateStatus: () => true,
+      timeout: Math.max(opts.timeout || 0, 0),
+      ...(opts.cancelToken !== undefined && { cancelToken: opts.cancelToken }),
     });
 
     return {

--- a/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
+++ b/packages/http/src/forwarder/__tests__/HttpForwarder.spec.ts
@@ -29,6 +29,7 @@ describe('HttpForwarder', () => {
           baseURL: 'http://api.example.com',
           responseType: 'text',
           validateStatus: expect.any(Function),
+          timeout: 0,
         });
       });
     });
@@ -65,6 +66,7 @@ describe('HttpForwarder', () => {
             responseType: 'text',
             validateStatus: expect.any(Function),
             headers: { 'x-test': 'b' },
+            timeout: 0,
           });
         });
       });
@@ -92,6 +94,7 @@ describe('HttpForwarder', () => {
               host: 'api.example.com',
               forwarded: 'host=localhost',
             },
+            timeout: 0,
           });
         });
       });
@@ -125,6 +128,7 @@ describe('HttpForwarder', () => {
             baseURL: 'http://api.example.com',
             responseType: 'text',
             validateStatus: expect.any(Function),
+            timeout: 0,
           });
         });
       });
@@ -192,6 +196,55 @@ describe('HttpForwarder', () => {
           );
         });
       });
+    });
+
+    describe('timeout is provided', () => {
+      it('overrides default timeout', async () => {
+        await forwarder.forward({
+          input: {
+            ...httpRequests[0],
+            data: {
+              ...httpInputs[0],
+              url: { ...httpInputs[0].url, baseUrl: 'http://api.example.com' },
+            },
+          },
+          timeout: 100,
+        });
+
+        expect(axios.default).toHaveBeenCalledWith(expect.objectContaining({ timeout: 100 }));
+      });
+
+      it('cannot be lower than 0', async () => {
+        await forwarder.forward({
+          input: {
+            ...httpRequests[0],
+            data: {
+              ...httpInputs[0],
+              url: { ...httpInputs[0].url, baseUrl: 'http://api.example.com' },
+            },
+          },
+          timeout: -2,
+        });
+
+        expect(axios.default).toHaveBeenCalledWith(expect.objectContaining({ timeout: 0 }));
+      });
+    });
+
+    it('accepts cancel token', async () => {
+      const cancelToken = { token: 'foo' } as any;
+      await forwarder.forward({
+        input: {
+          ...httpRequests[0],
+          data: {
+            ...httpInputs[0],
+            url: { ...httpInputs[0].url, baseUrl: 'http://api.example.com' },
+          },
+        },
+        timeout: 100,
+        cancelToken,
+      });
+
+      expect(axios.default).toHaveBeenCalledWith(expect.objectContaining({ cancelToken }));
     });
   });
 });

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -1,5 +1,7 @@
+import axios from 'axios';
 import { HttpForwarder } from './HttpForwarder';
 
 const forwarder = new HttpForwarder();
 
 export { forwarder };
+export const CancelToken = axios.CancelToken;


### PR DESCRIPTION
feat(http-forwarder): add support for timeout and cancelToken

## Checklist

- [x] Tests have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce

A slight improvement to HTTP Forwarder. Having timeout and cancel token is quite useful for components such as request-maker.

## What is the current behavior

Timeout is not configurable per given request and the request cannot be really cancel

## If this is a feature change, what is the new behavior

See above.

## Does this PR introduce a breaking change

Nope.

### Other information

(e.g. detailed explanation, related issues, links for us to have context, eg. Stack Overflow, issues outside of the repo, forum, etc.)
