### PR TITLE
Backport client stuff in Prism

### DIFF
--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -42,7 +42,8 @@ async function createPrismServerWithLogger(options: CreatePrismOptions, logInsta
   }
 
   const server = createHttpServer(options.operations, {
-    config: { cors: options.cors, mock: { dynamic: options.dynamic }, validateRequest: true, validateResponse: true },
+    cors: options.cors,
+    config: { mock: { dynamic: options.dynamic }, validateRequest: true, validateResponse: true },
     components: { logger: logInstance.child({ name: 'HTTP SERVER' }) },
   });
 

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -7,14 +7,14 @@ import { defaults } from 'lodash';
 import { IPrism, IPrismComponents, IPrismConfig, IPrismDiagnostic, PickRequired, ProblemJsonError } from './types';
 import { validateSecurity } from './utils/security';
 
-export function factory<Resource, Input, Output, Config>(
+export function factory<Resource, Input, Output, Config extends IPrismConfig>(
   defaultConfig: Config,
   components: PickRequired<Partial<IPrismComponents<Resource, Input, Output, Config>>, 'logger'>,
 ): IPrism<Resource, Input, Output, Config> {
   return {
     process: async (input: Input, resources: Resource[], c?: Config) => {
       // build the config for this request
-      const config = defaults(c, defaultConfig);
+      const config = defaults(c, defaultConfig) as Config; // Cast required because lodash types are wrong — https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38156
       const inputValidations: IPrismDiagnostic[] = [];
 
       if (components.router) {
@@ -23,7 +23,7 @@ export function factory<Resource, Input, Output, Config>(
           Either.fold(
             error => {
               // rethrow error we if we're attempting to mock
-              if (((config as unknown) as IPrismConfig).mock) {
+              if (config.mock) {
                 return TaskEither.left(error);
               }
 
@@ -61,7 +61,7 @@ export function factory<Resource, Input, Output, Config>(
               ),
             );
 
-            if (resource && components.mocker && ((config as unknown) as IPrismConfig).mock) {
+            if (resource && components.mocker && config.mock) {
               // generate the response
               return pipe(
                 TaskEither.fromEither(

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -1,6 +1,6 @@
 import { DiagnosticSeverity } from '@stoplight/types';
 import * as Either from 'fp-ts/lib/Either';
-import { fold } from 'fp-ts/lib/Option';
+import { getOrElse, map } from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as TaskEither from 'fp-ts/lib/TaskEither';
 import { defaults } from 'lodash';
@@ -56,7 +56,8 @@ export function factory<Resource, Input, Output, Config>(
             const inputValidationResult = inputValidations.concat(
               pipe(
                 validateSecurity(input, resource),
-                fold<IPrismDiagnostic, IPrismDiagnostic[]>(() => [], value => [value]),
+                map(sec => [sec]),
+                getOrElse<IPrismDiagnostic[]>(() => []),
               ),
             );
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,7 +5,7 @@ import { TaskEither } from 'fp-ts/lib/TaskEither';
 import { Logger } from 'pino';
 export type IPrismDiagnostic = Omit<IDiagnostic, 'range'>;
 
-export interface IPrism<Resource, Input, Output, Config> {
+export interface IPrism<Resource, Input, Output, Config extends IPrismConfig> {
   process: (input: Input, resources: Resource[], config?: Config) => Promise<IPrismOutput<Input, Output>>;
 }
 
@@ -16,11 +16,11 @@ export interface IPrismConfig {
   validateResponse: boolean;
 }
 
-export interface IRouter<Resource, Input, Config> {
+export interface IRouter<Resource, Input, Config extends IPrismConfig> {
   route: (opts: { resources: Resource[]; input: Input; config?: Config }) => Either<Error, Resource>;
 }
 
-export interface IForwarder<Resource, Input, Config, Output> {
+export interface IForwarder<Resource, Input, Config extends IPrismConfig, Output> {
   forward: (opts: { resource?: Resource; input: IPrismInput<Input>; config?: Config }) => Promise<Output>;
   fforward: (opts: { resource?: Resource; input: IPrismInput<Input>; config?: Config }) => TaskEither<Error, Output>;
 }
@@ -40,7 +40,7 @@ export interface IValidator<Resource, Input, Config, Output> {
   validateOutput?: (opts: { resource: Resource; output?: Output; config?: Config }) => IPrismDiagnostic[];
 }
 
-export interface IPrismComponents<Resource, Input, Output, Config> {
+export interface IPrismComponents<Resource, Input, Output, Config extends IPrismConfig> {
   router: IRouter<Resource, Input, Config>;
   forwarder: IForwarder<Resource, Input, Config, Output>;
   mocker: IMocker<Resource, Input, Config, Reader<Logger, Either<Error, Output>>>;

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -9,7 +9,8 @@ const logger = createLogger('TEST', { enabled: false });
 function instantiatePrism2(operations: IHttpOperation[]) {
   return createServer(operations, {
     components: { logger },
-    config: { validateRequest: true, validateResponse: true, cors: true, mock: { dynamic: false } },
+    cors: true,
+    config: { validateRequest: true, validateResponse: true, mock: { dynamic: false } },
   });
 }
 

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -19,7 +19,8 @@ async function instantiatePrism(specPath: string) {
   const operations = await getHttpOperations(specPath);
   const server = createServer(operations, {
     components: { logger },
-    config: { validateRequest: true, validateResponse: true, cors: true, mock: { dynamic: false } },
+    config: { validateRequest: true, validateResponse: true, mock: { dynamic: false } },
+    cors: true,
   });
   return server;
 }

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -24,7 +24,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     .register(formbodyParser)
     .register(fastifyAcceptsSerializer, { serializers });
 
-  if (opts.config.cors) server.register(fastifyCors);
+  if (opts.cors) server.register(fastifyCors);
 
   server.addContentTypeParser('*', { parseAs: 'string' }, (req, body, done) => {
     if (typeIs(req, ['application/*+json'])) {
@@ -54,7 +54,6 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
   });
 
   const mergedConfig = defaults<Partial<IHttpConfig>, IHttpConfig>(config, {
-    cors: true,
     mock: { dynamic: false },
     validateRequest: true,
     validateResponse: true,
@@ -62,7 +61,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
   const prism = createInstance(mergedConfig, components);
 
-  opts.config.cors
+  opts.cors
     ? server.route({
         url: '*',
         method: ['GET', 'DELETE', 'HEAD', 'PATCH', 'POST', 'PUT'],

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -4,6 +4,7 @@ import { FastifyInstance } from 'fastify';
 export interface IPrismHttpServerOpts {
   components?: PickRequired<TPrismHttpComponents, 'logger'>;
   config: IHttpConfig;
+  cors: boolean;
 }
 
 export interface IPrismHttpServer {

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -180,7 +180,6 @@ The actual interface looks like this (but rather than explain each property we'r
 ```ts
 export interface IHttpConfig extends IPrismConfig {
   mock: false | IHttpOperationConfig;
-  cors: boolean;
   validateRequest: boolean;
   validateResponse: boolean;
 }
@@ -193,7 +192,6 @@ export interface IHttpConfig extends IPrismConfig {
 ```javascript
 const config = {
   mock: false,
-  cors: false,
   validateRequest: false,
   validareResponse: true
 };

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -54,10 +54,7 @@ describe('Http Client .process', () => {
     ${basename(serverValidationOas3Path)} | ${serverValidationOas3Path}
   `('given spec $specName', ({ specPath }) => {
     beforeAll(async () => {
-      prism = createInstance(
-        { cors: true, validateRequest: true, validateResponse: true, mock: { dynamic: false } },
-        { logger },
-      );
+      prism = createInstance({ validateRequest: true, validateResponse: true, mock: { dynamic: false } }, { logger });
       resources = await getHttpOperations(specPath);
     });
 
@@ -131,7 +128,7 @@ describe('Http Client .process', () => {
     });
 
     describe('mocking is off', () => {
-      const config: IHttpConfig = { mock: false, cors: false, validateRequest: true, validateResponse: true };
+      const config: IHttpConfig = { mock: false, validateRequest: true, validateResponse: true };
       const baseUrl = 'http://stoplight.io';
       const serverReply = 'hello world';
 
@@ -243,10 +240,7 @@ describe('Http Client .process', () => {
 
   describe('given no-refs-petstore-minimal.oas2.json', () => {
     beforeAll(async () => {
-      prism = createInstance(
-        { cors: true, validateRequest: true, validateResponse: true, mock: { dynamic: false } },
-        { logger },
-      );
+      prism = createInstance({ validateRequest: true, validateResponse: true, mock: { dynamic: false } }, { logger });
       resources = await getHttpOperations(noRefsPetstoreMinimalOas2Path);
     });
 
@@ -375,10 +369,7 @@ describe('Http Client .process', () => {
   });
 
   it('returns stringified static example when one defined in spec', async () => {
-    prism = createInstance(
-      { cors: true, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
-      { logger },
-    );
+    prism = createInstance({ mock: { dynamic: false }, validateRequest: true, validateResponse: true }, { logger });
     resources = await getHttpOperations(staticExamplesOas2Path);
 
     const response = await prism.process(

--- a/packages/http/src/mocker/HttpMocker.ts
+++ b/packages/http/src/mocker/HttpMocker.ts
@@ -37,7 +37,7 @@ class HttpMocker
       withLogger(logger => {
         // setting default values
         const acceptMediaType = input.data.headers && caseless(input.data.headers).get('accept');
-        config = config || { mock: false, cors: false, validateRequest: true, validateResponse: true };
+        config = config || { mock: false, validateRequest: true, validateResponse: true };
         const mockConfig: IHttpOperationConfig =
           config.mock === false ? { dynamic: false } : Object.assign({}, config.mock);
 

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -196,7 +196,7 @@ describe('mocker', () => {
             const response = await mocker.mock({
               input: mockInput,
               resource: mockResource,
-              config: { cors: false, mock: { dynamic: true }, validateRequest: true, validateResponse: true },
+              config: { mock: { dynamic: true }, validateRequest: true, validateResponse: true },
             })(logger);
 
             expect(JSONSchemaGenerator.generate).toHaveBeenCalled();
@@ -225,7 +225,6 @@ describe('mocker', () => {
               input: mockInput,
               resource: mockResource,
               config: {
-                cors: false,
                 mock: { dynamic: false, exampleKey: 'test key' },
                 validateRequest: true,
                 validateResponse: true,
@@ -247,7 +246,7 @@ describe('mocker', () => {
             const response = mocker.mock({
               input: mockInput,
               resource: mockResource,
-              config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+              config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
             })(logger);
 
             it('returns the first example', () => {
@@ -288,7 +287,7 @@ describe('mocker', () => {
             return mocker.mock({
               input: mockInput,
               resource: createOperationWithSchema(schema),
-              config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+              config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
             })(logger);
           }
 

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -17,7 +17,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               mediaTypes: ['text/plain'],
@@ -35,7 +34,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               mediaTypes: ['text/funky'],
@@ -55,7 +53,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -77,7 +74,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -98,7 +94,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               exampleKey: 'bear',
@@ -116,7 +111,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               exampleKey: 'second',
@@ -137,7 +131,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -155,7 +148,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               code: '205',
@@ -173,7 +165,6 @@ describe('http mocker', () => {
           config: {
             validateRequest: true,
             validateResponse: true,
-            cors: false,
             mock: {
               dynamic: false,
               code: '201',
@@ -249,7 +240,6 @@ describe('http mocker', () => {
             config: {
               validateRequest: true,
               validateResponse: true,
-              cors: false,
               mock: {
                 dynamic: true,
               },

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -18,7 +18,6 @@ export interface IHttpOperationConfig {
 
 export interface IHttpConfig extends IPrismConfig {
   mock: false | IHttpOperationConfig;
-  cors: boolean;
 
   validateRequest: boolean;
   validateResponse: boolean;

--- a/packages/http/src/validator/__tests__/functional.spec.ts
+++ b/packages/http/src/validator/__tests__/functional.spec.ts
@@ -3,7 +3,7 @@ import { httpInputs, httpOperations, httpOutputs } from '../../__tests__/fixture
 import { IHttpConfig } from '../../types';
 import { validator } from '../index';
 
-const defaultConfig: IHttpConfig = { cors: false, mock: false, validateRequest: true, validateResponse: true };
+const defaultConfig: IHttpConfig = { mock: false, validateRequest: true, validateResponse: true };
 
 const BAD_INPUT = Object.assign({}, httpInputs[2], {
   body: { name: 'Shopping', completed: 'yes' },

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -43,7 +43,7 @@ describe('HttpValidator', () => {
               resourceExtension,
             ),
             input: { method: 'get', url: { path: '/' } },
-            config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+            config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
           }),
         ).toHaveLength(errorsNumber);
       };
@@ -95,7 +95,7 @@ describe('HttpValidator', () => {
             resourceExtension,
           ),
           input: { method: 'get', url: { path: '/' } },
-          config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+          config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
         }),
       ).toHaveLength(length);
     };
@@ -124,7 +124,7 @@ describe('HttpValidator', () => {
             resourceExtension,
           ),
           input: Object.assign({ method: 'get', url: { path: '/', query: {} } }, inputExtension),
-          config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+          config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
         }),
       ).toHaveLength(length);
 
@@ -164,7 +164,7 @@ describe('HttpValidator', () => {
               request: {},
               responses: [{ code: '200' }],
             },
-            config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+            config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
           }),
         ).toHaveLength(0);
 
@@ -184,7 +184,7 @@ describe('HttpValidator', () => {
               responses: [{ code: '200' }],
             },
             output: { statusCode: 200 },
-            config: { cors: false, mock: { dynamic: false }, validateRequest: true, validateResponse: true },
+            config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
           }),
         ).toHaveLength(2);
 


### PR DESCRIPTION
This PR back ports some of the changes I'm doing to the HttpClient to Prism master branch

1. Rename the `configObj` variable name so that we can use object auto-assigning (or whatever that feature is)
2. All configuration now must at least be an `IPrismConfig` — we were casting to it anyway so it's probably better be explicit and stop pretending to be super generic
3. Use `map + getOrElse` instead of `fold` — is semantically more correct.
4. More the `cors` option away from the `IHttpConfig` object