### PR TITLE
Static Examples generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,14 @@ jobs:
           paths:
             - node_modules/
       - run:
-          name: Download prism v2
-          command: curl -L https://github.com/stoplightio/prism/releases/download/v2.0.17/prism_linux_amd64 -o prism && chmod +x ./prism
-      - run:
           name: Run tests
           command: yarn test.coverage --verbose
       - run:
           name: Create Linux CLI binary
           command: HOST=host yarn build.binary
+      - run:
+          name: Download prism v2
+          command: curl -L https://github.com/stoplightio/prism/releases/download/v2.0.17/prism_linux_amd64 -o prism && chmod +x ./prism
       - run:
           name: Test Harness
           command: |

--- a/packages/cli/src/commands/__tests__/mock.spec.ts
+++ b/packages/cli/src/commands/__tests__/mock.spec.ts
@@ -1,7 +1,7 @@
 import { createServer } from '../../util/createServer';
 import Mock from '../mock';
 
-const listenMock = jest.fn();
+const listenMock = jest.fn().mockReturnValue('http://localhost:1000');
 
 jest.mock('../../util/createServer', () => ({
   createServer: jest.fn(() => ({ listen: listenMock, prism: { resources: [{ method: 'get', path: '/test' }] } })),

--- a/packages/cli/src/commands/__tests__/mock.spec.ts
+++ b/packages/cli/src/commands/__tests__/mock.spec.ts
@@ -14,25 +14,25 @@ describe('mock command', () => {
 
   test('starts mock server', async () => {
     await Mock.run(['/path/to']);
-    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
+    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: false } });
     expect(listenMock).toHaveBeenLastCalledWith(4010, '127.0.0.1');
   });
 
   test('starts mock server on custom port', async () => {
     await Mock.run(['-p', '666', '/path/to']);
-    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
+    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: false } });
     expect(listenMock).toHaveBeenLastCalledWith(666, '127.0.0.1');
   });
 
   test('starts mock server on custom host', async () => {
     await Mock.run(['-h', '0.0.0.0', '/path/to']);
-    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
+    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: false } });
     expect(listenMock).toHaveBeenLastCalledWith(4010, '0.0.0.0');
   });
 
   test('starts mock server on custom host and port', async () => {
     await Mock.run(['-p', '666', '-h', '0.0.0.0', '/path/to']);
-    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: true } });
+    expect(createServer).toHaveBeenLastCalledWith('/path/to', { mock: { dynamic: false } });
     expect(listenMock).toHaveBeenLastCalledWith(666, '0.0.0.0');
   });
 });

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -18,11 +18,11 @@ export default class Server extends Command {
 
     signaleInteractiveInstance.await('Starting Prism…');
 
-    if (true || dynamic) {
+    if (dynamic) {
       signale.star('Dynamic example generation enabled.');
     }
 
-    const server = createServer(spec, { mock: { dynamic: true || dynamic } });
+    const server = createServer(spec, { mock: { dynamic } });
     try {
       const address = await server.listen(port, host);
 

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -61,7 +61,7 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
         let output: Output | undefined;
         if (resource && components.mocker && (configObj as IPrismConfig).mock) {
           // generate the response
-          output = await components.mocker.mock(
+          output = components.mocker.mock(
             {
               resource,
               input: { validations: { input: inputValidations }, data: input },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,7 +54,7 @@ export interface IMocker<Resource, Input, Config, Output> {
   mock: (
     opts: Partial<IMockerOpts<Resource, Input, Config>>,
     defaultMocker?: IMocker<Resource, Input, Config, Output>,
-  ) => Promise<Output>;
+  ) => Output;
 }
 
 export interface IMockerOpts<Resource, Input, Config> {

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -220,7 +220,7 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
       'x-rate-limit': file === 'petstore.oas3.json' ? 1000 : expect.any(Number),
       'x-stats': file === 'petstore.oas3.json' ? 1500 : expect.any(Number),
       'x-expires-after': expect.any(String),
-      'x-strange-header': '',
+      'x-strange-header': null,
     };
 
     for (const headerName of Object.keys(expectedValues)) {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.18.0",
     "caseless": "^0.12.0",
     "json-schema-faker": "^0.5.0-rc17",
+    "openapi-sampler": "^1.0.0-beta.14",
     "tslib": "^1.9.0"
   },
   "publishConfig": {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -22,7 +22,7 @@
     "ajv-oai": "^1.0.0",
     "axios": "^0.18.0",
     "caseless": "^0.12.0",
-    "json-schema-faker": "^0.5.0-rc17",
+    "@stoplight/json-schema-faker": "",
     "openapi-sampler": "^1.0.0-beta.14",
     "tslib": "^1.9.0"
   },

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,13 +16,13 @@
     "node": ">=8"
   },
   "dependencies": {
+    "@stoplight/json-schema-faker": "^0.5.0-rc18",
     "@stoplight/prism-core": "^3.0.0-alpha.14",
     "accepts": "^1.3.7",
     "ajv": "^6.0.0",
     "ajv-oai": "^1.0.0",
     "axios": "^0.18.0",
     "caseless": "^0.12.0",
-    "@stoplight/json-schema-faker": "",
     "openapi-sampler": "^1.0.0-beta.14",
     "tslib": "^1.9.0"
   },

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,13 +16,13 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@stoplight/json-schema-faker": "^0.5.0-rc18",
     "@stoplight/prism-core": "^3.0.0-alpha.14",
     "accepts": "^1.3.7",
     "ajv": "^6.0.0",
     "ajv-oai": "^1.0.0",
     "axios": "^0.18.0",
     "caseless": "^0.12.0",
+    "json-schema-faker": "^0.5.0-rc17",
     "tslib": "^1.9.0"
   },
   "publishConfig": {

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -2,7 +2,6 @@ import { factory, FilesystemLoader, PartialPrismConfig } from '@stoplight/prism-
 import { IHttpOperation } from '@stoplight/types';
 import { forwarder } from './forwarder';
 import { HttpMocker } from './mocker';
-import { generate } from './mocker/generator/JSONSchema';
 import { router } from './router';
 export * from './types';
 import {
@@ -32,7 +31,7 @@ const createInstance = <LoaderInput>(
       router,
       forwarder,
       validator,
-      mocker: new HttpMocker(generate),
+      mocker: new HttpMocker(),
     },
   )(config, overrides);
 };

--- a/packages/http/src/mocker/HttpMocker.ts
+++ b/packages/http/src/mocker/HttpMocker.ts
@@ -77,7 +77,10 @@ function isINodeExample(nodeExample: INodeExample | INodeExternalExample | undef
   return !!nodeExample && 'value' in nodeExample;
 }
 
-function computeMockedHeaders(headers: IHttpHeaderParam[], ex: PayloadGenerator): Promise<Dictionary<string>> {
+function computeMockedHeaders(
+  headers: IHttpHeaderParam[],
+  payloadGenerator: PayloadGenerator,
+): Promise<Dictionary<string>> {
   const headerWithPromiseValues = mapValues(keyBy(headers, h => h.name), async header => {
     if (header.schema) {
       if (header.examples && header.examples.length > 0) {
@@ -86,7 +89,7 @@ function computeMockedHeaders(headers: IHttpHeaderParam[], ex: PayloadGenerator)
           return example.value;
         }
       } else {
-        const example = await ex(header.schema);
+        const example = await payloadGenerator(header.schema);
         if (!(isObject(example) && isEmpty(example))) return example;
       }
     }
@@ -98,12 +101,12 @@ function computeMockedHeaders(headers: IHttpHeaderParam[], ex: PayloadGenerator)
 
 async function computeBody(
   negotiationResult: Pick<IHttpNegotiationResult, 'schema' | 'mediaType' | 'bodyExample'>,
-  ex: PayloadGenerator,
+  payloadGenerator: PayloadGenerator,
 ) {
   if (isINodeExample(negotiationResult.bodyExample) && negotiationResult.bodyExample.value !== undefined) {
     return negotiationResult.bodyExample.value;
   } else if (negotiationResult.schema) {
-    return ex(negotiationResult.schema);
+    return payloadGenerator(negotiationResult.schema);
   }
   return undefined;
 }

--- a/packages/http/src/mocker/HttpMocker.ts
+++ b/packages/http/src/mocker/HttpMocker.ts
@@ -24,12 +24,8 @@ export class HttpMocker implements IMocker<IHttpOperation, IHttpRequest, IHttpCo
   }: Partial<IMockerOpts<IHttpOperation, IHttpRequest, IHttpConfig>>): IHttpResponse {
     let payloadGenerator: PayloadGenerator = generateStatic;
 
-    if (config) {
-      if (typeof config.mock !== 'boolean') {
-        if (config.mock.dynamic) {
-          payloadGenerator = generate;
-        }
-      }
+    if (config && typeof config.mock !== 'boolean' && config.mock.dynamic) {
+      payloadGenerator = generate;
     }
 
     // pre-requirements check

--- a/packages/http/src/mocker/HttpMocker.ts
+++ b/packages/http/src/mocker/HttpMocker.ts
@@ -85,7 +85,7 @@ function isINodeExample(nodeExample: INodeExample | INodeExternalExample | undef
 }
 
 function computeMockedHeaders(headers: IHttpHeaderParam[], payloadGenerator: PayloadGenerator): Dictionary<string> {
-  const headerWithPromiseValues = mapValues(keyBy(headers, h => h.name), header => {
+  return mapValues(keyBy(headers, h => h.name), header => {
     if (header.schema) {
       if (header.examples && header.examples.length > 0) {
         const example = header.examples[0];
@@ -97,10 +97,8 @@ function computeMockedHeaders(headers: IHttpHeaderParam[], payloadGenerator: Pay
         if (!(isObject(example) && isEmpty(example))) return example;
       }
     }
-    return '';
+    return null;
   });
-
-  return headerWithPromiseValues;
 }
 
 function computeBody(

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -230,7 +230,7 @@ describe('HttpMocker', () => {
         });
 
         describe('no response example is requested specifically, and a response example is defined', () => {
-          it('should return the first viable example', () => {
+          it('should return the first example', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,
@@ -299,7 +299,7 @@ describe('HttpMocker', () => {
               it('prefers the example', () => expect(response.body).toHaveProperty('middlename', 'J'));
             });
 
-            describe('with a objects', () => {
+            describe('and the property containing the example is deeply nested', () => {
               it('should return the example key', () => expect(response.body).toHaveProperty('pet.name', 'Clark'));
               it('should still prefer the example', () => expect(response.body).toHaveProperty('pet.middlename', 'J'));
             });

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -239,9 +239,7 @@ describe('HttpMocker', () => {
 
             expect(response.body).toBeDefined();
 
-            const selectedExample = flatMap(mockResource.responses, res =>
-              flatMap(res.contents, content => content.examples || []),
-            )[0];
+            const selectedExample = mockResource.responses[0].contents![0].examples![0];
 
             expect(selectedExample).toBeDefined();
             expect(response.body).toEqual((selectedExample as INodeExample).value);

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -271,6 +271,15 @@ describe('HttpMocker', () => {
                         email: { type: 'string' },
                         deposit: { type: 'number' },
                         paymentStatus: { type: 'string', enum: ['completed', 'outstanding'] },
+                        creditScore: {
+                          anyOf: [{ type: 'number', examples: [1958] }, { type: 'string' }],
+                        },
+                        paymentScore: {
+                          oneOf: [{ type: 'number', examples: [1958] }, { type: 'string' }],
+                        },
+                        walletScore: {
+                          allOf: [{ type: 'string' }, { default: 'hello' }],
+                        },
                         pet: {
                           type: 'object',
                           properties: {
@@ -322,6 +331,12 @@ describe('HttpMocker', () => {
               it('should return the default number', () => expect(response.body).toHaveProperty('deposit', 0));
               it('should return the first enum value', () =>
                 expect(response.body).toHaveProperty('paymentStatus', 'completed'));
+              it('should return the first anyOf value', () =>
+                expect(response.body).toHaveProperty('creditScore', 1958));
+              it('should return the first anyOf value', () =>
+                expect(response.body).toHaveProperty('creditScore', 1958));
+              it('should return the first allOf value', () =>
+                expect(response.body).toHaveProperty('walletScore', 'hello'));
             });
           });
         });

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -270,6 +270,7 @@ describe('HttpMocker', () => {
                         age: { type: ['number', 'null'] },
                         email: { type: 'string' },
                         deposit: { type: 'number' },
+                        paymentStatus: { type: 'string', enum: ['completed', 'outstanding'] },
                         pet: {
                           type: 'object',
                           properties: {
@@ -319,6 +320,8 @@ describe('HttpMocker', () => {
             describe('and is not nullable', () => {
               it('should return the default string', () => expect(response.body).toHaveProperty('email', 'string'));
               it('should return the default number', () => expect(response.body).toHaveProperty('deposit', 0));
+              it('should return the first enum value', () =>
+                expect(response.body).toHaveProperty('paymentStatus', 'completed'));
             });
           });
         });

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -229,7 +229,7 @@ describe('HttpMocker', () => {
           });
         });
 
-        describe('and the resource has an example, but the request does not specify any', () => {
+        describe('no response example is requested specifically, and a response example is defined', () => {
           it('should return the first viable example', () => {
             const response = httpMocker.mock({
               input: mockInput,
@@ -248,7 +248,7 @@ describe('HttpMocker', () => {
           });
         });
 
-        describe('and the resource has not an example', () => {
+        describe('and the resource has no response examples', () => {
           const resourceOperation: IHttpOperation = {
             id: 'id',
             method: 'get',
@@ -295,8 +295,8 @@ describe('HttpMocker', () => {
 
           describe('the property has an example key', () => {
             it('should return the example key', () => expect(response.body).toHaveProperty('name', 'Clark'));
-            describe('the property has an example and a default key', () => {
-              it('should still prefer the example', () => expect(response.body).toHaveProperty('middlename', 'J'));
+            describe('and a default key', () => {
+              it('prefers the example', () => expect(response.body).toHaveProperty('middlename', 'J'));
             });
 
             describe('with a objects', () => {

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -270,6 +270,13 @@ describe('HttpMocker', () => {
                         age: { type: ['number', 'null'] },
                         email: { type: 'string' },
                         deposit: { type: 'number' },
+                        pet: {
+                          type: 'object',
+                          properties: {
+                            name: { type: 'string', examples: ['Clark'] },
+                            middlename: { type: 'string', examples: ['J'], default: 'JJ' },
+                          },
+                        },
                       },
                       required: ['name', 'surname', 'age', 'email'],
                     },
@@ -286,11 +293,15 @@ describe('HttpMocker', () => {
             config: { mock: { dynamic: false } },
           });
 
-          console.log(response.body);
           describe('the property has an example key', () => {
             it('should return the example key', () => expect(response.body).toHaveProperty('name', 'Clark'));
             describe('the property has an example and a default key', () => {
               it('should still prefer the example', () => expect(response.body).toHaveProperty('middlename', 'J'));
+            });
+
+            describe('with a objects', () => {
+              it('should return the example key', () => expect(response.body).toHaveProperty('pet.name', 'Clark'));
+              it('should still prefer the example', () => expect(response.body).toHaveProperty('pet.middlename', 'J'));
             });
           });
 

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -308,7 +308,7 @@ describe('HttpMocker', () => {
                 expect(responseWithMultipleExamples.body).toHaveProperty('middlename', 'WW'));
             });
 
-            describe('with no multiple example values in the array', () => {
+            describe('with an empty `examples` array', () => {
               const responseWithNoExamples = mockResponseWithSchema({
                 type: 'object',
                 properties: {

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -275,7 +275,7 @@ describe('HttpMocker', () => {
                           anyOf: [{ type: 'number', examples: [1958] }, { type: 'string' }],
                         },
                         paymentScore: {
-                          oneOf: [{ type: 'number', examples: [1958] }, { type: 'string' }],
+                          oneOf: [{ type: 'string' }, { type: 'number', examples: [1958] }],
                         },
                         walletScore: {
                           allOf: [{ type: 'string' }, { default: 'hello' }],
@@ -333,8 +333,8 @@ describe('HttpMocker', () => {
                 expect(response.body).toHaveProperty('paymentStatus', 'completed'));
               it('should return the first anyOf value', () =>
                 expect(response.body).toHaveProperty('creditScore', 1958));
-              it('should return the first anyOf value', () =>
-                expect(response.body).toHaveProperty('creditScore', 1958));
+              it('should return the first oneOf value', () =>
+                expect(response.body).toHaveProperty('paymentScore', 'string'));
               it('should return the first allOf value', () =>
                 expect(response.body).toHaveProperty('walletScore', 'hello'));
             });

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -210,43 +210,44 @@ describe('HttpMocker', () => {
       });
 
       describe('and dynamic flag is false', () => {
-        describe('and the example has been explicited', () => {
-          it('should return the selected example', () => {
+        describe('and the response has an example', () => {
+          describe('and the example has been explicited', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,
               config: { mock: { dynamic: false, exampleKey: 'test key' } },
             });
 
-            expect(response.body).toBeDefined();
+            it('should return the selected example', () => {
+              expect(response.body).toBeDefined();
 
-            const selectedExample = flatMap(mockResource.responses, res =>
-              flatMap(res.contents, content => content.examples || []),
-            ).find(ex => ex.key === 'test key');
+              const selectedExample = flatMap(mockResource.responses, res =>
+                flatMap(res.contents, content => content.examples || []),
+              ).find(ex => ex.key === 'test key');
 
-            expect(selectedExample).toBeDefined();
-            expect(response.body).toEqual((selectedExample as INodeExample).value);
+              expect(selectedExample).toBeDefined();
+              expect(response.body).toEqual((selectedExample as INodeExample).value);
+            });
           });
-        });
 
-        describe('and a response example is defined, but no response example is requested', () => {
-          it('returns the first example', () => {
+          describe('no response example is requested', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,
               config: { mock: { dynamic: false } },
             });
 
-            expect(response.body).toBeDefined();
+            it('returns the first example', () => {
+              expect(response.body).toBeDefined();
+              const selectedExample = mockResource.responses[0].contents![0].examples![0];
 
-            const selectedExample = mockResource.responses[0].contents![0].examples![0];
-
-            expect(selectedExample).toBeDefined();
-            expect(response.body).toEqual((selectedExample as INodeExample).value);
+              expect(selectedExample).toBeDefined();
+              expect(response.body).toEqual((selectedExample as INodeExample).value);
+            });
           });
         });
 
-        describe('and the resource has no response examples', () => {
+        describe('and the response has not an examples', () => {
           function createOperationWithSchema(schema: JSONSchema): IHttpOperation {
             return {
               id: 'id',
@@ -276,7 +277,7 @@ describe('HttpMocker', () => {
             });
           }
 
-          describe('the property has an example key', () => {
+          describe('and the property has an example key', () => {
             const response = mockResponseWithSchema({
               type: 'object',
               properties: {
@@ -285,7 +286,8 @@ describe('HttpMocker', () => {
             });
 
             it('should return the example key', () => expect(response.body).toHaveProperty('name', 'Clark'));
-            describe('and a default key', () => {
+
+            describe('and also a default key', () => {
               const responseWithDefault = mockResponseWithSchema({
                 type: 'object',
                 properties: {
@@ -319,29 +321,29 @@ describe('HttpMocker', () => {
               it('fallbacks to string', () =>
                 expect(responseWithNoExamples.body).toHaveProperty('middlename', 'string'));
             });
-
-            describe('and the property containing the example is deeply nested', () => {
-              const responseWithNestedObject = mockResponseWithSchema({
-                type: 'object',
-                properties: {
-                  pet: {
-                    type: 'object',
-                    properties: {
-                      name: { type: 'string', examples: ['Clark'] },
-                      middlename: { type: 'string', examples: ['J'], default: 'JJ' },
-                    },
-                  },
-                },
-              });
-
-              it('should return the example key', () =>
-                expect(responseWithNestedObject.body).toHaveProperty('pet.name', 'Clark'));
-              it('should still prefer the example', () =>
-                expect(responseWithNestedObject.body).toHaveProperty('pet.middlename', 'J'));
-            });
           });
 
-          describe('the property has not an example, but a default key', () => {
+          describe('and the property containing the example is deeply nested', () => {
+            const responseWithNestedObject = mockResponseWithSchema({
+              type: 'object',
+              properties: {
+                pet: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', examples: ['Clark'] },
+                    middlename: { type: 'string', examples: ['J'], default: 'JJ' },
+                  },
+                },
+              },
+            });
+
+            it('should return the example key', () =>
+              expect(responseWithNestedObject.body).toHaveProperty('pet.name', 'Clark'));
+            it('should still prefer the example', () =>
+              expect(responseWithNestedObject.body).toHaveProperty('pet.middlename', 'J'));
+          });
+
+          describe('and the property has not an example, but a default key', () => {
             const response = mockResponseWithSchema({
               type: 'object',
               properties: {
@@ -354,7 +356,7 @@ describe('HttpMocker', () => {
             });
           });
 
-          describe('the property has nor default, nor example', () => {
+          describe('and the property has nor default, nor example', () => {
             describe('is nullable', () => {
               const response = mockResponseWithSchema({
                 type: 'object',

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -229,8 +229,8 @@ describe('HttpMocker', () => {
           });
         });
 
-        describe('no response example is requested specifically, and a response example is defined', () => {
-          it('should return the first example', () => {
+        describe('and a response example is defined, but no response example is requested', () => {
+          it('returns the first example', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -296,6 +296,30 @@ describe('HttpMocker', () => {
               it('prefers the example', () => expect(responseWithDefault.body).toHaveProperty('middlename', 'J'));
             });
 
+            describe('with multiple example values in the array', () => {
+              const responseWithMultipleExamples = mockResponseWithSchema({
+                type: 'object',
+                properties: {
+                  middlename: { type: 'string', examples: ['WW', 'JJ'] },
+                },
+              });
+
+              it('prefers the first example', () =>
+                expect(responseWithMultipleExamples.body).toHaveProperty('middlename', 'WW'));
+            });
+
+            describe('with no multiple example values in the array', () => {
+              const responseWithNoExamples = mockResponseWithSchema({
+                type: 'object',
+                properties: {
+                  middlename: { type: 'string', examples: [] },
+                },
+              });
+
+              it('fallbacks to string', () =>
+                expect(responseWithNoExamples.body).toHaveProperty('middlename', 'string'));
+            });
+
             describe('and the property containing the example is deeply nested', () => {
               const responseWithNestedObject = mockResponseWithSchema({
                 type: 'object',

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -186,7 +186,7 @@ describe('HttpMocker', () => {
             jest.restoreAllMocks();
           });
 
-          it.only('the dynamic response should not be an example one', () => {
+          it('the dynamic response should not be an example one', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -3,16 +3,15 @@ import * as Ajv from 'ajv';
 import { ProblemJsonError } from '@stoplight/prism-http';
 import { httpOperations, httpRequests } from '../../__tests__/fixtures';
 import { NOT_ACCEPTABLE } from '../errors';
-import { generate } from '../generator/JSONSchema';
 import { HttpMocker } from '../index';
 
 describe('http mocker', () => {
-  const mocker = new HttpMocker(generate);
+  const mocker = new HttpMocker();
 
   describe('request is valid', () => {
     describe('given only enforced content type', () => {
-      test('and that content type exists should first 200 static example', async () => {
-        const response = await mocker.mock({
+      test('and that content type exists should first 200 static example', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -27,7 +26,7 @@ describe('http mocker', () => {
       });
 
       test('and that content type does not exist should return an error', () => {
-        return expect(
+        return expect(() =>
           mocker.mock({
             resource: httpOperations[0],
             input: httpRequests[0],
@@ -38,13 +37,13 @@ describe('http mocker', () => {
               },
             },
           }),
-        ).rejects.toThrowError(ProblemJsonError.fromTemplate(NOT_ACCEPTABLE));
+        ).toThrowError(ProblemJsonError.fromTemplate(NOT_ACCEPTABLE));
       });
     });
 
     describe('given enforced status code and contentType and exampleKey', () => {
-      test('should return the matching example', async () => {
-        const response = await mocker.mock({
+      test('should return the matching example', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -62,8 +61,8 @@ describe('http mocker', () => {
     });
 
     describe('given enforced status code and contentType', () => {
-      test('should return the first matching example', async () => {
-        const response = await mocker.mock({
+      test('should return the first matching example', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -80,8 +79,8 @@ describe('http mocker', () => {
     });
 
     describe('given enforced example key', () => {
-      test('should return application/json, 200 response', async () => {
-        const response = await mocker.mock({
+      test('should return application/json, 200 response', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -95,8 +94,8 @@ describe('http mocker', () => {
         expect(response).toMatchSnapshot();
       });
 
-      test('and mediaType should return 200 response', async () => {
-        const response = await mocker.mock({
+      test('and mediaType should return 200 response', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -113,8 +112,8 @@ describe('http mocker', () => {
     });
 
     describe('given enforced status code', () => {
-      test('should return the first matching example of application/json', async () => {
-        const response = await mocker.mock({
+      test('should return the first matching example of application/json', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -129,22 +128,23 @@ describe('http mocker', () => {
       });
 
       test('given that status code is not defined should throw an error', () => {
-        const rejection = mocker.mock({
-          resource: httpOperations[0],
-          input: httpRequests[0],
-          config: {
-            mock: {
-              dynamic: false,
-              code: '205',
+        const rejection = () =>
+          mocker.mock({
+            resource: httpOperations[0],
+            input: httpRequests[0],
+            config: {
+              mock: {
+                dynamic: false,
+                code: '205',
+              },
             },
-          },
-        });
+          });
 
-        return expect(rejection).rejects.toEqual(new Error('Requested status code is not defined in the schema.'));
+        return expect(rejection).toThrowError('Requested status code is not defined in the schema.');
       });
 
-      test('and example key should return application/json example', async () => {
-        const response = await mocker.mock({
+      test('and example key should return application/json example', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
@@ -161,8 +161,8 @@ describe('http mocker', () => {
     });
 
     describe('HttpOperation contains example', () => {
-      test('return lowest 2xx code and match response example to media type accepted by request', async () => {
-        const response = await mocker.mock({
+      test('return lowest 2xx code and match response example to media type accepted by request', () => {
+        const response = mocker.mock({
           resource: httpOperations[0],
           input: httpRequests[0],
         });
@@ -175,8 +175,8 @@ describe('http mocker', () => {
         });
       });
 
-      test('return lowest 2xx response and the first example matching the media type', async () => {
-        const response = await mocker.mock({
+      test('return lowest 2xx response and the first example matching the media type', () => {
+        const response = mocker.mock({
           resource: httpOperations[1],
           input: Object.assign({}, httpRequests[0], {
             data: Object.assign({}, httpRequests[0].data, {
@@ -194,7 +194,7 @@ describe('http mocker', () => {
 
       describe('the media type requested does not match the example', () => {
         test('throw exception', () => {
-          return expect(
+          return expect(() =>
             mocker.mock({
               resource: httpOperations[0],
               input: Object.assign({}, httpRequests[0], {
@@ -203,13 +203,13 @@ describe('http mocker', () => {
                 }),
               }),
             }),
-          ).rejects.toThrowError(ProblemJsonError.fromTemplate(NOT_ACCEPTABLE));
+          ).toThrowError(ProblemJsonError.fromTemplate(NOT_ACCEPTABLE));
         });
       });
     });
 
     describe('HTTPOperation contain no examples', () => {
-      test('return dynamic response', async () => {
+      test('return dynamic response', () => {
         if (!httpOperations[1].responses[0].contents![0].schema) {
           throw new Error('Missing test');
         }
@@ -217,7 +217,7 @@ describe('http mocker', () => {
         const ajv = new Ajv();
         const validate = ajv.compile(httpOperations[1].responses[0].contents![0].schema);
 
-        const response = await mocker.mock({
+        const response = mocker.mock({
           resource: httpOperations[1],
           input: httpRequests[0],
           config: {
@@ -238,8 +238,8 @@ describe('http mocker', () => {
   });
 
   describe('request is invalid', () => {
-    test('returns 422 and static error response', async () => {
-      const response = await mocker.mock({
+    test('returns 422 and static error response', () => {
+      const response = mocker.mock({
         resource: httpOperations[0],
         input: httpRequests[1],
       });
@@ -248,12 +248,12 @@ describe('http mocker', () => {
       expect(response.body).toMatchObject({ message: 'error' });
     });
 
-    test('returns 422 and dynamic error response', async () => {
+    test('returns 422 and dynamic error response', () => {
       if (!httpOperations[1].responses[1].contents![0].schema) {
         throw new Error('Missing test');
       }
 
-      const response = await mocker.mock({
+      const response = mocker.mock({
         resource: httpOperations[1],
         input: httpRequests[1],
       });

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -128,7 +128,7 @@ describe('http mocker', () => {
       });
 
       test('given that status code is not defined should throw an error', () => {
-        const rejection = () =>
+        return expect(() =>
           mocker.mock({
             resource: httpOperations[0],
             input: httpRequests[0],
@@ -138,9 +138,8 @@ describe('http mocker', () => {
                 code: '205',
               },
             },
-          });
-
-        return expect(rejection).toThrowError('Requested status code is not defined in the schema.');
+          }),
+        ).toThrowError('Requested status code is not defined in the schema.');
       });
 
       test('and example key should return application/json example', () => {

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,5 +1,5 @@
-// @ts-ignore
 import { JSONSchema } from 'http/src/types';
+// @ts-ignore
 import * as jsf from 'json-schema-faker';
 import { cloneDeep } from 'lodash';
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,7 +1,7 @@
 import { JSONSchema } from 'http/src/types';
 import { JSONSchema6, JSONSchema7 } from 'json-schema';
 // @ts-ignore
-import * as jsf from 'json-schema-faker';
+import * as jsf from 'json-schema-faker/dist/bundle.umd.min.js';
 import { cloneDeep, mapValues } from 'lodash';
 // @ts-ignore
 import * as sampler from 'openapi-sampler';

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,7 +1,8 @@
 import { JSONSchema } from 'http/src/types';
+import { JSONSchema6, JSONSchema7 } from 'json-schema';
 // @ts-ignore
 import * as jsf from 'json-schema-faker';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, mapValues } from 'lodash';
 // @ts-ignore
 import * as sampler from 'openapi-sampler';
 
@@ -21,5 +22,30 @@ export function generate(source: JSONSchema): unknown {
 }
 
 export function generateStatic(source: JSONSchema): unknown {
-  return sampler.sample(source);
+  return sampler.sample(transformExampleFromExamples(source));
+}
+
+function hasExample(source: JSONSchema): source is JSONSchema6 | JSONSchema7 {
+  return 'examples' in source;
+}
+
+function transformExampleFromExamples(s: JSONSchema): any {
+  if (!s.properties) return s;
+
+  return {
+    ...s,
+    properties: mapValues(s.properties, prop => {
+      if (typeof prop === 'boolean') return prop;
+
+      if (hasExample(prop) && prop.examples) {
+        Object.assign(prop, { example: prop.examples[0] });
+      }
+
+      if (prop.properties) {
+        return transformExampleFromExamples(prop);
+      }
+
+      return prop;
+    }),
+  };
 }

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -3,7 +3,7 @@ import { JSONSchema6, JSONSchema7 } from 'json-schema';
 import { cloneDeep, map, mapValues } from 'lodash';
 
 // @ts-ignore
-import * as jsf from 'json-schema-faker/dist/bundle.umd.min.js';
+import * as jsf from '@stoplight/json-schema-faker';
 // @ts-ignore
 import * as sampler from 'openapi-sampler';
 
@@ -23,7 +23,7 @@ export function generate(source: JSONSchema): unknown {
 }
 
 export function generateStatic(source: JSONSchema): unknown {
-  const transformedSchema = createOASJSONSchemaesque(source);
+  const transformedSchema = toOpenAPIJSONSchemaesque(source);
   return sampler.sample(transformedSchema);
 }
 
@@ -31,7 +31,7 @@ function hasExamples(source: JSONSchema): source is JSONSchema6 | JSONSchema7 {
   return 'examples' in source;
 }
 
-function createOASJSONSchemaesque(schema: JSONSchema): any {
+function toOpenAPIJSONSchemaesque(schema: JSONSchema): any {
   const returnedSchema = cloneDeep(schema);
 
   ['properties', 'anyOf', 'allOf', 'oneOf'].forEach(property => {
@@ -46,7 +46,7 @@ function createOASJSONSchemaesque(schema: JSONSchema): any {
         Object.assign(innerProp, { example: innerProp.examples[0] });
       }
 
-      return createOASJSONSchemaesque(innerProp);
+      return toOpenAPIJSONSchemaesque(innerProp);
     });
   });
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import * as jsf from '@stoplight/json-schema-faker';
+import * as jsf from 'json-schema-faker';
 import { cloneDeep } from 'lodash';
 
 jsf.option({

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -42,7 +42,7 @@ function toOpenAPIJSONSchemaesque(schema: JSONSchema): any {
     returnedSchema[property] = mapFn(schema[property], innerProp => {
       if (typeof innerProp === 'boolean') return innerProp;
 
-      if (hasExamples(innerProp) && innerProp.examples) {
+      if (hasExamples(innerProp) && Array.isArray(innerProp.examples)) {
         Object.assign(innerProp, { example: innerProp.examples[0] });
       }
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -12,8 +12,6 @@ jsf.option({
   optionalsProbability: 1,
   fixedProbabilities: true,
   ignoreMissingRefs: true,
-  useExamplesValue: false,
-  useDefaultValue: false,
   maxItems: 20,
   maxLength: 100,
 });

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -2,6 +2,8 @@ import { JSONSchema } from 'http/src/types';
 // @ts-ignore
 import * as jsf from 'json-schema-faker';
 import { cloneDeep } from 'lodash';
+// @ts-ignore
+import * as sampler from 'openapi-sampler';
 
 jsf.option({
   failOnInvalidTypes: false,
@@ -10,12 +12,16 @@ jsf.option({
   optionalsProbability: 1,
   fixedProbabilities: true,
   ignoreMissingRefs: true,
-  useExamplesValue: true,
-  useDefaultValue: true,
+  useExamplesValue: false,
+  useDefaultValue: false,
   maxItems: 20,
   maxLength: 100,
 });
 
-export async function generate(source: JSONSchema): Promise<unknown> {
-  return jsf.resolve(cloneDeep(source));
+export function generate(source: JSONSchema): unknown {
+  return jsf.generate(cloneDeep(source));
+}
+
+export function generateStatic(source: JSONSchema): unknown {
+  return sampler.sample(source);
 }

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -35,7 +35,7 @@ function toOpenAPIJSONSchemaesque(schema: JSONSchema): any {
   const returnedSchema = cloneDeep(schema);
 
   ['properties', 'anyOf', 'allOf', 'oneOf'].forEach(property => {
-    if (!schema[property]) return;
+    if (!returnedSchema[property]) return;
 
     const mapFn = Array.isArray(returnedSchema[property]) ? map : (mapValues as (obj: unknown) => unknown[] | unknown);
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,4 +1,5 @@
 // @ts-ignore
+import { JSONSchema } from 'http/src/types';
 import * as jsf from 'json-schema-faker';
 import { cloneDeep } from 'lodash';
 
@@ -15,6 +16,6 @@ jsf.option({
   maxLength: 100,
 });
 
-export async function generate(source: unknown): Promise<unknown> {
+export async function generate(source: JSONSchema): Promise<unknown> {
   return jsf.resolve(cloneDeep(source));
 }

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -3,7 +3,7 @@ import { generate } from '../JSONSchema';
 
 describe('JSONSchema generator', () => {
   describe('generate()', () => {
-    it('generates dynamic example from schema', async () => {
+    it('generates dynamic example from schema', () => {
       const schema: JSONSchema = {
         type: 'object',
         properties: {
@@ -13,7 +13,7 @@ describe('JSONSchema generator', () => {
         required: ['name', 'email'],
       };
 
-      const instance = await generate(schema);
+      const instance = generate(schema);
       expect(instance).toHaveProperty('name');
       expect(instance).toHaveProperty('email');
     });
@@ -29,7 +29,7 @@ describe('JSONSchema generator', () => {
 
       Object.defineProperty(schema.properties, 'name', { writable: false });
 
-      return expect(generate(schema)).resolves.toBeTruthy();
+      return expect(generate(schema)).toBeTruthy();
     });
   });
 });

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -1,9 +1,10 @@
+import { JSONSchema } from 'http/src/types';
 import { generate } from '../JSONSchema';
 
 describe('JSONSchema generator', () => {
   describe('generate()', () => {
     it('generates dynamic example from schema', async () => {
-      const schema = {
+      const schema: JSONSchema = {
         type: 'object',
         properties: {
           name: { type: 'string', minLength: 1 },
@@ -18,7 +19,7 @@ describe('JSONSchema generator', () => {
     });
 
     it('operates on sealed schema objects', () => {
-      const schema = {
+      const schema: JSONSchema = {
         type: 'object',
         properties: {
           name: { type: 'string' },

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -104,7 +104,7 @@ export class ProblemJsonError extends Error {
   }
 }
 
-export type PayloadGenerator = (f: unknown) => Promise<unknown>;
+export type PayloadGenerator = (f: JSONSchema) => Promise<unknown>;
 
 export type PickRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -104,7 +104,7 @@ export class ProblemJsonError extends Error {
   }
 }
 
-export type PayloadGenerator = (f: JSONSchema) => Promise<unknown>;
+export type PayloadGenerator = (f: JSONSchema) => unknown;
 
 export type PickRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "exclude": [],
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,7 +1184,7 @@
     lodash "4.x.x"
     urijs "1.x.x"
 
-"@stoplight/json-schema-faker@":
+"@stoplight/json-schema-faker@^0.5.0-rc18":
   version "0.5.0-rc18"
   resolved "https://registry.yarnpkg.com/@stoplight/json-schema-faker/-/json-schema-faker-0.5.0-rc18.tgz#f2091443e74503c3ca7b86d65ed00e7082bbfeda"
   integrity sha512-BHDk7gLENfVcE9ZXXHIGb+u6HZhuxTfjUD7yozGJv7ESSxEkOfCDBZ5dj5Uiq8/A2WwqNrxnCxpBTcGpQWOGTQ==
@@ -4936,7 +4936,6 @@ jsonparse@^1.2.0:
 
 "jsonpath@https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17":
   version "1.0.0"
-  uid f1c0e9e634da2d45671b7639fa0a99afc807da17
   resolved "https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17"
   dependencies:
     esprima "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,15 +1184,6 @@
     lodash "4.x.x"
     urijs "1.x.x"
 
-"@stoplight/json-schema-faker@^0.5.0-rc18":
-  version "0.5.0-rc18"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-faker/-/json-schema-faker-0.5.0-rc18.tgz#f2091443e74503c3ca7b86d65ed00e7082bbfeda"
-  integrity sha512-BHDk7gLENfVcE9ZXXHIGb+u6HZhuxTfjUD7yozGJv7ESSxEkOfCDBZ5dj5Uiq8/A2WwqNrxnCxpBTcGpQWOGTQ==
-  dependencies:
-    json-schema-ref-parser "^5.0.0"
-    jsonpath "https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17"
-    randexp "^0.5.3"
-
 "@stoplight/json@2.1.0", "@stoplight/json@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-2.1.0.tgz#889b38d3078d9ff85c39122d04bd84968aabdd85"
@@ -4790,7 +4781,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.x, js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
+js-yaml@3.13.x, js-yaml@^3.12.1, js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4845,15 +4836,23 @@ json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-schema-ref-parser@^5.0.0:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz#f86c5868f40898e69169e1bbc854725a4fd0e1ad"
-  integrity sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==
+json-schema-faker@^0.5.0-rc17:
+  version "0.5.0-rc17"
+  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.0-rc17.tgz#d9c78ef0e2a891077a08c9660b7bfa3419e722d2"
+  integrity sha512-ZQSLPpnsGiMBuPOHi09cAzhsiIeOcs5im2GAQ2P6XKyWOuetO8eYdYCP/kW7VVU891Ucan0/dl8GYbRA6pf9gw==
+  dependencies:
+    json-schema-ref-parser "^6.0.2"
+    jsonpath "^1.0.1"
+    randexp "^0.5.3"
+
+json-schema-ref-parser@^6.0.2:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
+  integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
   dependencies:
     call-me-maybe "^1.0.1"
-    debug "^3.1.0"
-    js-yaml "^3.12.0"
-    ono "^4.0.6"
+    js-yaml "^3.12.1"
+    ono "^4.0.11"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -4913,19 +4912,18 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-"jsonpath@https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17":
-  version "1.0.0"
-  uid f1c0e9e634da2d45671b7639fa0a99afc807da17
-  resolved "https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17"
+jsonpath@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.0.2.tgz#e6aae681d03e9a77b4651d5d96eac5fc63b1fd13"
+  integrity sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==
   dependencies:
     esprima "1.2.2"
-    jison "0.4.13"
-    static-eval "2.0.0"
+    static-eval "2.0.2"
     underscore "1.7.0"
 
-"jsonpath@https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17":
+"jsonpath@https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17":
   version "1.0.0"
-  resolved "https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17"
+  resolved "https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17"
   dependencies:
     esprima "1.2.2"
     jison "0.4.13"
@@ -5984,7 +5982,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-ono@^4.0.6:
+ono@^4.0.11:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/ono/-/ono-4.0.11.tgz#c7f4209b3e396e8a44ef43b9cedc7f5d791d221d"
   integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
@@ -7403,6 +7401,13 @@ static-eval@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.0.tgz#0e821f8926847def7b4b50cda5d55c04a9b13864"
   integrity sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==
+  dependencies:
+    escodegen "^1.8.1"
+
+static-eval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
   dependencies:
     escodegen "^1.8.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,6 +3334,11 @@ for-in@^1.0.2:
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
 
+foreach@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -4836,6 +4841,13 @@ json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-pointer@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/json-pointer/-/json-pointer-0.6.0.tgz#8e500550a6aac5464a473377da57aa6cc22828d7"
+  integrity sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=
+  dependencies:
+    foreach "^2.0.4"
+
 json-schema-faker@^0.5.0-rc17:
   version "0.5.0-rc17"
   resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.0-rc17.tgz#d9c78ef0e2a891077a08c9660b7bfa3419e722d2"
@@ -5988,6 +6000,13 @@ ono@^4.0.11:
   integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
   dependencies:
     format-util "^1.0.3"
+
+openapi-sampler@^1.0.0-beta.14:
+  version "1.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz#e06807f33a9c0fab841e212f5fb90e7af4acf30c"
+  integrity sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==
+  dependencies:
+    json-pointer "^0.6.0"
 
 openapi3-ts@1.3.x:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,6 +1184,15 @@
     lodash "4.x.x"
     urijs "1.x.x"
 
+"@stoplight/json-schema-faker@":
+  version "0.5.0-rc18"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-faker/-/json-schema-faker-0.5.0-rc18.tgz#f2091443e74503c3ca7b86d65ed00e7082bbfeda"
+  integrity sha512-BHDk7gLENfVcE9ZXXHIGb+u6HZhuxTfjUD7yozGJv7ESSxEkOfCDBZ5dj5Uiq8/A2WwqNrxnCxpBTcGpQWOGTQ==
+  dependencies:
+    json-schema-ref-parser "^5.0.0"
+    jsonpath "https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17"
+    randexp "^0.5.3"
+
 "@stoplight/json@2.1.0", "@stoplight/json@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-2.1.0.tgz#889b38d3078d9ff85c39122d04bd84968aabdd85"
@@ -4786,7 +4795,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.x, js-yaml@^3.12.1, js-yaml@^3.13.1, js-yaml@^3.7.0:
+js-yaml@3.13.x, js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4848,23 +4857,15 @@ json-pointer@^0.6.0:
   dependencies:
     foreach "^2.0.4"
 
-json-schema-faker@^0.5.0-rc17:
-  version "0.5.0-rc17"
-  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.0-rc17.tgz#d9c78ef0e2a891077a08c9660b7bfa3419e722d2"
-  integrity sha512-ZQSLPpnsGiMBuPOHi09cAzhsiIeOcs5im2GAQ2P6XKyWOuetO8eYdYCP/kW7VVU891Ucan0/dl8GYbRA6pf9gw==
-  dependencies:
-    json-schema-ref-parser "^6.0.2"
-    jsonpath "^1.0.1"
-    randexp "^0.5.3"
-
-json-schema-ref-parser@^6.0.2:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
-  integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
+json-schema-ref-parser@^5.0.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz#f86c5868f40898e69169e1bbc854725a4fd0e1ad"
+  integrity sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==
   dependencies:
     call-me-maybe "^1.0.1"
-    js-yaml "^3.12.1"
-    ono "^4.0.11"
+    debug "^3.1.0"
+    js-yaml "^3.12.0"
+    ono "^4.0.6"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -4924,18 +4925,19 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonpath@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.0.2.tgz#e6aae681d03e9a77b4651d5d96eac5fc63b1fd13"
-  integrity sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==
-  dependencies:
-    esprima "1.2.2"
-    static-eval "2.0.2"
-    underscore "1.7.0"
-
 "jsonpath@https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17":
   version "1.0.0"
   resolved "https://github.com/stoplightio/jsonpath#f1c0e9e634da2d45671b7639fa0a99afc807da17"
+  dependencies:
+    esprima "1.2.2"
+    jison "0.4.13"
+    static-eval "2.0.0"
+    underscore "1.7.0"
+
+"jsonpath@https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17":
+  version "1.0.0"
+  uid f1c0e9e634da2d45671b7639fa0a99afc807da17
+  resolved "https://github.com/stoplightio/jsonpath.git#f1c0e9e634da2d45671b7639fa0a99afc807da17"
   dependencies:
     esprima "1.2.2"
     jison "0.4.13"
@@ -5994,7 +5996,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-ono@^4.0.11:
+ono@^4.0.6:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/ono/-/ono-4.0.11.tgz#c7f4209b3e396e8a44ef43b9cedc7f5d791d221d"
   integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
@@ -7420,13 +7422,6 @@ static-eval@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.0.tgz#0e821f8926847def7b4b50cda5d55c04a9b13864"
   integrity sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==
-  dependencies:
-    escodegen "^1.8.1"
-
-static-eval@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
-  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
   dependencies:
     escodegen "^1.8.1"
 


### PR DESCRIPTION
This PR implements the strategy we agreed for static examples generation.

1. Removes the forced `true` flag
2. Uses OpenAPI Sampler in case the static example generation is enabled
3. I _had_ to move the `generate` argument for `HttpMocker` because of the weird configuration merger thing which I do not want to touch right now
4. Adds a bunch of tests


---

As you can see from the code, I had to add an additional function that takes a regular JSON Schema and transforms it to something that OpenAPI Sampler can effectively use to generate static examples.

Maybe we could do it the other way around, but this is a followup though.

SO-225

---

If this gets merged:
https://github.com/Redocly/openapi-sampler/pull/10

I can remove the horrible function I had to wrote myself to walk through the schema and put the first `examples` in the `example`