### PR TITLE
fix: accept and handle csv collection format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prism won't return 406 when users request a `text/plain` response whose content is a primitive (string, number) #560
 - Prism's router is now able to correctly handle a path ending with a parameter, such as `/test.{format}`, while it would previously not match with anything. #561
 - Prism is correctly handling the `allowEmptyValue` property in OAS2 documents
+- Prism is correctly handling the `csv` collection format argument property in OAS2 documents
 
 # 3.0.4 (2019-08-20)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/http-spec": "^2.1.3",
+    "@stoplight/http-spec": "^2.1.4",
     "@stoplight/json-ref-resolver": "^2.2.0",
     "@stoplight/prism-core": "^3.0.4",
     "@stoplight/prism-http-server": "^3.0.4",

--- a/packages/http/src/validator/deserializers/index.ts
+++ b/packages/http/src/validator/deserializers/index.ts
@@ -14,5 +14,8 @@ export const query = new HttpParamDeserializerRegistry([
   new FormStyleDeserializer(),
   new DelimitedStyleDeserializer('%20', HttpParamStyles.SpaceDelimited),
   new DelimitedStyleDeserializer('|', HttpParamStyles.PipeDelimited),
+  new DelimitedStyleDeserializer(',', HttpParamStyles.CommaDelimited),
   new DeepObjectStyleDeserializer(),
 ]);
+
+export const body = query;

