### PR TITLE
refactor: use fp-ts non empty array

### DIFF
--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -2,10 +2,11 @@ import { IHttpContent, IHttpOperationResponse, IMediaTypeContent } from '@stopli
 // @ts-ignore
 import * as accepts from 'accepts';
 import { filter, findFirst, head, sort } from 'fp-ts/lib/Array';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { alt, map, Option } from 'fp-ts/lib/Option';
 import { ord, ordNumber } from 'fp-ts/lib/Ord';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { ContentExample, NonEmptyArray, PickRequired } from '../../';
+import { ContentExample, PickRequired } from '../../';
 
 export type IWithExampleMediaContent = IMediaTypeContent & { examples: NonEmptyArray<ContentExample> };
 

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -97,7 +97,6 @@ export class ProblemJsonError extends Error {
 }
 
 export type ContentExample = INodeExample | INodeExternalExample;
-export type NonEmptyArray<T> = T[] & { 0: T };
 export type PayloadGenerator = (f: JSONSchema) => unknown;
 
 export type PickRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;


### PR DESCRIPTION
It turns out fp-ts has already a `NonEmptyArray` definition which is definitely better than mine.