### PR TITLE
fix: use default/examples in json-schema-faker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Prism is correctly handling the `csv` collection format argument property in OAS2 documents #577
 - Prism is correctly returning the response when the request has `*/*` as Accept header #578
 - Prism is correctly returning a single root node with the payload for XML data #578
+- Prism utilizes schema's default value and/or examples when dynamically generating content #621
 
 # 3.0.4 (2019-08-20)
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -18,6 +18,8 @@ jsf.option({
   ignoreMissingRefs: true,
   maxItems: 20,
   maxLength: 100,
+  useDefaultValue: true,
+  useExamplesValue: true,
 });
 
 export function generate(source: JSONSchema): unknown {

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -79,7 +79,7 @@ describe('JSONSchema generator', () => {
     });
 
     describe('when default value is set', () => {
-      it('uses it instead of generating one', () => {
+      it('uses it instead of generating value', () => {
         const schema: JSONSchema = {
           type: 'string',
           default: 'a-string-which-is-hard-to-be-randomly-generated-although-who-knows?',
@@ -90,7 +90,7 @@ describe('JSONSchema generator', () => {
     });
 
     describe('when examples are set', () => {
-      it('uses it instead of generating one', () => {
+      it('uses it instead of generating value', () => {
         const schema: JSONSchema = {
           type: 'string',
           examples: ['a-string-which-is-hard-to-be-randomly-generated-although-who-knows?'],

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -89,7 +89,7 @@ describe('JSONSchema generator', () => {
       });
     });
 
-    describe('when example value is set', () => {
+    describe('when examples are set', () => {
       it('uses it instead of generating one', () => {
         const schema: JSONSchema = {
           type: 'string',
@@ -97,6 +97,22 @@ describe('JSONSchema generator', () => {
         };
 
         expect(generate(schema)).toEqual('a-string-which-is-hard-to-be-randomly-generated-although-who-knows?');
+      });
+    });
+
+    describe('when default value and examples are set', () => {
+      it('uses either default value or examples', () => {
+        const schema: JSONSchema = {
+          type: 'string',
+          examples: ['an-examples-string-which-is-hard-to-be-randomly-generated-although-who-knows?'],
+          default: 'a-default-string-which-is-hard-to-be-randomly-generated-although-who-knows?',
+        };
+
+        expect(generate(schema)).toEqual(
+          expect.stringMatching(
+            /^a(n-examples|-default)-string-which-is-hard-to-be-randomly-generated-although-who-knows\?$/,
+          ),
+        );
       });
     });
   });

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -77,5 +77,27 @@ describe('JSONSchema generator', () => {
 
       return expect(generate(schema)).toBeTruthy();
     });
+
+    describe('when default value is set', () => {
+      it('uses it instead of generating one', () => {
+        const schema: JSONSchema = {
+          type: 'string',
+          default: 'a-string-which-is-hard-to-be-randomly-generated-although-who-knows?',
+        };
+
+        expect(generate(schema)).toEqual('a-string-which-is-hard-to-be-randomly-generated-although-who-knows?');
+      });
+    });
+
+    describe('when example value is set', () => {
+      it('uses it instead of generating one', () => {
+        const schema: JSONSchema = {
+          type: 'string',
+          examples: ['a-string-which-is-hard-to-be-randomly-generated-although-who-knows?'],
+        };
+
+        expect(generate(schema)).toEqual('a-string-which-is-hard-to-be-randomly-generated-although-who-knows?');
+      });
+    });
   });
 });


### PR DESCRIPTION
Closes #586 

## Checklist

- [x] Tests have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior? What is the new behavior?

Current: neither default nor examples are used for dynamic content generation using json-schema-faker. 

New: default/examples are used if available

## Does this PR introduce a breaking change?

No