### PR TITLE
Expand fs-ts in Prism's router 

### DIFF
--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -35,7 +35,7 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
         }
       },
 
-      process: (input: Input, c?: Config) => {
+      process: async (input: Input, c?: Config) => {
         // build the config for this request
         const configMerger = configMergerFactory(defaultConfig, customConfig, c);
         const configObj: Config | undefined = configMerger(input);
@@ -145,14 +145,14 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
             );
         }
 
-        return Promise.resolve({
+        return {
           input,
           output: undefined,
           validations: {
             input: [],
             output: [],
           },
-        });
+        };
       },
     };
   };

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -96,18 +96,16 @@ export function factory<Resource, Input, Output, Config, LoadOpts>(
                 ).map(output => ({ output, resource }));
               } else if (components.forwarder) {
                 // forward request and set output from response
-                return tryCatch(
-                  () =>
-                    components.forwarder!.forward(
-                      {
-                        resource,
-                        input: { validations: { input: inputValidations }, data: input },
-                        config: configObj,
-                      },
-                      defaultComponents.forwarder,
-                    ),
-                  e => toError(e),
-                ).map(output => ({ output, resource }));
+                return components.forwarder
+                  .fforward(
+                    {
+                      resource,
+                      input: { validations: { input: inputValidations }, data: input },
+                      config: configObj,
+                    },
+                    defaultComponents.forwarder,
+                  )
+                  .map(output => ({ output, resource }));
               }
 
               return left2v(new Error('Nor forwarder nor mocker has been selected. Something is wrong'));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import { IDiagnostic } from '@stoplight/types';
 import { Either } from 'fp-ts/lib/Either';
 import { Reader } from 'fp-ts/lib/Reader';
+import { TaskEither } from 'fp-ts/lib/TaskEither';
 import { Logger } from 'pino';
 export type IPrismDiagnostic = Omit<IDiagnostic, 'range'>;
 
@@ -51,6 +52,10 @@ export interface IForwarder<Resource, Input, Config, Output> {
     opts: { resource?: Resource; input: IPrismInput<Input>; config?: Config },
     defaultForwarder?: IForwarder<Resource, Input, Config, Output>,
   ) => Promise<Output>;
+  fforward: (
+    opts: { resource?: Resource; input: IPrismInput<Input>; config?: Config },
+    defaultForwarder?: IForwarder<Resource, Input, Config, Output>,
+  ) => TaskEither<Error, Output>;
 }
 
 export interface IMocker<Resource, Input, Config, Output> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,7 +43,7 @@ export interface IRouter<Resource, Input, Config> {
   route: (
     opts: { resources: Resource[]; input: Input; config?: Config },
     defaultRouter?: IRouter<Resource, Input, Config>,
-  ) => Resource;
+  ) => Either<Error, Resource>;
 }
 
 export interface IForwarder<Resource, Input, Config, Output> {

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -188,14 +188,9 @@ describe.each([['petstore.oas2.json'], ['petstore.oas3.json']])('server %s', fil
     checkErrorPayloadShape(response.payload);
   });
 