--- a/packages/http/src/validator/deserializers/style/__tests__/__snapshots__/delimited.spec.ts.snap
+++ b/packages/http/src/validator/deserializers/style/__tests__/__snapshots__/delimited.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DelimitedStyleDeserializer deserialize() schema type is not array throws exception 1`] = `"Space/pipe/.. delimited style is only applicable to array parameter"`;
+exports[`DelimitedStyleDeserializer deserialize() schema type is not array throws exception 1`] = `"Space/pipe/comma.. delimited style is only applicable to array parameter"`;

--- a/packages/http/src/validator/deserializers/style/delimited.ts
+++ b/packages/http/src/validator/deserializers/style/delimited.ts
@@ -35,6 +35,6 @@ export class DelimitedStyleDeserializer implements IHttpQueryParamStyleDeseriali
       value = value[value.length - 1];
     }
 
-    return value.split(this.separator);
+    return value ? value.split(this.separator) : '';
   }
 }

--- a/packages/http/src/validator/deserializers/style/delimited.ts
+++ b/packages/http/src/validator/deserializers/style/delimited.ts
@@ -5,7 +5,10 @@ import { IHttpQueryParamStyleDeserializer } from '../types';
 export class DelimitedStyleDeserializer implements IHttpQueryParamStyleDeserializer {
   constructor(
     private readonly separator: string,
-    private readonly styleName: HttpParamStyles.PipeDelimited | HttpParamStyles.SpaceDelimited,
+    private readonly styleName:
+      | HttpParamStyles.PipeDelimited
+      | HttpParamStyles.SpaceDelimited
+      | HttpParamStyles.CommaDelimited,
   ) {}
   public supports(style: HttpParamStyles) {
     return style === this.styleName;
@@ -18,7 +21,7 @@ export class DelimitedStyleDeserializer implements IHttpQueryParamStyleDeseriali
     if (type === 'array') {
       return explode ? this.deserializeImplodeArray(values) : this.deserializeArray(values);
     } else {
-      throw new Error('Space/pipe/.. delimited style is only applicable to array parameter');
+      throw new Error('Space/pipe/comma.. delimited style is only applicable to array parameter');
     }
   }
 

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -21,11 +21,11 @@ export class HttpBodyValidator implements IHttpValidator<any, IMediaTypeContent>
       if (deserializer && deserializer.supports(content.encodings[0].style) && content.schema.properties) {
         const propertySchema = Object.keys(content.schema.properties)[0];
         const deserializedObject = deserializer.deserialize(propertySchema, target, Object.values(
-          propertySchema,
+          content.schema.properties,
         )[0] as any);
 
-        return validateAgainstSchema(deserializedObject, Object.values(propertySchema)[0] as any).map(error =>
-          Object.assign({}, error, { path: [prefix, ...(error.path || [])] }),
+        return validateAgainstSchema(deserializedObject, Object.values(content.schema.properties)[0] as any).map(
+          error => Object.assign({}, error, { path: [prefix, ...(error.path || [])] }),
         );
       }
     }

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -12,11 +12,7 @@ export class HttpBodyValidator implements IHttpValidator<any, IMediaTypeContent>
     const { _prefix: prefix } = this;
     const content = this.getContent(specs, mediaType);
 
-    if (!content) {
-      return [];
-    }
-
-    if (!content.schema) {
+    if (!content || !content.schema) {
       return [];
     }
 

--- a/test-harness/specs/parameters-ac7.oas2.txt
+++ b/test-harness/specs/parameters-ac7.oas2.txt
@@ -1,0 +1,29 @@
+====test====
+Request form-data body should be an array of strings (comma separated values)
+====spec====
+swagger: '2.0'
+paths:
+  /path:
+    post:
+      consumes:
+        - application/x-www-form-urlencoded
+      responses:
+        200:
+          schema:
+            type: string
+      parameters:
+        - in: formData
+          type: array
+          name: arr
+          items:
+            type: string
+          collectionFormat: csv
+====server====
+mock -p 4010
+====command====
+curl -i -X POST http://localhost:4010/path -H "Content-Type: application/x-www-form-urlencoded" --data "arr=a,b,c"
+====expect====
+HTTP/1.1 200 OK
+content-type: text/plain
+
+string

--- a/test-harness/specs/parameters-ac8.oas2.txt
+++ b/test-harness/specs/parameters-ac8.oas2.txt
@@ -1,5 +1,8 @@
 ====test====
-Request form-data body should be an array of strings (comma separated values)
+When I have a document with a Request with form-data body that should
+be an array of strings (comma separated values)
+And I send something encoded with the missing property
+I should receive a validation error
 ====spec====
 swagger: '2.0'
 paths:
@@ -23,7 +26,7 @@ mock -p 4010
 ====command====
 curl -i -X POST http://localhost:4010/path -H "Content-Type: application/x-www-form-urlencoded" --data "a/b/c"
 ====expect====
-HTTP/1.1 200 OK
-content-type: text/plain
+HTTP/1.1 422 Unprocessable Entity
+content-type: application/problem+json
 
-string
+{"type":"https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY","title":"Invalid request body payload","status":422,"detail":"Your request body is not valid and no HTTP validation response was found in the spec, so Prism is generating this error for you.","validation":[{"location":["body"],"severity":"Error","code":"type","message":"should be array"}]}

--- a/test-harness/specs/parameters-ac8.oas2.txt
+++ b/test-harness/specs/parameters-ac8.oas2.txt
@@ -1,8 +1,5 @@
 ====test====
-When I have a document with a Request with form-data body that should
-be an array of strings (comma separated values)
-And I send the correct values
-I should receive a 200 response
+Request form-data body should be an array of strings (comma separated values)
 ====spec====
 swagger: '2.0'
 paths:
@@ -24,7 +21,7 @@ paths:
 ====server====
 mock -p 4010
 ====command====
-curl -i -X POST http://localhost:4010/path -H "Content-Type: application/x-www-form-urlencoded" --data "arr=a,b,c"
+curl -i -X POST http://localhost:4010/path -H "Content-Type: application/x-www-form-urlencoded" --data "a/b/c"
 ====expect====
 HTTP/1.1 200 OK
 content-type: text/plain

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,13 +1151,13 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@stoplight/http-spec@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-2.1.3.tgz#6fb2dab7f5266a80bf0840641fe47f71b9ba4f8f"
-  integrity sha512-lb6t0BoA0DaHgoufSIGWxDBrvkBb0FzbrNLdvkpkWjrNVmtEKjicqLt5Ys1EFeu/IyAiaDZuq+uq//bWhkUi7Q==
+"@stoplight/http-spec@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-2.1.4.tgz#27cfdba7d2458da7499ba33a44e0d90e45daae70"
+  integrity sha512-+QyFh7XtuA+t2Ue8LD7qVfMiLCom2ZMMDMDMP9n5YekYdrb4KcS5oR8UhxsgRqjZ0jL2+bY4NKYDsZRATrkLSA==
   dependencies:
-    "@stoplight/json" "^3.1.0"
-    "@stoplight/types" "^11.0.0"
+    "@stoplight/json" "^3.1.1"
+    "@stoplight/types" "^11.1.0"
     "@types/swagger-schema-official" "~2.0.18"
     "@types/urijs" "~1.19.1"
     lodash "^4.17.15"
@@ -1189,7 +1189,17 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
-"@stoplight/types@^11.0.0":
+"@stoplight/json@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.1.1.tgz#531d966a62247bf2ab1e8a06a685fa62e36cf890"
+  integrity sha512-DK2ufmnPvfW9Mv0q4DYtldjicTTcBY+j4kiEUOEmc9hL+mzMDV08+5ix4tmPtheUDZH6OtEqEmGcf8ZKCHFbpg==
+  dependencies:
+    "@stoplight/types" "^11.0.0"
+    jsonc-parser "~2.1.1"
+    lodash "^4.17.15"
+    safe-stable-stringify "^1.1"
+
+"@stoplight/types@^11.0.0", "@stoplight/types@^11.1.0":
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.1.0.tgz#b29ecd8c8ad27bb564c7820c99f93c27f1d11bf1"
   integrity sha512-z4VqnYIDTcj9R0f8AIDitBWkiAKKJ4W/Z5GJz/3fnBZBa/TD9Oak0xHbicXFXUvqTVCv/7D32PjPYiUX6W/EfQ==


### PR DESCRIPTION
Closes #498

This PR updates the http spec with the version that supports the CommaDelimited enum value, adds a serialiser for it and uses it for the payload in case it's necessary.

Note — I know this is not exactly a great piece of code, but unfortunately there's no other way to make this right unless we dismantle the whole validation system, which won't happen in this PR.