### PR TITLE
CORS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+## Added
+- Prism is now returning CORS headers by default and responding to all the preflights requests. You can disable this behaviour by running Prism with the `--cors` flag set to false #525
+
 ## Fixed
 - Prism now respects the `nullable` value for OpenAPI 3.x documents when generating examples
 - Prism now loads correctly OpenAPI 3.x documents with `encodings` with non specified `style` property

--- a/docs/guides/cors.md
+++ b/docs/guides/cors.md
@@ -2,7 +2,7 @@
 
 By default, Prism will handle all the [preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) responding with a `204` and with headers that will allow all the methods and all the origins.
 
-This is regardless of your OpenAPI Specification. A a request to `OPTIONS /api/todo` will receive a `204` as a response even though your OpenAPI document does not specify the `OPTIONS` verb for that endpoint, **and** even if your OpenAPI document does **not** have an `/api/todo` path at all.
+This is regardless of your OpenAPI description. A request to `OPTIONS /api/todo` will receive a `204` as a response even though your description document does not specify the `OPTIONS` verb for that endpoint, **and** even if your description document does **not** have an `/api/todo` path at all.
 
 Moreover, in case your OpenAPI Document specifies an `OPTIONS` handler (returning a custom status code or different headers) it will be **skipped** in favour of the default one.
 

--- a/docs/guides/cors.md
+++ b/docs/guides/cors.md
@@ -1,0 +1,9 @@
+# CORS
+
+By default, Prism will handle all the [preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) responding with a `204` and with headers that will allow all the methods and all the origins.
+
+This is regardless of your OpenAPI Specification. A a request to `OPTIONS /api/todo` will receive a `204` as a response even though your OpenAPI document does not specify the `OPTIONS` verb for that endpoint, **and** even if your OpenAPI document does **not** have an `/api/todo` path at all.
+
+Moreover, in case your OpenAPI Document speicifes an `OPTIONS` handler (returning a custom status code or different headers) it will be **skipped** in favour of the default one.
+
+You can disable the default CORS handler with a command line flag (`prism mock document.yml --cors=false`). In that case, you are in complete control of the response for all the preflight request, and you can decide which header you want to return.