-  it.skip('should automagically provide the parameters when not provided in the query string and a default is defined', async () => {
-    const response = await server.fastify.inject({
-      method: 'GET',
-      url: '/pets/findByStatus',
-    });
-
-    expect(response.statusCode).toBe(200);
-  });
+  test.todo(
+    'should automagically provide the parameters when not provided in the query string and a default is defined',
+  );
 
   it('should support multiple param values', async () => {
     const response = await server.fastify.inject({

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -201,18 +201,8 @@ describe('Http Client .process', () => {
       });
     });
 
-    describe('GET /pet without an optional body parameter', () => {
-      // TODO will be fixed by https://stoplightio.atlassian.net/browse/SO-260
-      xit('returns 200 response', async () => {
-        const response = await prism.process({
-          method: 'get',
-          url: { path: '/pet' },
-        });
-
-        expect(response.output).toBeDefined();
-        expect(response.output!.statusCode).toEqual(200);
-      });
-    });
+    // TODO will be fixed by https://stoplightio.atlassian.net/browse/SO-260
+    test.todo('GET /pet without an optional body parameter');
 
     describe('when processing GET /pet/findByStatus', () => {
       it('with valid query params returns generated body', async () => {
@@ -269,24 +259,7 @@ describe('Http Client .process', () => {
       });
 
       // TODO: will be fixed by https://stoplightio.atlassian.net/browse/SO-259
-      xit('with invalid body returns validation errors', () => {
-        return expect(
-          prism.process({
-            method: 'get',
-            url: {
-              path: '/pet/findByStatus',
-              query: {
-                status: ['available'],
-              },
-            },
-            body: {
-              id: 'should not be a string',
-              status: 'should be one of "placed", "approved", "delivered"',
-              complete: 'should be a boolean',
-            },
-          }),
-        ).rejects.toThrowError(ProblemJsonError.fromTemplate(UNPROCESSABLE_ENTITY));
-      });
+      test.todo('with invalid body returns validation errors');
     });
   });
 

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -1,3 +1,4 @@
+import { assertLeft, assertRight } from '@stoplight/prism-http/src/__tests__/utils';
 import { IHttpOperation, IServer } from '@stoplight/types';
 import { Chance } from 'chance';
 import { IHttpMethod, ProblemJsonError } from '../../';
@@ -31,7 +32,7 @@ describe('http router', () => {
       const method = pickOneHttpMethod();
       const path = randomPath();
 
-      return expect(() =>
+      assertLeft(
         router.route({
           resources: [createResource(method, path, [])],
           input: {
@@ -42,11 +43,12 @@ describe('http router', () => {
             },
           },
         }),
-      ).toThrow(ProblemJsonError.fromTemplate(NO_SERVER_CONFIGURATION_PROVIDED_ERROR));
+        error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_SERVER_CONFIGURATION_PROVIDED_ERROR)),
+      );
     });
 
     test('should not match if no resources given', () => {
-      expect(() =>
+      assertLeft(
         router.route({
           resources: [],
           input: {
@@ -57,7 +59,8 @@ describe('http router', () => {
             },
           },
         }),
-      ).toThrow(ProblemJsonError.fromTemplate(NO_RESOURCE_PROVIDED_ERROR));
+        error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_RESOURCE_PROVIDED_ERROR)),
+      );
     });
 
     describe('given a resource', () => {
@@ -65,25 +68,27 @@ describe('http router', () => {
         const method = pickOneHttpMethod();
         const path = randomPath();
 
-        return expect(() =>
-          router.route({
-            resources: [createResource(method, path, [])],
-            input: {
-              method,
-              url: {
-                baseUrl: '',
-                path,
+        return expect(
+          router
+            .route({
+              resources: [createResource(method, path, [])],
+              input: {
+                method,
+                url: {
+                  baseUrl: '',
+                  path,
+                },
               },
-            },
-          }),
-        ).not.toThrowError();
+            })
+            .isRight(),
+        ).toBeTruthy();
       });
 
       test('given a concrete matching server and unmatched methods should not match', () => {
         const url = chance.url();
         const [resourceMethod, requestMethod] = pickSetOfHttpMethods(2);
 
-        return expect(() =>
+        assertLeft(
           router.route({
             resources: [
               createResource(resourceMethod, randomPath(), [
@@ -100,7 +105,8 @@ describe('http router', () => {
               },
             },
           }),
-        ).toThrow(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR));
+          error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR)),
+        );
       });
 
       describe('given matched methods', () => {
@@ -110,7 +116,7 @@ describe('http router', () => {
           const url = chance.url();
           const path = randomPath({ trailingSlash: false });
 
-          return expect(() =>
+          assertLeft(
             router.route({
               resources: [
                 createResource(method, path, [
@@ -127,7 +133,8 @@ describe('http router', () => {
                 },
               },
             }),
-          ).toThrow(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR));
+            error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR)),
+          );
         });
 
         test('given a concrete matching server and matched concrete path should match', async () => {
@@ -138,25 +145,26 @@ describe('http router', () => {
               url,
             },
           ]);
-          const resource = router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path,
+          assertRight(
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(expectedResource);
+            }),
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
 
         test(`given two resources with different servers
               when routing to third server
               with path matching of one of the resources
               throws an error`, () => {
-          return expect(() => {
+          assertLeft(
             router.route({
               resources: [
                 createResource(method, '/pet', [{ url: 'http://example.com/api' }]),
@@ -169,8 +177,9 @@ describe('http router', () => {
                   path: '/owner',
                 },
               },
-            });
-          }).toThrowError(ProblemJsonError.fromTemplate(NO_SERVER_MATCHED_ERROR));
+            }),
+            error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_SERVER_MATCHED_ERROR)),
+          );
         });
 
         test('given a templated matching server and matched concrete path should match', async () => {
@@ -187,18 +196,19 @@ describe('http router', () => {
             },
           ]);
 
-          const resource = router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                baseUrl: 'http://stoplight.io/v1',
-                path,
+          assertRight(
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: 'http://stoplight.io/v1',
+                  path,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(expectedResource);
+            }),
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
 
         test('given a templated matching server and matched templated path should match', async () => {
@@ -215,18 +225,19 @@ describe('http router', () => {
             },
           ]);
 
-          const resource = router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                baseUrl: 'http://stoplight.io/v1',
-                path: '/a/b',
+          assertRight(
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: 'http://stoplight.io/v1',
+                  path: '/a/b',
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(expectedResource);
+            }),
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
 
         test('given a concrete matching server and matched templated path should match', async () => {
@@ -239,18 +250,19 @@ describe('http router', () => {
             },
           ]);
 
-          const resource = router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path: requestPath,
+          assertRight(
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: requestPath,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(expectedResource);
+            }),
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
 
         test('given a concrete matching server and unmatched templated path should not match', () => {
@@ -263,7 +275,7 @@ describe('http router', () => {
             },
           ]);
 
-          return expect(() =>
+          assertLeft(
             router.route({
               resources: [expectedResource],
               input: {
@@ -274,7 +286,8 @@ describe('http router', () => {
                 },
               },
             }),
-          ).toThrow(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR));
+            error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR)),
+          );
         });
 
         test('given a concrete servers and mixed paths should match concrete path', async () => {
@@ -284,18 +297,19 @@ describe('http router', () => {
           const resourceWithConcretePath = createResource(method, concretePath, [{ url }]);
           const resourceWithTemplatedPath = createResource(method, templatedPath, [{ url }]);
 
-          const resource = router.route({
-            resources: [resourceWithTemplatedPath, resourceWithConcretePath],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path: concretePath,
+          assertRight(
+            router.route({
+              resources: [resourceWithTemplatedPath, resourceWithConcretePath],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: concretePath,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(resourceWithConcretePath);
+            }),
+            resource => expect(resource).toBe(resourceWithConcretePath),
+          );
         });
 
         test('given a concrete servers and templated paths should match first resource', async () => {
@@ -305,18 +319,19 @@ describe('http router', () => {
           const firstResource = createResource(method, templatedPathA, [{ url }]);
           const secondResource = createResource(method, templatedPathB, [{ url }]);
 
-          const resource = router.route({
-            resources: [firstResource, secondResource],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path: '/a/y',
+          assertRight(
+            router.route({
+              resources: [firstResource, secondResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: '/a/y',
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(firstResource);
+            }),
+            resource => expect(resource).toBe(firstResource),
+          );
         });
 
         test('given a concrete server and templated server should match concrete', async () => {
@@ -331,18 +346,19 @@ describe('http router', () => {
             { url: '{template}', variables: { template: { default: url, enum: [url] } } },
           ]);
 
-          const resource = router.route({
-            resources: [resourceWithConcreteMatch, resourceWithTemplatedMatch],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path,
+          assertRight(
+            router.route({
+              resources: [resourceWithConcreteMatch, resourceWithTemplatedMatch],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(resourceWithConcreteMatch);
+            }),
+            resource => expect(resource).toBe(resourceWithConcreteMatch),
+          );
         });
 
         test('given concrete servers should match by path', async () => {
@@ -352,18 +368,19 @@ describe('http router', () => {
           const resourceWithMatchingPath = createResource(method, matchingPath, [{ url }]);
           const resourceWithNonMatchingPath = createResource(method, nonMatchingPath, [{ url }]);
 
-          const resource = router.route({
-            resources: [resourceWithNonMatchingPath, resourceWithMatchingPath],
-            input: {
-              method,
-              url: {
-                baseUrl: url,
-                path: matchingPath,
+          assertRight(
+            router.route({
+              resources: [resourceWithNonMatchingPath, resourceWithMatchingPath],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: matchingPath,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(resourceWithMatchingPath);
+            }),
+            resource => expect(resource).toBe(resourceWithMatchingPath),
+          );
         });
 
         test('given empty baseUrl and concrete server it should match', () => {
@@ -371,7 +388,7 @@ describe('http router', () => {
           const url = 'concrete.com';
           const expectedResource = createResource(method, path, [{ url }]);
 
-          return expect(
+          assertRight(
             router.route({
               resources: [expectedResource],
               input: {
@@ -382,14 +399,15 @@ describe('http router', () => {
                 },
               },
             }),
-          ).toEqual(expectedResource);
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
 
         test('given baseUrl and concrete server and non-existing request baseUrl it should not match', () => {
           const path = randomPath({ includeTemplates: false });
           const url = 'concrete.com';
 
-          return expect(() =>
+          assertLeft(
             router.route({
               resources: [createResource(method, path, [{ url }])],
               input: {
@@ -400,7 +418,8 @@ describe('http router', () => {
                 },
               },
             }),
-          ).toThrowError(ProblemJsonError.fromTemplate(NO_SERVER_MATCHED_ERROR));
+            error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_SERVER_MATCHED_ERROR)),
+          );
         });
 
         test('given empty baseUrl and empty server url it should match', async () => {
@@ -408,35 +427,37 @@ describe('http router', () => {
           const url = '';
           const expectedResource = createResource(method, path, [{ url }]);
 
-          const resource = router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                baseUrl: '',
-                path,
+          assertRight(
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: '',
+                  path,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(expectedResource);
+            }),
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
 
         test('given no baseUrl and a server url it should ignore servers and match by path', async () => {
           const path = randomPath({ includeTemplates: false });
           const expectedResource = createResource(method, path, [{ url: 'www.stoplight.io/v1' }]);
 
-          const resource = router.route({
-            resources: [expectedResource],
-            input: {
-              method,
-              url: {
-                path,
+          assertRight(
+            router.route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  path,
+                },
               },
-            },
-          });
-
-          expect(resource).toBe(expectedResource);
+            }),
+            resource => expect(resource).toBe(expectedResource),
+          );
         });
       });
 
@@ -445,7 +466,7 @@ describe('http router', () => {
         const path = randomPath({ includeTemplates: false });
         const url = 'concrete.com';
 
-        return expect(() =>
+        assertLeft(
           router.route({
             resources: [createResource(method, path, [{ url }])],
             input: {
@@ -456,7 +477,8 @@ describe('http router', () => {
               },
             },
           }),
-        ).toThrowError(ProblemJsonError.fromTemplate(NO_METHOD_MATCHED_ERROR));
+          error => expect(error).toEqual(ProblemJsonError.fromTemplate(NO_METHOD_MATCHED_ERROR)),
+        );
       });
     });
   });


### PR DESCRIPTION
The following PR extends the usage of fp-ts to the routing package as well by basically making sure it does not throw exceptions anymore, but rather use the `Either` object to express an error object.

With this — the router and the mocker finally compose because the type match (they both return an `Either<Error, T>`.

Extend the `Either` usage to the router was indeed the easy part: https://github.com/stoplightio/prism/pull/402/files#diff-f9a10b37616fb5669ecd5218fc8535c9L16

The problem started when I started to integrate and try to compose the new function in the mega-file-to-split:

1. The whole flow is sync apart from the edge case when we need to employ the forwarder, and this requires an additional abstraction layer
https://github.com/stoplightio/prism/pull/402/files#diff-47c5dc2d65fd624c869f5f08d0cfb56aR45

2. What's really preventing from having a clean and functional flow is the validation process that's basically creating an empty array, giving it to the mocker and expecting to receive a filled array. This forces me to keep some stuff here and some stuff there; if the mocker could just return the validations, that'd improve the code a lot.

3. In order to keep the API compatible with what we have, I have to do some wrapping I'd like to avoid
https://github.com/stoplightio/prism/pull/402/files#diff-47c5dc2d65fd624c869f5f08d0cfb56aR98

---

That said, the funny thing is that, although this Pull Request is meant to be an improvement, you can argue that the code is effectively uglier than it is. (Well I do not think it is, but you mileage may vary)

The good news though is that — I'm not sure if you remember, we were discussing on how to refactor this part and nobody (me included) really came up with good ideas.

By trying to extend the functional parts to the router — I now know exactly what needs to be done and how to move forward. This is freaking awesome, to be honest.
