### PR TITLE
feat: remove support for __contentType

### DIFF
--- a/packages/http-server/src/__tests__/__snapshots__/getHttpConfigFromRequest.spec.ts.snap
+++ b/packages/http-server/src/__tests__/__snapshots__/getHttpConfigFromRequest.spec.ts.snap
@@ -64,11 +64,3 @@ Object {
   },
 }
 `;
-
-exports[`getHttpConfigFromRequest() given no default config extracts mediaType 1`] = `
-Object {
-  "mock": Object {
-    "mediaType": "application/json",
-  },
-}
-`;

--- a/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
+++ b/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
@@ -26,14 +26,6 @@ describe('getHttpConfigFromRequest()', () => {
         }),
       ).toMatchSnapshot();
     });
-    test('extracts mediaType', () => {
-      return expect(
-        getHttpConfigFromRequest({
-          method: 'get',
-          url: { path: '/', query: { __contentType: 'application/json' } },
-        }),
-      ).toMatchSnapshot();
-    });
     test('extracts example', () => {
       return expect(
         getHttpConfigFromRequest({

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -19,7 +19,7 @@ export const getHttpConfigFromRequest: PartialPrismConfigFactory<IHttpConfig, IH
     return config;
   }
 
-  const { __code, __dynamic, __contentType, __example } = query;
+  const { __code, __dynamic, __example } = query;
 
   if (__code) {
     httpOperationConfig.code = __code;
@@ -27,10 +27,6 @@ export const getHttpConfigFromRequest: PartialPrismConfigFactory<IHttpConfig, IH
 
   if (__dynamic) {
     httpOperationConfig.dynamic = __dynamic === 'true';
-  }
-
-  if (__contentType) {
-    httpOperationConfig.mediaType = __contentType;
   }
 
   if (__example) {

--- a/packages/http/src/mocker/negotiator/types.ts
+++ b/packages/http/src/mocker/negotiator/types.ts
@@ -9,7 +9,9 @@ export interface IHttpNegotiationResult {
   headers: IHttpHeaderParam[];
 }
 
-export type NegotiationOptions = IHttpOperationConfig;
+export type NegotiationOptions = IHttpOperationConfig & {
+  mediaTypes: string[];
+};
 
 export type NegotiatePartialOptions = {
   code: string;

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -17,7 +17,6 @@ export type TPrismHttpComponents<LoaderInput> = Partial<
 export type IHttpMethod = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace'; // ... etc
 
 export interface IHttpOperationConfig {
-  mediaTypes?: string[];
   code?: string;
   exampleKey?: string;
   dynamic: boolean;


### PR DESCRIPTION
Kill the `__contentType` custom keyword in favour of the newly implemented `Accept` header support