### PR TITLE
[WIP] Return the defined 204 response regardless of content-type / accept header

### DIFF
--- a/test-harness/specs/204-no-content.oas2.txt
+++ b/test-harness/specs/204-no-content.oas2.txt
@@ -1,0 +1,21 @@
+====test====
+When I send a request to an operation
+And this operation has only a 204 response defined
+Then I should get back the 204 response code
+====spec====
+swagger: "2.0"
+paths:
+  /foo:
+    post:
+      summary: No response body, 204 code
+      operationId: 204_no_response_body
+      responses:
+        204:
+          description: No Content
+====server====
+mock -p 4010
+====command====
+curl -i -X POST http://localhost:4010/foo -H "accept: application/json"
+====expect====
+HTTP/1.1 204 No Content
+content-type: application/json

--- a/test-harness/specs/204-no-content.oas3.txt
+++ b/test-harness/specs/204-no-content.oas3.txt
@@ -1,0 +1,25 @@
+====test====
+When I send a request to an operation
+And this operation has only a 204 response defined
+Then I should get back the 204 response code
+====spec====
+openapi: 3.0.2
+info:
+  description: 204 responses
+  version: 1.0.0
+  title: 204 responses
+paths:
+  /foo:
+   post:
+     summary: No response body, 204 code
+     operationId: 204_no_response_body
+     responses:
+       204:
+         description: No Content
+====server====
+mock -p 4010
+====command====
+curl -i -X POST http://localhost:4010/foo -H "accept: application/json"
+====expect====
+HTTP/1.1 204 No Content
+content-type: application/json


### PR DESCRIPTION
## TODO:

- [ ] implement the fix for provided failing tests

## Checklist

- [x] Tests have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior? What is the new behavior?

**Currently:**

1. Define a route in your spec with a 204 response, e.g.

```yaml
paths:
  /foo:
   post:
     summary: No response body, 204 code
     operationId: 204_no_response_body
     responses:
       204:
         description: No Content
```

2. Send a request to that route with a content-type of `application/json`, and you receive a "406 Not Acceptable" response instead.

**New Behaviour:**

If a 204 response is defined in the spec, then it should be returned regardless of the request's `Accept` header. 

The swagger 2.0 spec states (https://swagger.io/docs/specification/2-0/describing-responses/):

> Some responses, such as 204 No Content, have no body. To indicate the response body is empty, do not specify a schema for the response. Swagger treats no schema as a response without a body.

And for OAS 3.0+ (https://swagger.io/docs/specification/describing-responses/):

> Some responses, such as 204 No Content, have no body. To indicate the response body is empty, do not specify a content for the response:

## Does this PR introduce a breaking change?

No.
