### PR TITLE
chore: azure on master and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Prism
 
-<a href="https://codeclimate.com/github/stoplightio/prism/test_coverage"><img src="https://api.codeclimate.com/v1/badges/f5e363a7eb5b8f4e570f/test_coverage" /></a>
+[![Build Status](https://dev.azure.com/vncz/vncz/_apis/build/status/stoplightio.prism?branchName=master)](https://dev.azure.com/vncz/vncz/_build/latest?definitionId=1&branchName=master)
+[![CircleCI](https://circleci.com/gh/stoplightio/prism.svg?style=svg)](https://circleci.com/gh/stoplightio/prism)
 
 Prism is a set of packages for API mocking with **OpenAPI Specification v2** (formerly known as Swagger Specification) and **OpenAPI Specification v3**.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,8 @@
+trigger:
+  branches:
+    include:
+      - master
+      - refs/tags/*
 jobs:
   - job: test
     displayName: Test


### PR DESCRIPTION
1. Add badges, now the status in master is more important since we're doing additional stuff than regular PRs
2. Azure stuff runs on tags and master branch