### PR TITLE
Move the validator enablement out of the validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/signale": "^1.2.1",
     "@types/split2": "^2.1.6",
     "@types/type-is": "^1.6.3",
+    "abstract-logging": "^1.0.0",
     "chance": "^1.0.18",
     "diff-js-xml": "^1.0.5",
     "gavel": "^8.0.3",

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -1,0 +1,47 @@
+// @ts-ignore
+import logger from 'abstract-logging';
+import { right } from 'fp-ts/lib/Either';
+import { asks } from 'fp-ts/lib/ReaderEither';
+import { Logger } from 'pino';
+import { factory, IPrismConfig } from '..';
+
+describe('validation', () => {
+  const validator = {
+    validateInput: jest.fn().mockReturnValue(['something']),
+    validateOutput: jest.fn().mockReturnValue(['something']),
+  };
+
+  const prismInstance = factory<string, string, string, IPrismConfig>(
+    { mock: true, validateRequest: false, validateResponse: false },
+    {
+      validator,
+      router: {
+        route: jest.fn().mockReturnValue(right('hey')),
+      },
+      logger: { ...logger, child: jest.fn().mockReturnValue(logger) },
+      mocker: {
+        mock: jest.fn().mockReturnValue(asks<Logger, Error, string>(r => 'hey')),
+      },
+    },
+  );
+
+  describe.each([
+    ['input', 'validateRequest', 'validateInput', 'validateOutput'],
+    ['output', 'validateResponse', 'validateOutput', 'validateInput'],
+  ])('%s', (_type, fieldType, fnName, reverseFnName) => {
+    describe('when enabled', () => {
+      beforeAll(async () => {
+        const obj: any = {};
+        obj[fieldType] = true;
+        await prismInstance.request('', [], obj);
+      });
+
+      afterEach(() => jest.clearAllMocks());
+      afterAll(() => jest.restoreAllMocks());
+
+      test('should call the relative validate function', () => expect(validator[fnName]).toHaveBeenCalled());
+      test('should not call the relative other function', () =>
+        expect(validator[reverseFnName]).not.toHaveBeenCalled());
+    });
+  });
+});

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -33,13 +33,23 @@ describe('validation', () => {
       beforeAll(async () => {
         const obj: any = {};
         obj[fieldType] = true;
-        await prismInstance.request('', [], obj);
+        await prismInstance.process('', [], obj);
       });
 
       afterEach(() => jest.clearAllMocks());
       afterAll(() => jest.restoreAllMocks());
 
       test('should call the relative validate function', () => expect(validator[fnName]).toHaveBeenCalled());
+      test('should not call the relative other function', () =>
+        expect(validator[reverseFnName]).not.toHaveBeenCalled());
+    });
+
+    describe('when disabled', () => {
+      beforeAll(() => prismInstance.process('', []));
+      afterEach(() => jest.clearAllMocks());
+      afterAll(() => jest.restoreAllMocks());
+
+      test('should not call the relative validate function', () => expect(validator[fnName]).not.toHaveBeenCalled());
       test('should not call the relative other function', () =>
         expect(validator[reverseFnName]).not.toHaveBeenCalled());
     });

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -42,12 +42,11 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
         ),
         TaskEither.chain(resource => {
           // validate input
-          if (resource && components.validator.validateInput) {
+          if (config.validateRequest && resource && components.validator.validateInput) {
             inputValidations.push(
               ...components.validator.validateInput({
                 resource,
                 input,
-                config,
               }),
             );
           }
@@ -98,11 +97,10 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
         }),
         TaskEither.map(({ output, resource }) => {
           let outputValidations: IPrismDiagnostic[] = [];
-          if (resource && components.validator.validateOutput) {
+          if (config.validateResponse && resource && components.validator.validateOutput) {
             outputValidations = components.validator.validateOutput({
               resource,
               output,
-              config,
             });
           }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,9 +35,9 @@ export interface IMockerOpts<Resource, Input, Config> {
   config?: Config;
 }
 
-export interface IValidator<Resource, Input, Config, Output> {
-  validateInput?: (opts: { resource: Resource; input: Input; config?: Config }) => IPrismDiagnostic[];
-  validateOutput?: (opts: { resource: Resource; output?: Output; config?: Config }) => IPrismDiagnostic[];
+export interface IValidator<Resource, Input, Output> {
+  validateInput?: (opts: { resource: Resource; input: Input }) => IPrismDiagnostic[];
+  validateOutput?: (opts: { resource: Resource; output: Output }) => IPrismDiagnostic[];
 }
 
 type MockerOrForwarder<Resource, Input, Output, Config extends IPrismConfig> =
@@ -52,7 +52,7 @@ type MockerOrForwarder<Resource, Input, Output, Config extends IPrismConfig> =
 
 export type IPrismComponents<Resource, Input, Output, Config extends IPrismConfig> = {
   router: IRouter<Resource, Input, Config>;
-  validator: IValidator<Resource, Input, Config, Output>;
+  validator: IValidator<Resource, Input, Output>;
   logger: Logger;
 } & MockerOrForwarder<Resource, Input, Output, Config>;
 

--- a/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
+++ b/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HttpValidator validateInput() all validations are turned off returns no validation errors 1`] = `Array []`;
-
 exports[`HttpValidator validateInput() all validations are turned on returns validation errors for whole request structure 1`] = `
 Array [
   Object {
@@ -32,8 +30,6 @@ Array [
   },
 ]
 `;
-
-exports[`HttpValidator validateOutput() all validations are turned off returns no validation errors 1`] = `Array []`;
 
 exports[`HttpValidator validateOutput() all validations are turned on returns validation errors for whole request structure 1`] = `
 Array [

--- a/packages/http/src/validator/__tests__/functional.spec.ts
+++ b/packages/http/src/validator/__tests__/functional.spec.ts
@@ -69,7 +69,6 @@ describe('HttpValidator', () => {
                 api_Key: 'ha',
               },
             },
-            config: defaultConfig,
           }),
         ).toEqual([]);
       });
@@ -81,7 +80,6 @@ describe('HttpValidator', () => {
           validator.validateInput({
             resource: httpOperations[2],
             input: BAD_INPUT,
-            config: defaultConfig,
           }),
         ).toContainEqual({
           code: 'pattern',
@@ -91,36 +89,12 @@ describe('HttpValidator', () => {
         });
       });
     });
-
-    describe('all validations are turned off', () => {
-      it('returns no validation errors', async () => {
-        expect(
-          await validator.validateInput({
-            resource: httpOperations[2],
-            input: BAD_INPUT,
-            config: Object.assign(defaultConfig, { validateRequest: false }),
-          }),
-        ).toMatchSnapshot();
-      });
-    });
   });
 
   describe('validateOutput()', () => {
     describe('all validations are turned on', () => {
       it('returns validation errors for whole request structure', async () => {
         expect(await validator.validateOutput({ resource: httpOperations[1], output: BAD_OUTPUT })).toMatchSnapshot();
-      });
-    });
-
-    describe('all validations are turned off', () => {
-      it('returns no validation errors', async () => {
-        expect(
-          await validator.validateOutput({
-            resource: httpOperations[1],
-            output: BAD_OUTPUT,
-            config: Object.assign(defaultConfig, { validateResponse: false }),
-          }),
-        ).toMatchSnapshot();
       });
     });
   });

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -43,7 +43,6 @@ describe('HttpValidator', () => {
               resourceExtension,
             ),
             input: { method: 'get', url: { path: '/' } },
-            config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
           }),
         ).toHaveLength(errorsNumber);
       };