--- a/docs/guides/cors.md
+++ b/docs/guides/cors.md
@@ -4,6 +4,6 @@ By default, Prism will handle all the [preflight requests](https://developer.moz
 
 This is regardless of your OpenAPI Specification. A a request to `OPTIONS /api/todo` will receive a `204` as a response even though your OpenAPI document does not specify the `OPTIONS` verb for that endpoint, **and** even if your OpenAPI document does **not** have an `/api/todo` path at all.
 
-Moreover, in case your OpenAPI Document speicifes an `OPTIONS` handler (returning a custom status code or different headers) it will be **skipped** in favour of the default one.
+Moreover, in case your OpenAPI Document specifies an `OPTIONS` handler (returning a custom status code or different headers) it will be **skipped** in favour of the default one.
 
 You can disable the default CORS handler with a command line flag (`prism mock document.yml --cors=false`). In that case, you are in complete control of the response for all the preflight request, and you can decide which header you want to return.

--- a/packages/cli/src/commands/__tests__/mock.spec.ts
+++ b/packages/cli/src/commands/__tests__/mock.spec.ts
@@ -25,6 +25,7 @@ describe('mock command', () => {
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
+      cors: false,
       host: '127.0.0.1',
       port: 4010,
     });
@@ -41,6 +42,7 @@ describe('mock command', () => {
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
+      cors: false,
       host: '127.0.0.1',
       port: 666,
     });
@@ -57,6 +59,7 @@ describe('mock command', () => {
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
+      cors: false,
       host: '0.0.0.0',
       port: 4010,
     });
@@ -72,6 +75,7 @@ describe('mock command', () => {
     expect(createMultiProcessPrism).not.toHaveBeenCalled();
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
+      cors: false,
       dynamic: false,
       host: '0.0.0.0',
       port: 666,
@@ -89,6 +93,7 @@ describe('mock command', () => {
     expect(createMultiProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
+      cors: false,
       host: '0.0.0.0',
       port: 4010,
     });

--- a/packages/cli/src/commands/__tests__/mock.spec.ts
+++ b/packages/cli/src/commands/__tests__/mock.spec.ts
@@ -25,7 +25,7 @@ describe('mock command', () => {
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
-      cors: false,
+      cors: true,
       host: '127.0.0.1',
       port: 4010,
     });
@@ -42,7 +42,7 @@ describe('mock command', () => {
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
-      cors: false,
+      cors: true,
       host: '127.0.0.1',
       port: 666,
     });
@@ -59,7 +59,7 @@ describe('mock command', () => {
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
-      cors: false,
+      cors: true,
       host: '0.0.0.0',
       port: 4010,
     });
@@ -75,7 +75,7 @@ describe('mock command', () => {
     expect(createMultiProcessPrism).not.toHaveBeenCalled();
     expect(createSingleProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
-      cors: false,
+      cors: true,
       dynamic: false,
       host: '0.0.0.0',
       port: 666,
@@ -93,7 +93,7 @@ describe('mock command', () => {
     expect(createMultiProcessPrism).toHaveBeenLastCalledWith({
       operations: [],
       dynamic: false,
-      cors: false,
+      cors: true,
       host: '0.0.0.0',
       port: 4010,
     });

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -46,7 +46,7 @@ const mockCommand: CommandModule = {
         cors: {
           description: 'Enables CORS headers.',
           boolean: true,
-          default: false,
+          default: true,
         },
 
         multiprocess: {

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -43,6 +43,12 @@ const mockCommand: CommandModule = {
           default: false,
         },
 
+        cors: {
+          description: 'Enables CORS headers.',
+          boolean: true,
+          default: false,
+        },
+
         multiprocess: {
           alias: 'm',
           description: 'Forks the http server from the CLI for faster log processing.',
@@ -51,15 +57,15 @@ const mockCommand: CommandModule = {
         },
       }),
   handler: parsedArgs => {
-    const { multiprocess, dynamic, port, host, operations } = (parsedArgs as unknown) as CreatePrismOptions & {
+    const { multiprocess, dynamic, port, host, cors, operations } = (parsedArgs as unknown) as CreatePrismOptions & {
       multiprocess: boolean;
     };
 
     if (multiprocess) {
-      return createMultiProcessPrism({ dynamic, port, host, operations });
+      return createMultiProcessPrism({ cors, dynamic, port, host, operations });
     }
 
-    return createSingleProcessPrism({ dynamic, port, host, operations });
+    return createSingleProcessPrism({ cors, dynamic, port, host, operations });
   },
 };
 

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -15,14 +15,6 @@ export async function createMultiProcessPrism(options: CreatePrismOptions) {
 
     signale.await({ prefix: chalk.bgWhiteBright.black('[CLI]'), message: 'Starting Prism…' });
 
-    if (options.dynamic) {
-      logCLIMessage(`Dynamic example generation ${chalk.green('enabled')}.`);
-    }
-
-    if (options.cors) {
-      logCLIMessage(`CORS ${chalk.green('enabled')}. OPTIONS verbs in the specification will be skipped.`);
-    }
-
     const worker = cluster.fork();
 
     if (worker.process.stdout) {
@@ -36,14 +28,6 @@ export async function createMultiProcessPrism(options: CreatePrismOptions) {
 
 export function createSingleProcessPrism(options: CreatePrismOptions) {
   signale.await({ prefix: chalk.bgWhiteBright.black('[CLI]'), message: 'Starting Prism…' });
-
-  if (options.dynamic) {
-    logCLIMessage(`Dynamic example generation ${chalk.green('enabled')}.`);
-  }
-
-  if (options.cors) {
-    logCLIMessage(`CORS ${chalk.green('enabled')}. OPTIONS verbs in the specification will be skipped.`);
-  }
 
   const logStream = new PassThrough();
   const logInstance = createLogger('CLI', undefined, logStream);
@@ -89,13 +73,6 @@ function pipeOutputToSignale(stream: Readable) {
   stream.pipe(split(JSON.parse)).on('data', (logLine: LogDescriptor) => {
     const logLevelType = logLevels.labels[logLine.level];
     signale[logLevelType]({ prefix: constructPrefix(logLine), message: logLine.msg });
-  });
-}
-
-function logCLIMessage(message: string) {
-  signale.star({
-    prefix: chalk.bgWhiteBright.black('[CLI]'),
-    message,
   });
 }
 

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -19,6 +19,10 @@ export async function createMultiProcessPrism(options: CreatePrismOptions) {
       logCLIMessage(`Dynamic example generation ${chalk.green('enabled')}.`);
     }
 
+    if (options.cors) {
+      logCLIMessage(`CORS ${chalk.green('enabled')}. OPTIONS verbs in the specification will be skipped.`);
+    }
+
     const worker = cluster.fork();
 
     if (worker.process.stdout) {
@@ -37,6 +41,10 @@ export function createSingleProcessPrism(options: CreatePrismOptions) {
     logCLIMessage(`Dynamic example generation ${chalk.green('enabled')}.`);
   }
 
+  if (options.cors) {
+    logCLIMessage(`CORS ${chalk.green('enabled')}. OPTIONS verbs in the specification will be skipped.`);
+  }
+
   const logStream = new PassThrough();
   const logInstance = createLogger('CLI', undefined, logStream);
   pipeOutputToSignale(logStream);
@@ -50,7 +58,7 @@ async function createPrismServerWithLogger(options: CreatePrismOptions, logInsta
   }
 
   const server = createHttpServer(options.operations, {
-    config: { mock: { dynamic: options.dynamic } },
+    config: { cors: options.cors, mock: { dynamic: options.dynamic } },
     components: { logger: logInstance.child({ name: 'HTTP SERVER' }) },
   });
 
@@ -93,6 +101,7 @@ function logCLIMessage(message: string) {
 
 export type CreatePrismOptions = {
   dynamic: boolean;
+  cors: boolean;
   host?: string;
   port: number;
   operations: IHttpOperation[];

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.15",
-    "pino": "^5.13.1",
+    "pino": "^5.13.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -24,6 +24,7 @@
     "fast-xml-parser": "^3.12.19",
     "fastify": "^2.7.0",
     "fastify-accepts-serializer": "^2.0.1",
+    "fastify-cors": "^2.1.3",
     "fastify-formbody": "^3.1.0",
     "tslib": "^1.10.0",
     "type-is": "^1.6.18"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -21,8 +21,8 @@
   "dependencies": {
     "@stoplight/prism-core": "^3.0.3",
     "@stoplight/prism-http": "^3.0.3",
-    "fast-xml-parser": "^3.12.19",
-    "fastify": "^2.7.0",
+    "fast-xml-parser": "^3.12.20",
+    "fastify": "^2.7.1",
     "fastify-accepts-serializer": "^2.0.1",
     "fastify-cors": "^2.1.3",
     "fastify-formbody": "^3.1.0",

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -4,6 +4,7 @@ import { IHttpOperation } from '@stoplight/types';
 import * as fastify from 'fastify';
 // @ts-ignore
 import * as fastifyAcceptsSerializer from 'fastify-accepts-serializer';
+import * as fastifyCors from 'fastify-cors';
 import * as formbodyParser from 'fastify-formbody';
 import { IncomingMessage, ServerResponse } from 'http';
 import * as typeIs from 'type-is';
@@ -22,6 +23,8 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     .register(formbodyParser)
     .register(fastifyAcceptsSerializer, { serializers });
 
+  if (opts.config.cors) server.register(fastifyCors);
+
   server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
     if (typeIs(req, ['application/*+json'])) {
       try {
@@ -36,11 +39,17 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     return done(error);
   });
 
-  const mergedConfig = configMergerFactory({ mock: { dynamic: false } }, config, getHttpConfigFromRequest);
+  const mergedConfig = configMergerFactory({ cors: false, mock: { dynamic: false } }, config, getHttpConfigFromRequest);
 
   const prism = createInstance(mergedConfig, components);
 
-  server.all('*', {}, replyHandler(prism));
+  opts.config.cors
+    ? server.route({
+        url: '*',
+        method: ['GET', 'DELETE', 'HEAD', 'PATCH', 'POST', 'PUT'],
+        handler: replyHandler(prism),
+      })
+    : server.all('*', replyHandler(prism));
 
   const prismServer: IPrismHttpServer = {
     get prism() {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -26,7 +26,7 @@
     "fp-ts": "^2.0.3",
     "json-schema-faker": "json-schema-faker/json-schema-faker",
     "openapi-sampler": "^1.0.0-beta.15",
-    "pino": "^5.13.1",
+    "pino": "^5.13.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -128,7 +128,7 @@ describe('Http Client .process', () => {
     });
 
     describe('mocking is off', () => {
-      const config: IHttpConfig = { mock: false };
+      const config: IHttpConfig = { mock: false, cors: false };
       const baseUrl = 'http://stoplight.io';
       const serverReply = 'hello world';
 

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -25,7 +25,7 @@ const createInstance = (
   overrides?: PickRequired<TPrismHttpComponents, 'logger'>,
 ) => {
   return factory<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>(
-    { mock: { dynamic: false } },
+    { cors: false, mock: { dynamic: false } },
     {
       router,
       forwarder,

--- a/packages/http/src/mocker/HttpMocker.ts
+++ b/packages/http/src/mocker/HttpMocker.ts
@@ -38,7 +38,7 @@ export class HttpMocker
       withLogger(logger => {
         // setting default values
         const acceptMediaType = input.data.headers && caseless(input.data.headers).get('accept');
-        config = config || { mock: false };
+        config = config || { mock: false, cors: false };
         const mockConfig: IHttpOperationConfig =
           config.mock === false ? { dynamic: false } : Object.assign({}, config.mock);
 

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -198,7 +198,7 @@ describe('HttpMocker', () => {
             const response = await httpMocker.mock({
               input: mockInput,
               resource: mockResource,
-              config: { mock: { dynamic: true } },
+              config: { cors: false, mock: { dynamic: true } },
             })(logger);
 
             expect(JSONSchemaGenerator.generate).toHaveBeenCalled();
@@ -226,7 +226,7 @@ describe('HttpMocker', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,
-              config: { mock: { dynamic: false, exampleKey: 'test key' } },
+              config: { cors: false, mock: { dynamic: false, exampleKey: 'test key' } },
             })(logger);
 
             it('should return the selected example', () => {
@@ -244,7 +244,7 @@ describe('HttpMocker', () => {
             const response = httpMocker.mock({
               input: mockInput,
               resource: mockResource,
-              config: { mock: { dynamic: false } },
+              config: { cors: false, mock: { dynamic: false } },
             })(logger);
 
             it('returns the first example', () => {
@@ -285,7 +285,7 @@ describe('HttpMocker', () => {
             return httpMocker.mock({
               input: mockInput,
               resource: createOperationWithSchema(schema),
-              config: { mock: { dynamic: false } },
+              config: { cors: false, mock: { dynamic: false } },
             })(logger);
           }
 

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -17,6 +17,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               mediaTypes: ['text/plain'],
@@ -32,6 +33,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               mediaTypes: ['text/funky'],
@@ -49,6 +51,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -68,6 +71,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -86,6 +90,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               exampleKey: 'bear',
@@ -101,6 +106,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               exampleKey: 'second',
@@ -119,6 +125,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -134,6 +141,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               code: '205',
@@ -149,6 +157,7 @@ describe('http mocker', () => {
           resource: httpOperations[0],
           input: httpRequests[0],
           config: {
+            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -222,6 +231,7 @@ describe('http mocker', () => {
             resource: httpOperations[1],
             input: httpRequests[0],
             config: {
+              cors: false,
               mock: {
                 dynamic: true,
               },

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -18,6 +18,7 @@ export interface IHttpOperationConfig {
 
 export interface IHttpConfig extends IPrismConfig {
   mock: false | IHttpOperationConfig;
+  cors: boolean;
 
   validate?: {
     request?:

--- a/packages/http/src/validator/__tests__/functional.spec.ts
+++ b/packages/http/src/validator/__tests__/functional.spec.ts
@@ -37,7 +37,7 @@ describe('HttpValidator', () => {
           await validator.validateInput({
             resource: httpOperations[2],
             input: BAD_INPUT,
-            config: { mock: false, validate: { request: { headers: true, query: false, body: false } } },
+            config: { cors: false, mock: false, validate: { request: { headers: true, query: false, body: false } } },
           }),
         ).toMatchSnapshot();
       });
@@ -76,7 +76,7 @@ describe('HttpValidator', () => {
                 api_Key: 'ha',
               },
             },
-            config: { mock: false, validate: { request: { headers: true, query: false, body: false } } },
+            config: { cors: false, mock: false, validate: { request: { headers: true, query: false, body: false } } },
           }),
         ).toEqual([]);
       });
@@ -88,7 +88,7 @@ describe('HttpValidator', () => {
           await validator.validateInput({
             resource: httpOperations[2],
             input: BAD_INPUT,
-            config: { mock: false, validate: { request: { headers: false, query: true, body: false } } },
+            config: { cors: false, mock: false, validate: { request: { headers: false, query: true, body: false } } },
           }),
         ).toMatchSnapshot();
       });
@@ -99,7 +99,7 @@ describe('HttpValidator', () => {
             await validator.validateInput({
               resource: httpOperations[0],
               input: GOOD_INPUT,
-              config: { mock: false, validate: { request: { headers: false, query: true, body: false } } },
+              config: { cors: false, mock: false, validate: { request: { headers: false, query: true, body: false } } },
             }),
           ).toEqual([]);
         });
@@ -112,7 +112,7 @@ describe('HttpValidator', () => {
           await validator.validateInput({
             resource: httpOperations[2],
             input: BAD_INPUT,
-            config: { mock: false, validate: { request: { headers: false, query: false, body: true } } },
+            config: { cors: false, mock: false, validate: { request: { headers: false, query: false, body: true } } },
           }),
         ).toMatchSnapshot();
       });
@@ -124,7 +124,7 @@ describe('HttpValidator', () => {
           await validator.validateInput({
             resource: httpOperations[2],
             input: BAD_INPUT,
-            config: { mock: false, validate: { request: false } },
+            config: { cors: false, mock: false, validate: { request: false } },
           }),
         ).toMatchSnapshot();
       });
@@ -144,7 +144,7 @@ describe('HttpValidator', () => {
           await validator.validateOutput({
             resource: httpOperations[1],
             output: BAD_OUTPUT,
-            config: { mock: false, validate: { response: { headers: true, body: false } } },
+            config: { cors: false, mock: false, validate: { response: { headers: true, body: false } } },
           }),
         ).toMatchSnapshot();
       });
@@ -156,7 +156,7 @@ describe('HttpValidator', () => {
           await validator.validateOutput({
             resource: httpOperations[1],
             output: BAD_OUTPUT,
-            config: { mock: false, validate: { response: { headers: false, body: true } } },
+            config: { cors: false, mock: false, validate: { response: { headers: false, body: true } } },
           }),
         ).toMatchSnapshot();
       });
@@ -168,7 +168,7 @@ describe('HttpValidator', () => {
           await validator.validateOutput({
             resource: httpOperations[1],
             output: BAD_OUTPUT,
-            config: { mock: false, validate: { response: false } },
+            config: { cors: false, mock: false, validate: { response: false } },
           }),
         ).toMatchSnapshot();
       });

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -51,7 +51,7 @@ describe('HttpValidator', () => {
               extendResource,
             ),
             input: { method: 'get', url: { path: '/' } },
-            config: { mock: { dynamic: false }, validate: { request: { body: true } } },
+            config: { cors: false, mock: { dynamic: false }, validate: { request: { body: true } } },
           }),
         ).toEqual(expectedError);
 
@@ -124,7 +124,7 @@ describe('HttpValidator', () => {
               extendResource,
             ),
             input: { method: 'get', url: { path: '/' } },
-            config: { mock: { dynamic: false }, validate: { request: { headers: true } } },
+            config: { cors: false, mock: { dynamic: false }, validate: { request: { headers: true } } },
           }),
         ).toEqual([mockError]);
 
@@ -168,7 +168,7 @@ describe('HttpValidator', () => {
               extendResource,
             ),
             input: Object.assign({ method: 'get', url: { path: '/', query: {} } }, extendInput),
-            config: { mock: { dynamic: false }, validate: { request: { query: true } } },
+            config: { cors: false, mock: { dynamic: false }, validate: { request: { query: true } } },
           }),
         ).toEqual([mockError]);
 
@@ -210,7 +210,7 @@ describe('HttpValidator', () => {
               request: {},
               responses: [{ code: '200' }],
             },
-            config: { mock: { dynamic: false }, validate: { response: { body: true } } },
+            config: { cors: false, mock: { dynamic: false }, validate: { response: { body: true } } },
           }),
         ).toEqual([]);
 
@@ -235,7 +235,7 @@ describe('HttpValidator', () => {
                 responses: [{ code: '200' }],
               },
               output: { statusCode: 200 },
-              config: { mock: { dynamic: false }, validate: { response: { body: true } } },
+              config: { cors: false, mock: { dynamic: false }, validate: { response: { body: true } } },
             }),
           ).toEqual([mockError]);
 
@@ -262,7 +262,7 @@ describe('HttpValidator', () => {
                 responses: [{ code: '200' }],
               },
               output: { statusCode: 200 },
-              config: { mock: { dynamic: false }, validate: { response: { headers: true } } },
+              config: { cors: false, mock: { dynamic: false }, validate: { response: { headers: true } } },
             }),
           ).toEqual([mockError]);
 

--- a/packages/http/src/validator/utils/__tests__/config.spec.ts
+++ b/packages/http/src/validator/utils/__tests__/config.spec.ts
@@ -20,14 +20,16 @@ describe('resolveResponseValidationConfig()', () => {
   describe('config is set', () => {
     describe('config.validate is not set', () => {
       it('resolves to default config', () => {
-        expect(resolveResponseValidationConfig({ mock: { dynamic: false } })).toEqual(defaultEnabledConfig);
+        expect(resolveResponseValidationConfig({ cors: false, mock: { dynamic: false } })).toEqual(
+          defaultEnabledConfig,
+        );
       });
     });
 
     describe('config.validate is set', () => {
       describe('config.validate.response is not set', () => {
         it('resolves to default config', () => {
-          expect(resolveResponseValidationConfig({ mock: { dynamic: false }, validate: {} })).toEqual(
+          expect(resolveResponseValidationConfig({ cors: false, mock: { dynamic: false }, validate: {} })).toEqual(
             defaultEnabledConfig,
           );
         });
@@ -38,7 +40,11 @@ describe('resolveResponseValidationConfig()', () => {
           describe('response is set to true', () => {
             it('resolves to all-enabled config', () => {
               expect(
-                resolveResponseValidationConfig({ mock: { dynamic: false }, validate: { response: true } }),
+                resolveResponseValidationConfig({
+                  cors: false,
+                  mock: { dynamic: false },
+                  validate: { response: true },
+                }),
               ).toEqual(defaultEnabledConfig);
             });
           });
@@ -46,7 +52,11 @@ describe('resolveResponseValidationConfig()', () => {
           describe('response is set to false', () => {
             it('response to all-disabled config', () => {
               expect(
-                resolveResponseValidationConfig({ mock: { dynamic: false }, validate: { response: false } }),
+                resolveResponseValidationConfig({
+                  cors: false,
+                  mock: { dynamic: false },
+                  validate: { response: false },
+                }),
               ).toEqual(defaultDisabledConfig);
             });
           });
@@ -55,9 +65,9 @@ describe('resolveResponseValidationConfig()', () => {
         describe('response is an object', () => {
           describe('none parameters are set', () => {
             it('resolves to default config', () => {
-              expect(resolveResponseValidationConfig({ mock: { dynamic: false }, validate: { response: {} } })).toEqual(
-                defaultEnabledConfig,
-              );
+              expect(
+                resolveResponseValidationConfig({ cors: false, mock: { dynamic: false }, validate: { response: {} } }),
+              ).toEqual(defaultEnabledConfig);
             });
           });
 
@@ -65,6 +75,7 @@ describe('resolveResponseValidationConfig()', () => {
             it('resolves to given config', () => {
               expect(
                 resolveResponseValidationConfig({
+                  cors: false,
                   mock: { dynamic: false },
                   validate: { response: defaultDisabledConfig },
                 }),
@@ -101,14 +112,14 @@ describe('resolveRequestValidationConfig()', () => {
   describe('config is set', () => {
     describe('config.validate is not set', () => {
       it('resolves to default config', () => {
-        expect(resolveRequestValidationConfig({ mock: { dynamic: false } })).toEqual(defaultEnabledConfig);
+        expect(resolveRequestValidationConfig({ cors: false, mock: { dynamic: false } })).toEqual(defaultEnabledConfig);
       });
     });
 
     describe('config.validate is set', () => {
       describe('config.validate.request is not set', () => {
         it('resolves to default config', () => {
-          expect(resolveRequestValidationConfig({ mock: { dynamic: false }, validate: {} })).toEqual(
+          expect(resolveRequestValidationConfig({ cors: false, mock: { dynamic: false }, validate: {} })).toEqual(
             defaultEnabledConfig,
           );
         });
@@ -118,16 +129,16 @@ describe('resolveRequestValidationConfig()', () => {
         describe('request is a boolean', () => {
           describe('request is set to true', () => {
             it('resolves to all-enabled config', () => {
-              expect(resolveRequestValidationConfig({ mock: { dynamic: false }, validate: { request: true } })).toEqual(
-                defaultEnabledConfig,
-              );
+              expect(
+                resolveRequestValidationConfig({ cors: false, mock: { dynamic: false }, validate: { request: true } }),
+              ).toEqual(defaultEnabledConfig);
             });
           });
 
           describe('request is set to false', () => {
             it('request to all-disabled config', () => {
               expect(
-                resolveRequestValidationConfig({ mock: { dynamic: false }, validate: { request: false } }),
+                resolveRequestValidationConfig({ cors: false, mock: { dynamic: false }, validate: { request: false } }),
               ).toEqual(defaultDisabledConfig);
             });
           });
@@ -136,9 +147,9 @@ describe('resolveRequestValidationConfig()', () => {
         describe('request is an object', () => {
           describe('none parameters are set', () => {
             it('resolves to default config', () => {
-              expect(resolveRequestValidationConfig({ mock: { dynamic: false }, validate: { request: {} } })).toEqual(
-                defaultEnabledConfig,
-              );
+              expect(
+                resolveRequestValidationConfig({ cors: false, mock: { dynamic: false }, validate: { request: {} } }),
+              ).toEqual(defaultEnabledConfig);
             });
           });
 
@@ -146,6 +157,7 @@ describe('resolveRequestValidationConfig()', () => {
             it('resolves to default config', () => {
               expect(
                 resolveRequestValidationConfig({
+                  cors: false,
                   mock: { dynamic: false },
                   validate: { request: defaultDisabledConfig },
                 }),

--- a/test-harness/specs/cors/cors-headers-disabled.txt
+++ b/test-harness/specs/cors/cors-headers-disabled.txt
@@ -1,0 +1,24 @@
+====test====
+If I run Prism with a document that has not the OPTION verb handled
+And the CORS support is not enabled
+And I do a request with OPTIONS as verb
+I should get a 404 response
+====spec====
+swagger: "2.0"
+paths:
+  /todos:
+    get:
+      responses:
+        200:
+          description: ok
+          schema:
+            type: string
+            example: ok
+====server====
+mock --cors=false -p 4010
+====command====
+curl -i -X OPTIONS http://localhost:4010/todos
+====expect====
+HTTP/1.1 405 Method Not Allowed
+
+{"type":"https://stoplight.io/prism/errors#NO_METHOD_MATCHED_ERROR","title":"Route resolved, but no path matched.","status":405,"detail":"The route /todos has been matched, but it does not have \"options\" method defined"}

--- a/test-harness/specs/cors/cors-headers-disabled.txt
+++ b/test-harness/specs/cors/cors-headers-disabled.txt
@@ -2,7 +2,7 @@
 If I run Prism with a document that has not the OPTION verb handled
 And the CORS support is not enabled
 And I do a request with OPTIONS as verb
-I should get a 404 response
+I should get a 405 response
 ====spec====
 swagger: "2.0"
 paths:

--- a/test-harness/specs/cors/cors-headers-precedence.txt
+++ b/test-harness/specs/cors/cors-headers-precedence.txt
@@ -1,0 +1,24 @@
+====test====
+If I run Prism with a document that has the OPTION verb handled
+And the CORS support is enabled
+And I do a request with OPTIONS as verb
+I should get a 204 response with the CORS headers ignoring the specification one
+====spec====
+swagger: "2.0"
+paths:
+  /todos:
+    options:
+      responses:
+        200:
+          description: ok
+          schema:
+            type: string
+            example: ok
+====server====
+mock -p 4010
+====command====
+curl -i -X OPTIONS http://localhost:4010/todos
+====expect====
+HTTP/1.1 204 No Content
+access-control-allow-origin: *
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE

--- a/test-harness/specs/cors/cors-headers.txt
+++ b/test-harness/specs/cors/cors-headers.txt
@@ -1,0 +1,24 @@
+====test====
+If I run Prism with a document that has not the OPTION verb handled
+And the CORS support is enabled
+And I do a request with OPTIONS as verb
+I should get a 204 response with the CORS headers
+====spec====
+swagger: "2.0"
+paths:
+  /todos:
+    get:
+      responses:
+        200:
+          description: ok
+          schema:
+            type: string
+            example: ok
+====server====
+mock -p 4010
+====command====
+curl -i -X OPTIONS http://localhost:4010/todos
+====expect====
+HTTP/1.1 204 No Content
+access-control-allow-origin: *
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE

--- a/yarn.lock
+++ b/yarn.lock
@@ -1488,7 +1488,7 @@ ajv-oai@^1.0.0:
     ajv "^6.1.1"
     decimal.js "^9.0.1"
 
-ajv@^6.1.1, ajv@^6.5.5, ajv@^6.8.1, ajv@^6.9.2:
+ajv@^6.1.1, ajv@^6.5.5, ajv@^6.8.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -3137,10 +3137,10 @@ fast-safe-stringify@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
   integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
 
-fast-xml-parser@^3.12.19:
-  version "3.12.19"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.12.19.tgz#be70984fc61d870ce72bbcda474a0ffe6440524e"
-  integrity sha512-DB93FtI9FCn4DDxjDSFW91vdAo+Y1La6jNDRxKCO3F4WxyodeHtXo/HwWum/Qy/XunTdXEAdwiSVYAFvHeJOIw==
+fast-xml-parser@^3.12.20:
+  version "3.12.20"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.12.20.tgz#1bf60f1860b06bd1e5cad02736ce96714bdf81ed"
+  integrity sha512-viadHdefuuqkyJWUhF2r2Ymb5LJ0T7uQhzSRv4OZzYxpoPQnY05KtaX0pLkolabD7tLzIE8q/OytIAEhqPyYbw==
   dependencies:
     nimnjs "^1.3.2"
 
@@ -3190,20 +3190,20 @@ fastify-plugin@^1.0.0, fastify-plugin@^1.2.1, fastify-plugin@^1.5.0:
   dependencies:
     semver "^6.0.0"
 
-fastify@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/fastify/-/fastify-2.7.0.tgz#088f0123f6e85e0d64bdce79fcb577ba6603e213"
-  integrity sha512-TFQoHKMXfE8Of9W/5qH7PUSW0pk98tnS2IWUgYNY4FbiD9U/La1VVlaaV8nXd52Sm+3dD3A0QncoRlPKpWlkiA==
+fastify@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-2.7.1.tgz#09ec9dfaa67b453f90537501a1e148b0d98486ac"
+  integrity sha512-ScKPXD84lkdCgz7q0zjyBr1aLxKbXRt9HYL3XIt/L8ZD2f3fAcsLEyQ2/rHxLUzLGjPlEjIvprWUL3RZvlLRLw==
   dependencies:
     abstract-logging "^1.0.0"
-    ajv "^6.9.2"
+    ajv "^6.10.2"
     avvio "^6.1.1"
     fast-json-stringify "^1.15.0"
     find-my-way "^2.0.0"
     flatstr "^1.0.12"
-    light-my-request "^3.2.0"
+    light-my-request "^3.4.1"
     middie "^4.0.1"
-    pino "^5.11.1"
+    pino "^5.13.1"
     proxy-addr "^2.0.4"
     readable-stream "^3.1.1"
     rfdc "^1.1.2"
@@ -5160,10 +5160,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-light-my-request@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-3.3.0.tgz#5cdb3c75c50bc57429f20b08e3be805662e23232"
-  integrity sha512-dLtwhjzbuHJ+KMMUBSlVid6Iqxx+KKvULWLnBD06WMgPHxiPkEh1cVyj+Xc8HGU64hULlSw/sZVCdFsvjNQeNA==
+light-my-request@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-3.4.1.tgz#c30087005f6ae64ce5ef92c2484b1ab93c71ad3e"
+  integrity sha512-E1zMvRWjqsaCS60dTkD7c//xKV1KOFD2zo92Ru3o3e95lCfQSDCC9aS8MZm1V+zXaA/SeKDwK9gvrfaCseTusg==
   dependencies:
     ajv "^6.8.1"
     readable-stream "^3.1.1"
@@ -6565,22 +6565,22 @@ pino-std-serializers@^2.3.0:
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz#7fefc2dba56700494ac8b9ce0d027f7b648e438f"
   integrity sha512-v/JglhO0aFcvkMV9VUxhgyuJo8K1si857Ww86Tx8H2cjC/kp0ndzzcF6Vbxr4RgKFYJdHfLVpEuD55znMZuxnw==
 
-pino@^5.11.1:
-  version "5.12.5"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-5.12.5.tgz#4cf008b91a13338a4198277a30a9b5eef8ab81b7"
-  integrity sha512-Y493vt9ci7Jez3WZ/aUArijTQZXbHgWvDB3TMZlTu731p2kan/qyJk5k46aveEmYFnTlEommc+PSncUcuiMrBg==
+pino@^5.13.1:
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-5.13.1.tgz#583eb92be0ccbaa2a98ab2842817a1fa103cb26e"
+  integrity sha512-IxusG28L0g50uuf21kZELypdFOeNrJ/kRhktdi7LtdZQWCxLliMxG5iOrGUQ/ng7MiJ4XqXi/hfyXwZeKc1MxA==
   dependencies:
     fast-redact "^1.4.4"
     fast-safe-stringify "^2.0.6"
     flatstr "^1.0.9"
     pino-std-serializers "^2.3.0"
     quick-format-unescaped "^3.0.2"
-    sonic-boom "^0.7.3"
+    sonic-boom "^0.7.5"
 
-pino@^5.13.1:
-  version "5.13.1"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-5.13.1.tgz#583eb92be0ccbaa2a98ab2842817a1fa103cb26e"
-  integrity sha512-IxusG28L0g50uuf21kZELypdFOeNrJ/kRhktdi7LtdZQWCxLliMxG5iOrGUQ/ng7MiJ4XqXi/hfyXwZeKc1MxA==
+pino@^5.13.2:
+  version "5.13.2"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-5.13.2.tgz#773416c9764634276e7b2ae021357679ff7b5634"
+  integrity sha512-WwOSCy36/gWhinsqWqAnuwIi2WtcH+jvoyeLm3bjUALIrzWIst0AovQjK4jVvSN2l64KFPfi3gd2fjsTovjdLQ==
   dependencies:
     fast-redact "^1.4.4"
     fast-safe-stringify "^2.0.6"
@@ -7426,13 +7426,6 @@ socks@~2.3.2:
   dependencies:
     ip "^1.1.5"
     smart-buffer "4.0.2"
-
-sonic-boom@^0.7.3:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-0.7.4.tgz#dc1740a900cf8646471f6ac1f4933a5c66c0ca60"
-  integrity sha512-8JRAJg0RxZtFLQMxolwETvWd2JSlH3ZGo/Z4xPxMbpqF14xCgVYPVeFCFOR3zyr3pcfG82QDVj6537Sx5ZWdNw==
-  dependencies:
-    flatstr "^1.0.9"
 
 sonic-boom@^0.7.5:
   version "0.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3160,6 +3160,14 @@ fastify-accepts@>=0.5.0:
     accepts "^1.3.3"
     fastify-plugin "^0.2.1"
 
+fastify-cors@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fastify-cors/-/fastify-cors-2.1.3.tgz#5ae8fcc620a47270cd68d46acc3b8dd7919b538b"
+  integrity sha512-ZHFzKn1DddymsxzvdtjEQfkuMfGgwcp++FKuTTMmAN2KFB7hJRmOINffjfRdmUcgXdE4LoSy5XJROWKx/b+CPQ==
+  dependencies:
+    fastify-plugin "^1.5.0"
+    vary "^1.1.2"
+
 fastify-formbody@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fastify-formbody/-/fastify-formbody-3.1.0.tgz#604cdafdb9e3af6068e6d9940985baf692d6e922"
@@ -3175,7 +3183,7 @@ fastify-plugin@^0.2.1:
   dependencies:
     semver "^5.4.1"
 
-fastify-plugin@^1.0.0, fastify-plugin@^1.2.1:
+fastify-plugin@^1.0.0, fastify-plugin@^1.2.1, fastify-plugin@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-1.6.0.tgz#c8198b08608f20c502b5dad26b36e9ae27206d7c"
   integrity sha512-lFa9txg8LZx4tljj33oG53nUXhVg0baZxtP9Pxi0dJmI0NQxzkDk5DS9kr3D7iMalUAp3mvIq16OQumc7eIvLA==
@@ -8265,6 +8273,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+vary@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
+  integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
This PR installs the CORS middleware to the Prism instance when the `--cors` flag is enabled (which is enabled by default).

Docs and changeling added as well


Closes #412