### PR TITLE
feat: update openapi-sampler

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.18.0",
     "caseless": "^0.12.0",
     "fp-ts": "^1.18.2",
-    "openapi-sampler": "^1.0.0-beta.14",
+    "openapi-sampler": "^1.0.0-beta.15",
     "pino": "^5.12.6",
     "tslib": "^1.10.0"
   },

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -331,9 +331,9 @@ describe('HttpMocker', () => {
                 },
               });
 
-              it('prefers the example', () =>
+              it('prefers the default', () =>
                 assertRight(eitherResponseWithDefault, responseWithDefault =>
-                  expect(responseWithDefault.body).toHaveProperty('middlename', 'J'),
+                  expect(responseWithDefault.body).toHaveProperty('middlename', 'JJ'),
                 ));
             });
 
@@ -383,8 +383,8 @@ describe('HttpMocker', () => {
             assertRight(eitherResponseWithNestedObject, responseWithNestedObject => {
               it('should return the example key', () =>
                 expect(responseWithNestedObject.body).toHaveProperty('pet.name', 'Clark'));
-              it('should still prefer the example', () =>
-                expect(responseWithNestedObject.body).toHaveProperty('pet.middlename', 'J'));
+              it('should still prefer the default', () =>
+                expect(responseWithNestedObject.body).toHaveProperty('pet.middlename', 'JJ'));
             });
           });
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -23,34 +23,5 @@ export function generate(source: JSONSchema): unknown {
 }
 
 export function generateStatic(source: JSONSchema): unknown {
-  const transformedSchema = toOpenAPIJSONSchemaesque(source);
-  return sampler.sample(transformedSchema);
-}
-
-function hasExamples(source: JSONSchema): source is JSONSchema6 | JSONSchema7 {
-  return 'examples' in source;
-}
-
-function toOpenAPIJSONSchemaesque(schema: JSONSchema): any {
-  const returnedSchema = cloneDeep(schema);
-
-  const targetKeys: Array<keyof JSONSchema> = ['properties', 'anyOf', 'allOf', 'oneOf'];
-
-  targetKeys.forEach(property => {
-    if (!returnedSchema[property]) return;
-
-    const mapFn = Array.isArray(returnedSchema[property]) ? map : (mapValues as (obj: unknown) => unknown[] | unknown);
-
-    returnedSchema[property] = mapFn(schema[property], innerProp => {
-      if (typeof innerProp === 'boolean') return innerProp;
-
-      if (hasExamples(innerProp) && Array.isArray(innerProp.examples)) {
-        Object.assign(innerProp, { example: innerProp.examples[0] });
-      }
-
-      return toOpenAPIJSONSchemaesque(innerProp);
-    });
-  });
-
-  return returnedSchema;
+  return sampler.sample(source);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6092,10 +6092,10 @@ ono@^4.0.6:
   dependencies:
     format-util "^1.0.3"
 
-openapi-sampler@^1.0.0-beta.14:
-  version "1.0.0-beta.14"
-  resolved "https://registry.yarnpkg.com/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz#e06807f33a9c0fab841e212f5fb90e7af4acf30c"
-  integrity sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==
+openapi-sampler@^1.0.0-beta.15:
+  version "1.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/openapi-sampler/-/openapi-sampler-1.0.0-beta.15.tgz#c087143826962fa07a0c7bda9ce5c36d732f45de"
+  integrity sha512-wUD/vD3iBHKik/sME3uwUu4X3HFA53rDrPcVvLzgEELjHLbnTpSYfm4Jo9qZT1dPfBRowAnrF/VRQfOjL5QRAw==
   dependencies:
     json-pointer "^0.6.0"
 


### PR DESCRIPTION
Thanks to the new version I can now remove the fallback I had to implement in order to make it generate the examples.

Curiously, the new version is correctly giving the precedence to `default` values over the examples, which is indeed correct.