### PR TITLE
HTTP Server should parse formbody data

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -56,5 +56,6 @@ module.exports = {
   ],
   collectCoverageFrom: [
     '**/src/**/*.{ts,tsx}',
+    '!**/src/**/__tests__/**/*.{ts,tsx}',
   ],
 };

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -23,6 +23,7 @@
     "@stoplight/prism-http": "^3.0.0-beta.2",
     "fastify": "^2.5.0",
     "fastify-accepts-serializer": "^2.0.1",
+    "fastify-formbody": "^3.1.0",
     "tslib": "^1.10.0",
     "type-is": "^1.6.18"
   }

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -3,6 +3,7 @@ import { createInstance, IHttpMethod, ProblemJsonError, TPrismHttpInstance } fro
 import * as fastify from 'fastify';
 // @ts-ignore
 import * as fastifyAcceptsSerializer from 'fastify-accepts-serializer';
+import * as formbodyParser from 'fastify-formbody';
 import { IncomingMessage, ServerResponse } from 'http';
 import * as typeIs from 'type-is';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
@@ -18,22 +19,24 @@ export const createServer = <LoaderInput>(
     logger: (components && components.logger) || createLogger('HTTP SERVER'),
     disableRequestLogging: true,
     modifyCoreObjects: false,
-  }).register(fastifyAcceptsSerializer, {
-    serializers: [
-      {
-        /*
-          This is a workaround, to make Fastify less strict in its json detection.
-          It expects a regexp, but instead we are using typeIs.
-        */
-        regex: {
-          test: (value: string) => !!typeIs.is(value, ['application/*+json']),
-          toString: () => 'application/*+json',
+  })
+    .register(formbodyParser)
+    .register(fastifyAcceptsSerializer, {
+      serializers: [
+        {
+          /*
+            This is a workaround, to make Fastify less strict in its json detection.
+            It expects a regexp, but instead we are using typeIs.
+          */
+          regex: {
+            test: (value: string) => !!typeIs.is(value, ['application/*+json']),
+            toString: () => 'application/*+json',
+          },
+          serializer: JSON.stringify,
         },
-        serializer: JSON.stringify,
-      },
-    ],
-    default: 'application/json; charset=utf-8',
-  });
+      ],
+      default: 'application/json; charset=utf-8',
+    });
 
   server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
     if (typeIs(req, ['application/*+json'])) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,6 +3413,14 @@ fastify-accepts@>=0.5.0:
     accepts "^1.3.3"
     fastify-plugin "^0.2.1"
 
+fastify-formbody@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/fastify-formbody/-/fastify-formbody-3.1.0.tgz#604cdafdb9e3af6068e6d9940985baf692d6e922"
+  integrity sha512-GQQtRmI8w07SMcnXiWrk9H8GAMJwheKAkQS4q0FbJ56Qu8bV39GOffiZ8GLHQmvcJ2B65S+4IAtNjsG6vtMEig==
+  dependencies:
+    fastify-plugin "^1.0.0"
+    qs "^6.5.1"
+
 fastify-plugin@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-0.2.2.tgz#e01b67685fd02e87edc98670ce2acfe251a2c715"
@@ -3420,7 +3428,7 @@ fastify-plugin@^0.2.1:
   dependencies:
     semver "^5.4.1"
 
-fastify-plugin@^1.2.1:
+fastify-plugin@^1.0.0, fastify-plugin@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-1.6.0.tgz#c8198b08608f20c502b5dad26b36e9ae27206d7c"
   integrity sha512-lFa9txg8LZx4tljj33oG53nUXhVg0baZxtP9Pxi0dJmI0NQxzkDk5DS9kr3D7iMalUAp3mvIq16OQumc7eIvLA==


### PR DESCRIPTION
Adds the parser for form body data so that Fastify will not block the request.

This can be only tested from the harness, because the Fastify testing utilities bypass the whole parsing/content type; harness though is being rebuilt in #372 ; so I think we need to coordinate here.

Closes #380