### PR TITLE
fix: transfer rootDir and out to build configuration files

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "references": [
     {

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+  },
   "references": [
     {
       "path": "../core/tsconfig.build.json"

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,19 +1,11 @@
 {
-  "include": [
-    "src"
-  ],
   "extends": "../tsconfig.json",
+  "include": ["src"],
   "compilerOptions": {
     "paths": {
-      "@stoplight/prism-core": [
-        "./core/src"
-      ],
-      "@stoplight/prism-http": [
-        "./http/src"
-      ],
-      "@stoplight/prism-http-server": [
-        "./http-server/src"
-      ]
+      "@stoplight/prism-core": ["./core/src"],
+      "@stoplight/prism-http": ["./http/src"],
+      "@stoplight/prism-http-server": ["./http-server/src"]
     }
   }
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,13 +1,19 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
     "paths": {
-      "@stoplight/prism-core": ["./core/src"],
-      "@stoplight/prism-http": ["./http/src"],
-      "@stoplight/prism-http-server": ["./http-server/src"]
+      "@stoplight/prism-core": [
+        "./core/src"
+      ],
+      "@stoplight/prism-http": [
+        "./http/src"
+      ],
+      "@stoplight/prism-http-server": [
+        "./http-server/src"
+      ]
     }
   }
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["src"],
   "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
     "paths": {
       "@stoplight/prism-core": ["./core/src"],
       "@stoplight/prism-http": ["./http/src"],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
   }
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
+  "include": ["src"],
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": true,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,6 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "include": [
-    "src"
-  ],
-  "extends": "../tsconfig.json",
+  "extends": "../tsconfig.json"
 }

--- a/packages/http-server/tsconfig.build.json
+++ b/packages/http-server/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
   },
   "references": [
     {

--- a/packages/http-server/tsconfig.build.json
+++ b/packages/http-server/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "references": [
     {

--- a/packages/http-server/tsconfig.json
+++ b/packages/http-server/tsconfig.json
@@ -1,16 +1,9 @@
 {
-  "include": [
-    "src"
-  ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@stoplight/prism-core": [
-        "./core/src"
-      ],
-      "@stoplight/prism-http": [
-        "./http/src"
-      ]
+      "@stoplight/prism-core": ["./core/src"],
+      "@stoplight/prism-http": ["./http/src"]
     }
   }
 }

--- a/packages/http-server/tsconfig.json
+++ b/packages/http-server/tsconfig.json
@@ -1,12 +1,16 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
     "paths": {
-      "@stoplight/prism-core": ["./core/src"],
-      "@stoplight/prism-http": ["./http/src"]
+      "@stoplight/prism-core": [
+        "./core/src"
+      ],
+      "@stoplight/prism-http": [
+        "./http/src"
+      ]
     }
   }
 }

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { DiagnosticSeverity, IHttpContent, IHttpHeaderParam, IHttpOperation, IHttpQueryParam } from '@stoplight/types';
 
-import { IPrismDiagnostic } from '@stoplight/prism-core/src';
+import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { IHttpNameValue, IHttpNameValues } from '../../types';
 import { IHttpRequest } from '../../types';
 import { HttpValidator } from '../index';

--- a/packages/http/tsconfig.build.json
+++ b/packages/http/tsconfig.build.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist",
   },
   "references": [
     {

--- a/packages/http/tsconfig.build.json
+++ b/packages/http/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src"],
   "compilerOptions": {
     "composite": true,
     "rootDir": "src",
-    "outDir": "dist",
+    "outDir": "dist"
   },
   "references": [
     {

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -1,11 +1,13 @@
 {
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
     "paths": {
-      "@stoplight/prism-core": ["./core/src"]
+      "@stoplight/prism-core": [
+        "./core/src"
+      ]
     }
   }
 }

--- a/packages/http/tsconfig.json
+++ b/packages/http/tsconfig.json
@@ -1,13 +1,8 @@
 {
-  "include": [
-    "src"
-  ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "paths": {
-      "@stoplight/prism-core": [
-        "./core/src"
-      ]
+      "@stoplight/prism-core": ["./core/src"]
     }
   }
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "exclude": ["**/__tests__"],
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,

--- a/packages/tsconfig.test.json
+++ b/packages/tsconfig.test.json
@@ -7,7 +7,7 @@
       "@stoplight/prism-http-server": ["./http-server/src"]
     }
   },
-  "extends": "./tsconfig.build.json",
+  "extends": "./tsconfig.json",
   "exclude": [],
   "include": ["**/src"]
 }


### PR DESCRIPTION
TypeScript's server sometimes goes just nuts and shows errors only after minutes and minutes of usages.

I looked at its source code *yet another time* and I hope this PR will settle the errors from VSCode. Basically VSCode thinks it needs to compile the code but it's not true, so I've transferred as much options as possible to the build files.