@@ -95,7 +94,6 @@ describe('HttpValidator', () => {
             resourceExtension,
           ),
           input: { method: 'get', url: { path: '/' } },
-          config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
         }),
       ).toHaveLength(length);
     };
@@ -124,7 +122,6 @@ describe('HttpValidator', () => {
             resourceExtension,
           ),
           input: Object.assign({ method: 'get', url: { path: '/', query: {} } }, inputExtension),
-          config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
         }),
       ).toHaveLength(length);
 
@@ -153,8 +150,8 @@ describe('HttpValidator', () => {
   });
 
   describe('validateOutput()', () => {
-    describe('output is not set', () => {
-      it('omits validation', () => {
+    describe('output is set', () => {
+      it('validates the body and headers', () => {
         expect(
           httpValidator.validateOutput({
             resource: {
@@ -164,27 +161,7 @@ describe('HttpValidator', () => {
               request: {},
               responses: [{ code: '200' }],
             },
-            config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
-          }),
-        ).toHaveLength(0);
-
-        expect(httpBodyValidator.validate).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('output is set', () => {
-      it('validates the body and headers', async () => {
-        await expect(
-          httpValidator.validateOutput({
-            resource: {
-              method: 'get',
-              path: '/',
-              id: '1',
-              request: {},
-              responses: [{ code: '200' }],
-            },
             output: { statusCode: 200 },
-            config: { mock: { dynamic: false }, validateRequest: true, validateResponse: true },
           }),
         ).toHaveLength(2);
 

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -2,88 +2,61 @@ import { IPrismDiagnostic, IValidator } from '@stoplight/prism-core';
 import { DiagnosticSeverity, IHttpContent, IHttpHeaderParam, IHttpOperation, IHttpQueryParam } from '@stoplight/types';
 import * as caseless from 'caseless';
 
-import { IHttpConfig, IHttpNameValue, IHttpNameValues, IHttpRequest, IHttpResponse } from '../types';
+import { IHttpNameValue, IHttpNameValues, IHttpRequest, IHttpResponse } from '../types';
 import { header as headerDeserializerRegistry, query as queryDeserializerRegistry } from './deserializers';
 import { findOperationResponse } from './utils/spec';
 import { HttpBodyValidator, HttpHeadersValidator, HttpQueryValidator, IHttpValidator } from './validators';
 
-export class HttpValidator implements IValidator<IHttpOperation, IHttpRequest, IHttpConfig, IHttpResponse> {
+export class HttpValidator implements IValidator<IHttpOperation, IHttpRequest, IHttpResponse> {
   constructor(
     private readonly bodyValidator: IHttpValidator<any, IHttpContent>,
     private readonly headersValidator: IHttpValidator<IHttpNameValue, IHttpHeaderParam>,
     private readonly queryValidator: IHttpValidator<IHttpNameValues, IHttpQueryParam>,
   ) {}
 
-  public validateInput({
-    resource,
-    input,
-    config,
-  }: {
-    resource: IHttpOperation;
-    input: IHttpRequest;
-    config?: IHttpConfig;
-  }): IPrismDiagnostic[] {
+  public validateInput({ resource, input }: { resource: IHttpOperation; input: IHttpRequest }): IPrismDiagnostic[] {
     const results: IPrismDiagnostic[] = [];
     const mediaType = caseless(input.headers || {}).get('content-type');
 
     // Replace resource.request in this function with request
     const { request } = resource;
 
-    if (!config || (config && config.validateRequest)) {
-      const { body } = input;
-      if (request && request.body) {
-        if (!body && request.body.required) {
-          results.push({ code: 'required', message: 'Body parameter is required', severity: DiagnosticSeverity.Error });
-        } else if (body) {
-          this.bodyValidator
-            .validate(body, (request && request.body && request.body.contents) || [], mediaType)
-            .forEach(validationResult => results.push(validationResult));
-        }
+    const { body } = input;
+    if (request && request.body) {
+      if (!body && request.body.required) {
+        results.push({ code: 'required', message: 'Body parameter is required', severity: DiagnosticSeverity.Error });
+      } else if (body) {
+        this.bodyValidator
+          .validate(body, (request && request.body && request.body.contents) || [], mediaType)
+          .forEach(validationResult => results.push(validationResult));
       }
-
-      this.headersValidator
-        .validate(input.headers || {}, (request && request.headers) || [], mediaType)
-        .forEach(validationResult => results.push(validationResult));
-
-      this.queryValidator
-        .validate(input.url.query || {}, (request && request.query) || [], mediaType)
-        .forEach(validationResult => results.push(validationResult));
-
-      return results;
     }
-    return [];
+
+    this.headersValidator
+      .validate(input.headers || {}, (request && request.headers) || [], mediaType)
+      .forEach(validationResult => results.push(validationResult));
+
+    this.queryValidator
+      .validate(input.url.query || {}, (request && request.query) || [], mediaType)
+      .forEach(validationResult => results.push(validationResult));
+
+    return results;
   }
 
-  public validateOutput({
-    resource,
-    output,
-    config,
-  }: {
-    resource: IHttpOperation;
-    output?: IHttpResponse;
-    config?: IHttpConfig;
-  }): IPrismDiagnostic[] {
-    if (!output) {
-      return [];
-    }
+  public validateOutput({ resource, output }: { resource: IHttpOperation; output: IHttpResponse }): IPrismDiagnostic[] {
+    const results: IPrismDiagnostic[] = [];
+    const mediaType = caseless(output.headers || {}).get('content-type');
+    const responseSpec = resource.responses && findOperationResponse(resource.responses, output.statusCode);
 
-    if (!config || (config && config.validateResponse)) {
-      const results: IPrismDiagnostic[] = [];
-      const mediaType = caseless(output.headers || {}).get('content-type');
-      const responseSpec = resource.responses && findOperationResponse(resource.responses, output.statusCode);
+    this.bodyValidator
+      .validate(output.body, (responseSpec && responseSpec.contents) || [], mediaType)
+      .forEach(validationResult => results.push(validationResult));
 
-      this.bodyValidator
-        .validate(output.body, (responseSpec && responseSpec.contents) || [], mediaType)
-        .forEach(validationResult => results.push(validationResult));
+    this.headersValidator
+      .validate(output.headers || {}, (responseSpec && responseSpec.headers) || [], mediaType)
+      .forEach(validationResult => results.push(validationResult));
 
-      this.headersValidator
-        .validate(output.headers || {}, (responseSpec && responseSpec.headers) || [], mediaType)
-        .forEach(validationResult => results.push(validationResult));
-
-      return results;
-    }
-
-    return [];
+    return results;
   }
 }
 


### PR DESCRIPTION
This PR is yet another back port from the HTTP Client changes were doing. We're still trying to make sure the final PR is not a 🐲 dragon 🐲 

* Move the logic to understand whether the validator should be ran or not on the caller, and not the validator itself. This allows to remove the need of passing the whole configuration object
* The output parameter for the `validateOutput` function is now mandatory. If you do not have it, you've got nothing to validate.
* I've moved the enablement tests from the validator function to the factory function, which is where the real logic is happening.