### PR TITLE
refactor: make Prism's Input and Output mandatory

### DIFF
--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -4,7 +4,7 @@ import { getOrElse, map } from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as TaskEither from 'fp-ts/lib/TaskEither';
 import { defaults } from 'lodash';
-import { IPrism, IPrismComponents, IPrismConfig, IPrismDiagnostic, PickRequired, ProblemJsonError } from './types';
+import { IPrism, IPrismComponents, IPrismConfig, IPrismDiagnostic, ProblemJsonError } from './types';
 import { validateSecurity } from './utils/security';
 
 export function factory<Resource, Input, Output, Config extends IPrismConfig>(

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -9,7 +9,7 @@ import { validateSecurity } from './utils/security';
 
 export function factory<Resource, Input, Output, Config extends IPrismConfig>(
   defaultConfig: Config,
-  components: PickRequired<Partial<IPrismComponents<Resource, Input, Output, Config>>, 'logger'>,
+  components: IPrismComponents<Resource, Input, Output, Config>,
 ): IPrism<Resource, Input, Output, Config> {
   return {
     process: async (input: Input, resources: Resource[], c?: Config) => {
@@ -17,71 +17,54 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
       const config = defaults(c, defaultConfig) as Config; // Cast required because lodash types are wrong — https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38156
       const inputValidations: IPrismDiagnostic[] = [];
 
-      if (components.router) {
-        return pipe(
-          components.router.route({ resources, input, config }),
-          Either.fold(
-            error => {
-              // rethrow error we if we're attempting to mock
-              if (config.mock) {
-                return TaskEither.left(error);
-              }
-
-              const { message, name, status } = error as ProblemJsonError;
-              // otherwise let's just stack it on the inputValidations
-              // when someone simply wants to hit an URL, don't block them
-              inputValidations.push({
-                message,
-                source: name,
-                code: status,
-                severity: DiagnosticSeverity.Warning,
-              });
-
-              return TaskEither.right<Error, Resource | undefined>(undefined);
-            },
-            value => TaskEither.right(value),
-          ),
-          TaskEither.chain(resource => {
-            // validate input
-            if (resource && components.validator && components.validator.validateInput) {
-              inputValidations.push(
-                ...components.validator.validateInput({
-                  resource,
-                  input,
-                  config,
-                }),
-              );
+      return pipe(
+        components.router.route({ resources, input, config }),
+        Either.fold(
+          error => {
+            // rethrow error we if we're attempting to mock
+            if (config.mock) {
+              return TaskEither.left(error);
             }
 
-            const inputValidationResult = inputValidations.concat(
-              pipe(
-                validateSecurity(input, resource),
-                map(sec => [sec]),
-                getOrElse<IPrismDiagnostic[]>(() => []),
-              ),
-            );
+            const { message, name, status } = error as ProblemJsonError;
+            // otherwise let's just stack it on the inputValidations
+            // when someone simply wants to hit an URL, don't block them
+            inputValidations.push({
+              message,
+              source: name,
+              code: status,
+              severity: DiagnosticSeverity.Warning,
+            });
 
-            if (resource && components.mocker && config.mock) {
-              // generate the response
-              return pipe(
-                TaskEither.fromEither(
-                  components.mocker.mock({
-                    resource,
-                    input: {
-                      validations: {
-                        input: inputValidationResult,
-                      },
-                      data: input,
-                    },
-                    config,
-                  })(components.logger.child({ name: 'NEGOTIATOR' })),
-                ),
-                TaskEither.map(output => ({ output, resource })),
-              );
-            } else if (components.forwarder) {
-              // forward request and set output from response
-              return pipe(
-                components.forwarder.fforward({
+            return TaskEither.right<Error, Resource | undefined>(undefined);
+          },
+          value => TaskEither.right(value),
+        ),
+        TaskEither.chain(resource => {
+          // validate input
+          if (resource && components.validator.validateInput) {
+            inputValidations.push(
+              ...components.validator.validateInput({
+                resource,
+                input,
+                config,
+              }),
+            );
+          }
+
+          const inputValidationResult = inputValidations.concat(
+            pipe(
+              validateSecurity(input, resource),
+              map(sec => [sec]),
+              getOrElse<IPrismDiagnostic[]>(() => []),
+            ),
+          );
+
+          if (resource && components.mocker && config.mock) {
+            // generate the response
+            return pipe(
+              TaskEither.fromEither(
+                components.mocker.mock({
                   resource,
                   input: {
                     validations: {
@@ -90,53 +73,59 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
                     data: input,
                   },
                   config,
-                }),
-                TaskEither.map(output => ({ output, resource })),
-              );
-            }
-
-            return TaskEither.left(new Error('Nor forwarder nor mocker has been selected. Something is wrong'));
-          }),
-          TaskEither.map(({ output, resource }) => {
-            let outputValidations: IPrismDiagnostic[] = [];
-            if (resource && components.validator && components.validator.validateOutput) {
-              outputValidations = components.validator.validateOutput({
+                })(components.logger.child({ name: 'NEGOTIATOR' })),
+              ),
+              TaskEither.map(output => ({ output, resource })),
+            );
+          } else if (components.forwarder) {
+            // forward request and set output from response
+            return pipe(
+              components.forwarder.fforward({
                 resource,
-                output,
+                input: {
+                  validations: {
+                    input: inputValidationResult,
+                  },
+                  data: input,
+                },
                 config,
-              });
-            }
+              }),
+              TaskEither.map(output => ({ output, resource })),
+            );
+          }
 
-            return {
-              input,
+          return TaskEither.left(new Error('Nor forwarder nor mocker has been selected. Something is wrong'));
+        }),
+        TaskEither.map(({ output, resource }) => {
+          let outputValidations: IPrismDiagnostic[] = [];
+          if (resource && components.validator.validateOutput) {
+            outputValidations = components.validator.validateOutput({
+              resource,
               output,
-              validations: {
-                input: inputValidations,
-                output: outputValidations,
-              },
-            };
-          }),
-        )().then(v =>
-          pipe(
-            v,
-            Either.fold(
-              e => {
-                throw e;
-              },
-              o => o,
-            ),
-          ),
-        );
-      }
+              config,
+            });
+          }
 
-      return {
-        input,
-        output: undefined,
-        validations: {
-          input: [],
-          output: [],
-        },
-      };
+          return {
+            input,
+            output,
+            validations: {
+              input: inputValidations,
+              output: outputValidations,
+            },
+          };
+        }),
+      )().then(v =>
+        pipe(
+          v,
+          Either.fold(
+            e => {
+              throw e;
+            },
+            o => o,
+          ),
+        ),
+      );
     },
   };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,8 +79,6 @@ export type ProblemJson = {
   detail: string;
 };
 
-export type PickRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
-
 export class ProblemJsonError extends Error {
   public static fromTemplate(template: Omit<ProblemJson, 'detail'>, detail?: string): ProblemJsonError {
     const error = new ProblemJsonError(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,13 +40,21 @@ export interface IValidator<Resource, Input, Config, Output> {
   validateOutput?: (opts: { resource: Resource; output?: Output; config?: Config }) => IPrismDiagnostic[];
 }
 
-export interface IPrismComponents<Resource, Input, Output, Config extends IPrismConfig> {
+type MockerOrForwarder<Resource, Input, Output, Config extends IPrismConfig> =
+  | {
+      forwarder?: IForwarder<Resource, Input, Config, Output>;
+      mocker: IMocker<Resource, Input, Config, Reader<Logger, Either<Error, Output>>>;
+    }
+  | {
+      forwarder: IForwarder<Resource, Input, Config, Output>;
+      mocker?: IMocker<Resource, Input, Config, Reader<Logger, Either<Error, Output>>>;
+    };
+
+export type IPrismComponents<Resource, Input, Output, Config extends IPrismConfig> = {
   router: IRouter<Resource, Input, Config>;
-  forwarder: IForwarder<Resource, Input, Config, Output>;
-  mocker: IMocker<Resource, Input, Config, Reader<Logger, Either<Error, Output>>>;
   validator: IValidator<Resource, Input, Config, Output>;
   logger: Logger;
-}
+} & MockerOrForwarder<Resource, Input, Output, Config>;
 
 export interface IPrismInput<I> {
   data: I;
@@ -56,8 +64,8 @@ export interface IPrismInput<I> {
 }
 
 export interface IPrismOutput<I, O> {
-  input?: I;
-  output?: O;
+  input: I;
+  output: O;
   validations: {
     input: IPrismDiagnostic[];
     output: IPrismDiagnostic[];

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@stoplight/prism-core';
-import { createInstance, IHttpConfig, IHttpMethod, ProblemJsonError, TPrismHttpInstance } from '@stoplight/prism-http';
+import { createInstance, IHttpConfig, IHttpMethod, PrismHttpInstance, ProblemJsonError } from '@stoplight/prism-http';
 import { IHttpOperation } from '@stoplight/types';
 import * as fastify from 'fastify';
 // @ts-ignore
@@ -81,7 +81,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     listen: (port: number, ...args: any[]) => server.listen(port, ...args),
   };
 
-  function replyHandler(prismInstance: TPrismHttpInstance): fastify.RequestHandler<IncomingMessage, ServerResponse> {
+  function replyHandler(prismInstance: PrismHttpInstance): fastify.RequestHandler<IncomingMessage, ServerResponse> {
     return async (request, reply) => {
       const {
         req: { method, url },

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -1,14 +1,14 @@
-import { IHttpConfig, PickRequired, TPrismHttpComponents, TPrismHttpInstance } from '@stoplight/prism-http';
+import { IHttpConfig, PickRequired, PrismHttpComponents, PrismHttpInstance } from '@stoplight/prism-http';
 import { FastifyInstance } from 'fastify';
 
 export interface IPrismHttpServerOpts {
-  components?: PickRequired<TPrismHttpComponents, 'logger'>;
+  components?: PickRequired<Partial<PrismHttpComponents>, 'logger'>;
   config: IHttpConfig;
   cors: boolean;
 }
 
 export interface IPrismHttpServer {
-  readonly prism: TPrismHttpInstance;
+  readonly prism: PrismHttpInstance;
   readonly fastify: FastifyInstance;
   listen: (port: number, address?: string, backlog?: number) => Promise<string>;
 }

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -163,7 +163,7 @@ const prism = Prism.createInstance(config /*, components */);
 There are two (both optional) arguments you can supply `createInstance` with:
 
 - config (of `IHttpConfig` type)
-- components (of `TPrismHttpComponents` type)
+- components (of `PrismHttpComponents` type)
 
 We will cover the `config` argument in next section and we'll leave `components` for some other time (overriding default `components` is the _ultimate advanced stuff_).
 

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -15,13 +15,13 @@ import {
   IHttpRequest,
   IHttpResponse,
   PickRequired,
+  PrismHttpComponents,
+  PrismHttpInstance,
   ProblemJson,
   ProblemJsonError,
-  TPrismHttpComponents,
-  TPrismHttpInstance,
 } from './types';
 
-const createInstance = (config: IHttpConfig, components?: PickRequired<TPrismHttpComponents, 'logger'>) => {
+const createInstance = (config: IHttpConfig, components?: PickRequired<Partial<PrismHttpComponents>, 'logger'>) => {
   return factory<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>(
     config,
     defaults(components, {
@@ -41,9 +41,9 @@ export {
   IHttpNameValue,
   IHttpNameValues,
   createInstance,
-  TPrismHttpInstance,
+  PrismHttpInstance,
   IHttpOperationConfig,
-  TPrismHttpComponents,
+  PrismHttpComponents,
   ProblemJsonError,
   ProblemJson,
   PickRequired,

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -1,8 +1,7 @@
-import { PickRequired } from '@stoplight/prism-core';
 import { IHttpContent, IHttpOperationResponse, IMediaTypeContent } from '@stoplight/types';
 // @ts-ignore
 import * as accepts from 'accepts';
-import { ContentExample, NonEmptyArray } from '../../';
+import { ContentExample, NonEmptyArray, PickRequired } from '../../';
 
 export type IWithExampleMediaContent = IMediaTypeContent & { examples: NonEmptyArray<ContentExample> };
 

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,10 +1,10 @@
-import { IPrism, IPrismComponents, IPrismConfig, IPrismDiagnostic } from '@stoplight/prism-core';
+import { IPrism, IPrismComponents, IPrismConfig } from '@stoplight/prism-core';
 import { Dictionary, HttpMethod, IHttpOperation, INodeExample, INodeExternalExample } from '@stoplight/types';
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 
-export type TPrismHttpInstance = IPrism<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>;
+export type PrismHttpInstance = IPrism<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>;
 
-export type TPrismHttpComponents = Partial<IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>>;
+export type PrismHttpComponents = IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>;
 
 // TODO: should be complete | and in the @stoplight/types repo
 export type IHttpMethod = HttpMethod | 'trace';


### PR DESCRIPTION
This PR is another back port from the work I've been doing on the HTTP Client that I thought it would be a good idea  to bring in master as soon as possible.

This is still to make sure the final PR it's not a 🐲 dragon 🐲 to review.

* Rename `TSomething` to `Something` — the Hungarian era is over
* Stop pretending that components can just be undefined and skip entire parts of the code. Currently if the `router` component is not provided, Prism will just *not* do anything. I've modified this behavior to make the `router` component mandatory. Either you give me what I need to do my job or get out of here
* Make sure that, by definition, either the mocker or the forwarder is passed as a component


For an easier review, disable whitespaces from the diff:

➡️ https://github.com/stoplightio/prism/pull/593/files?w=1 ⬅️ 