### PR TITLE
test harness: do not swallow exceptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Prism is using TypeScript's incremental compiler capability that sometimes does 
 
 ```sh
 rm -rf packages/**/dist
-rm -rf packages/**/.tsbuildinfo
+rm -rf packages/**/*.tsbuildinfo
 ```
 
 …then try again. If it does not work, you can generally blame [Vincenzo](https://github.com/XVincentX) and write him.

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -85,12 +85,12 @@ describe('harness', () => {
             } else {
               expect(output).toMatchObject(expected);
             }
-
-            if (parsed.expect) expect(output.body).toMatch(expected.body);
-          } catch (e) {
-            return shutdownPrism(prismMockProcessHandle, done);
+            if (parsed.expect) {
+              expect(output.body).toStrictEqual(expected.body);
+            }
+          } finally {
+            shutdownPrism(prismMockProcessHandle, done);
           }
-          shutdownPrism(prismMockProcessHandle, done);
         }
       });
     });


### PR DESCRIPTION
Instead of swallowing the error, let's cleanup using the `finally` clause