### PR TITLE
fix: killing subprocess only if prism is running in multiprocess mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
-## Added
-
 ## Fixed
 
 - Killing sub-process only if Prism is running in multi-process mode [#645](https://github.com/stoplightio/prism/pull/645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to Semantic Versioning.
 
+# Unreleased
+
+## Added
+
+## Fixed
+
+- Killing sub-process only if Prism is running in multi-process mode [#645](https://github.com/stoplightio/prism/pull/645)
+
 # 3.1.1 (2019-09-23)
 
 ## Fixed

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -39,7 +39,7 @@ export async function createSingleProcessPrism(options: CreatePrismOptions) {
   pipeOutputToSignale(logStream);
 
   try {
-    return createPrismServerWithLogger(options, logInstance);
+    return await createPrismServerWithLogger(options, logInstance);
   } catch (e) {
     logInstance.fatal(e.message);
   }

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -22,23 +22,32 @@ export async function createMultiProcessPrism(options: CreatePrismOptions) {
     }
   } else {
     const logInstance = createLogger('CLI');
-    return createPrismServerWithLogger(options, logInstance);
+    try {
+      return await createPrismServerWithLogger(options, logInstance);
+    } catch (e) {
+      logInstance.fatal(e.message);
+      cluster.worker.kill();
+    }
   }
 }
 
-export function createSingleProcessPrism(options: CreatePrismOptions) {
+export async function createSingleProcessPrism(options: CreatePrismOptions) {
   signale.await({ prefix: chalk.bgWhiteBright.black('[CLI]'), message: 'Starting Prism…' });
 
   const logStream = new PassThrough();
   const logInstance = createLogger('CLI', undefined, logStream);
   pipeOutputToSignale(logStream);
-  return createPrismServerWithLogger(options, logInstance);
+
+  try {
+    return createPrismServerWithLogger(options, logInstance);
+  } catch (e) {
+    logInstance.fatal(e.message);
+  }
 }
 
 async function createPrismServerWithLogger(options: CreatePrismOptions, logInstance: Logger) {
   if (options.operations.length === 0) {
-    logInstance.fatal('No operations found in the current file.');
-    cluster.worker.kill();
+    throw new Error('No operations found in the current file.');
   }
 
   const server = createHttpServer(options.operations, {
@@ -47,16 +56,11 @@ async function createPrismServerWithLogger(options: CreatePrismOptions, logInsta
     components: { logger: logInstance.child({ name: 'HTTP SERVER' }) },
   });
 
-  try {
-    const address = await server.listen(options.port, options.host);
-    options.operations.forEach(resource => {
-      logInstance.note(`${resource.method.toUpperCase().padEnd(10)} ${address}${resource.path}`);
-    });
-    logInstance.start(`Prism is listening on ${address}`);
-  } catch (e) {
-    logInstance.fatal(e.message);
-    cluster.worker.kill();
-  }
+  const address = await server.listen(options.port, options.host);
+  options.operations.forEach(resource => {
+    logInstance.note(`${resource.method.toUpperCase().padEnd(10)} ${address}${resource.path}`);
+  });
+  logInstance.start(`Prism is listening on ${address}`);
 }
 
 function pipeOutputToSignale(stream: Readable) {


### PR DESCRIPTION
Closes #644 

## Checklist

- [ ] Tests have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior? What is the new behavior?

Cli is trying to kill subprocess even if it is not running in multi-process mode. It results in no nice-looking line `✖ fatal Cannot read property 'kill' of undefined`.

This fix moves logging of errors to the place where the context (single/multiprocess) is known. `.kill` will be invoked only in the latter context.

## Does this PR introduce a breaking change?

No