### PR TITLE
Custom host cli option

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -59,6 +59,7 @@ ARGUMENTS
 
 OPTIONS
   -d, --dynamic    Dynamically generate examples.
+  -h, --host=host  [default: 127.0.0.1] Host that Prism will listen to.
   -p, --port=port  (required) [default: 4010] Port that Prism will run on.
 ```
 

--- a/packages/cli/src/commands/__tests__/mock.spec.ts
+++ b/packages/cli/src/commands/__tests__/mock.spec.ts
@@ -15,12 +15,24 @@ describe('mock command', () => {
   test('starts mock server', async () => {
     await Mock.run(['/path/to']);
     expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
-    expect(listenMock).toHaveBeenLastCalledWith(4010);
+    expect(listenMock).toHaveBeenLastCalledWith(4010, '127.0.0.1');
   });
 
   test('starts mock server on custom port', async () => {
     await Mock.run(['-p', '666', '/path/to']);
     expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
-    expect(listenMock).toHaveBeenLastCalledWith(666);
+    expect(listenMock).toHaveBeenLastCalledWith(666, '127.0.0.1');
+  });
+
+  test('starts mock server on custom host', async () => {
+    await Mock.run(['-h', '0.0.0.0', '/path/to']);
+    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
+    expect(listenMock).toHaveBeenLastCalledWith(4010, '0.0.0.0');
+  });
+
+  test('starts mock server on custom host and port', async () => {
+    await Mock.run(['-p', '666', '-h', '0.0.0.0', '/path/to']);
+    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
+    expect(listenMock).toHaveBeenLastCalledWith(666, '0.0.0.0');
   });
 });

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -5,14 +5,14 @@ import { createServer } from '../util/createServer';
 
 export default class Server extends Command {
   public static description = 'Start a mock server with the given spec file';
-  public static flags = { port: FLAGS.port, dynamic: FLAGS.dynamic };
+  public static flags = { port: FLAGS.port, host: FLAGS.host, dynamic: FLAGS.dynamic };
   public static args = [ARGS.spec];
 
   public async run() {
     const signaleInteractiveInstance = new signale.Signale({ interactive: true });
 
     const {
-      flags: { port, dynamic },
+      flags: { port, dynamic, host },
       args: { spec },
     } = this.parse(Server);
 
@@ -24,7 +24,7 @@ export default class Server extends Command {
 
     const server = createServer(spec, { mock: { dynamic: true || dynamic } });
     try {
-      const address = await server.listen(port);
+      const address = await server.listen(port, host);
 
       if (server.prism.resources.length === 0) {
         signaleInteractiveInstance.fatal('No operations found in the current file.');

--- a/packages/cli/src/const/options.ts
+++ b/packages/cli/src/const/options.ts
@@ -16,6 +16,12 @@ export const FLAGS = {
     required: true,
   }),
 
+  host: oflags.string({
+    char: 'h',
+    description: 'Host that Prism will listen to.',
+    default: '127.0.0.1',
+  }),
+
   dynamic: oflags.boolean({
     char: 'd',
     description: 'Dynamically generate examples.',


### PR DESCRIPTION
Add optional custom host cli option

## Checklist

- [x] Tests have been added (features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce

Add optional custom host cli option to allow to listen to another host than 127.0.0.1

## What is the current behavior

Currently [fastify](https://github.com/fastify/fastify#fastify-v1x)
> .listen binds to the local host, localhost, interface by default (127.0.0.1 or ::1) [...]
when the host is not specified

This is an issue to easily deploy prism or run it inside docker.

## If this is a feature change, what is the new behavior

This PR introduce an optional `--host` / `-h` prism cli option that will be passed to '@stoplight/prism-http-server' & then fastify `.listen`, thus allowing to listen to specific host or '0.0.0.0'

## Does this PR introduce a breaking change

No.

### Other information

It could be interesting to reproduce the fastify note https://github.com/fastify/fastify#note in the readme.
