### PR TITLE
generate dynamic properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prism is correctly handling the `csv` collection format argument property in OAS2 documents #577
 - Prism is correctly returning the response when the request has `*/*` as Accept header #578
 - Prism is correctly returning a single root node with the payload for XML data #578
+- Prism is generating dynamic properties for both required and optional ones
 
 # 3.0.4 (2019-08-20)
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -22,6 +22,7 @@
     "ajv-oai": "^1.0.0",
     "axios": "^0.18.0",
     "caseless": "^0.12.0",
+    "deep-cleaner": "^1.2.1",
     "faker": "^4.1.0",
     "fp-ts": "^2.0.5",
     "json-schema-faker": "json-schema-faker/json-schema-faker",

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -7,6 +7,8 @@ import * as jsf from 'json-schema-faker';
 // @ts-ignore
 import * as sampler from 'openapi-sampler';
 
+const dc = require('deep-cleaner');
+
 jsf.extend('faker', () => faker);
 
 jsf.option({
@@ -21,7 +23,7 @@ jsf.option({
 });
 
 export function generate(source: JSONSchema): unknown {
-  return jsf.generate(cloneDeep(source));
+  return jsf.generate(dc(cloneDeep(source), 'required'));
 }
 
 export function generateStatic(source: JSONSchema): unknown {

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -77,5 +77,263 @@ describe('JSONSchema generator', () => {
 
       return expect(generate(schema)).toBeTruthy();
     });
+
+    describe('multiple properties', () => {
+      describe('no required properties specified', () => {
+        it('generates all of the properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              abc: { type: 'string' },
+              xyz: { type: 'string' },
+            },
+          };
+
+          const instance = generate(schema);
+
+          expect(instance).toHaveProperty('name');
+          expect(instance).toHaveProperty('abc');
+          expect(instance).toHaveProperty('xyz');
+        });
+      });
+
+      describe('with required properties specified', () => {
+        it('generates all of the properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              abc: { type: 'string' },
+              xyz: { type: 'string' },
+            },
+            required: ['name', 'abc'],
+          };
+
+          const instance = generate(schema);
+
+          expect(instance).toHaveProperty('name');
+          expect(instance).toHaveProperty('abc');
+          expect(instance).toHaveProperty('xyz');
+        });
+      });
+    });
+
+    describe('allOf', () => {
+      describe('no required properties specified in any of the 2 allOfs', () => {
+        it('generates all of the properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            allOf: [
+              {
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                properties: {
+                  color: {
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          };
+
+          const instance = generate(schema);
+
+          expect(instance).toHaveProperty('name');
+          expect(instance).toHaveProperty('color');
+        });
+      });
+
+      describe('with required properties specified for the 2 of the 2 allOfs', () => {
+        it('generates all of the properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            allOf: [
+              {
+                required: ['name', 'length'],
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  length: {
+                    type: 'integer',
+                  },
+                },
+              },
+              {
+                required: ['color'],
+                type: 'object',
+                properties: {
+                  color: {
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          };
+
+          const instance = generate(schema);
+
+          expect(instance).toHaveProperty('name');
+          expect(instance).toHaveProperty('length');
+          expect(instance).toHaveProperty('color');
+        });
+      });
+
+      describe('with required properties specified in 1 of the 2 allOfs', () => {
+        it('generates all of the properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            allOf: [
+              {
+                required: ['name', 'length'],
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  length: {
+                    type: 'integer',
+                  },
+                },
+              },
+              {
+                type: 'object',
+                properties: {
+                  color: {
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+          };
+
+          const instance = generate(schema);
+
+          expect(instance).toHaveProperty('name');
+          expect(instance).toHaveProperty('length');
+          expect(instance).toHaveProperty('color');
+        });
+      });
+    });
+
+    describe('oneOf', () => {
+      describe('no required properties specified in any of the 2 oneOfs', () => {
+        it('generates all of the properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  color: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                type: 'object',
+                properties: {
+                  age: {
+                    type: 'integer',
+                  },
+                },
+              },
+            ],
+          };
+
+          const instance = generate(schema);
+
+          try {
+            expect(instance).toHaveProperty('color');
+          } catch (e) {
+            expect(instance).toHaveProperty('age');
+          }
+        });
+      });
+
+      describe('with required properties specified in 1 of the 2 oneOfs', () => {
+        it('generates proper properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            oneOf: [
+              {
+                required: ['name'],
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  color: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                type: 'object',
+                properties: {
+                  age: {
+                    type: 'integer',
+                  },
+                },
+              },
+            ],
+          };
+
+          const instance = generate(schema);
+
+          if ((instance as any).name) {
+            expect(instance).toHaveProperty('color');
+          } else {
+            expect(instance).toHaveProperty('age');
+          }
+        });
+      });
+
+      describe('with required properties specified in the 2 of the 2 oneOfs', () => {
+        it('generates proper properties', () => {
+          const schema: JSONSchema = {
+            type: 'object',
+            oneOf: [
+              {
+                required: ['name'],
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  color: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                required: ['age'],
+                type: 'object',
+                properties: {
+                  age: {
+                    type: 'integer',
+                  },
+                },
+              },
+            ],
+          };
+
+          const instance = generate(schema);
+
+          if ((instance as any).name) {
+            expect(instance).toHaveProperty('color');
+          } else {
+            expect(instance).toHaveProperty('age');
+          }
+        });
+      });
+    });
   });
 });

--- a/test-harness/specs/dynamic_json_responses-AC-3.dynamic-response.only_oas3.txt
+++ b/test-harness/specs/dynamic_json_responses-AC-3.dynamic-response.only_oas3.txt
@@ -1,0 +1,54 @@
+====test====
+Prism generates dynamic properties for both required and not-required ones.
+====spec====
+openapi: 3.0.2
+paths:
+  /service:
+    get:
+      description: Returns a single resource.
+      responses:
+        200:
+          description: get a resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resource'
+components:
+  schemas:
+    Resource:
+      type: object
+      discriminator:
+        propertyName: resourceType
+      oneOf:
+        - $ref: '#/components/schemas/A'
+        - $ref: '#/components/schemas/B'
+    A:
+      required:
+        - resourceType
+      type: object
+      properties:
+        resourceType:
+          type: string
+        name:
+          type: string
+        color:
+          type: string
+    B:
+      required:
+        - resourceType
+      type: object
+      properties:
+        resourceType:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+====server====
+mock -p 4010 -d
+====command====
+curl -i http://localhost:4010/service
+====expect-loose====
+HTTP/1.1 200 OK
+
+{"resourceType": "officia voluptate amet ut","name": "sit"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2576,6 +2576,11 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
+deep-cleaner@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/deep-cleaner/-/deep-cleaner-1.2.1.tgz#abc30c05bbf79a43abaf449da50e41d89ba47890"
+  integrity sha512-/WLL2O+GnNA/t9DRagOBT7ckJnfz5wV/8TqLo5bHykcBlXPH0+PeUzd0/s2MzOQ3IiRRIFpcWVe016rCqQIhMA==
+
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -5019,14 +5024,14 @@ json-pointer@0.6.0, json-pointer@^0.6.0:
     foreach "^2.0.4"
 
 json-schema-faker@json-schema-faker/json-schema-faker:
-  version "0.5.0-rc17"
-  resolved "https://codeload.github.com/json-schema-faker/json-schema-faker/tar.gz/30bd096547ec87a365c9df6de049c33ba86eca27"
+  version "0.5.0-rc19"
+  resolved "https://codeload.github.com/json-schema-faker/json-schema-faker/tar.gz/75e69e776efa2df4536f8c9cb23854adc00e6e53"
   dependencies:
-    json-schema-ref-parser "^6.0.2"
-    jsonpath-plus "^0.20.1"
+    json-schema-ref-parser "^6.1.0"
+    jsonpath-plus "^1.0.0"
     randexp "^0.5.3"
 
-json-schema-ref-parser@^6.0.2:
+json-schema-ref-parser@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
   integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
@@ -5081,10 +5086,10 @@ jsonparse@^1.2.0:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonpath-plus@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-0.20.1.tgz#5358b8e8a5df569c541de64908d54bca55550e1c"
-  integrity sha512-8O4tBeXh9XGma2x2aPVwvpo9lXJAd4bx0XA0eRjYs4Cpz7e5PQy7sPttk2YmhvROJhEUu4DNUxmtLueicCqyZg==
+jsonpath-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-1.0.0.tgz#78fa5c4ae62968476268d505d9f78c65469d0e7c"
+  integrity sha512-CXQJ/tsgFogKYBuCRmnlChIw66JBXp8kAkT+R4mSB2cuzCSBi88lx2A+vHvo27RY4Wtj5xVVGu2/2O7NwZ79mg==
 
 jsprim@^1.2.2:
   version "1.4.1"


### PR DESCRIPTION
Fixes #570

## Checklist

- [x] Tests have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior? What is the new behavior?

`json-schema-faker` doesn't generate `required` properties when `alwaysFakeOptionals` is on. So we now have this hacky solution. What happens is `required` attribute is removed from the passed-in schema. So, all of the properties are optional during faking. But, with `alwaysFakeOptionals: true`, all of the properties are faked. This solution is meant to be temporary until it's resolved in `json-schema-faker`.

