### PR TITLE
Add default IP address env var that can be overridden by Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ FROM node:12-alpine
 
 WORKDIR /usr/src/prism
 ENV NODE_ENV production
+ENV DEFAULT_PRISM_IP_ADDRESS 0.0.0.0
 
 COPY package.json /usr/src/prism/
 COPY packages/core/package.json /usr/src/prism/packages/core/

--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ After [installation](https://stoplight.io/p/docs/gh/stoplightio/prism/docs/getti
 
 ## FAQs
 
-**Cannot access mock server when using docker?**
-
-Prism uses localhost by default, which usually means 127.0.0.1. When using docker the mock server will
-be unreachable outside of the container unless you run the mock command with `-h 0.0.0.0`. 
-
 **Why am I getting 404 errors when I include my basePath?**
 
 OpenAPI v2.0 had a concept called "basePath", which was essentially part of the HTTP path the stuff

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -31,7 +31,7 @@ const mockCommand: CommandModule = {
         host: {
           alias: 'h',
           description: 'Host that Prism will listen to.',
-          default: '127.0.0.1',
+          default: process.env.DEFAULT_PRISM_IP_ADDRESS || '127.0.0.1',
           demandOption: true,
           string: true,
         },


### PR DESCRIPTION
## Checklist

- [ x] Tests have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

_Bug fix_, _feature_, or _docs update_

## What is the current behavior? What is the new behavior?

Currently, prism users have to specify `-h 0.0.0.0` explicitly when running prism server via the `Dockerfile`. I added a `DEFAULT_PRISM_IP_ADDRESS` environment variable that is empty by default, but is overridden in the `Dockerfile` to use `0.0.0.0` so that new users don't get confused when they don't specify an IP address explicitly.

## Does this PR introduce a breaking change?

No


## Manual Tests run:
```bash
# using cli package directly
$ yarn cli mock https://raw.githack.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
yarn run v1.17.3
$ node -r ts-node/register -r tsconfig-paths/register src/index.ts mock https://raw.githack.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
[CLI] …  awaiting  Starting Prism…
[HTTP SERVER] ℹ  info      Server listening at http://127.0.0.1:4010
[CLI] ●  note      GET        http://127.0.0.1:4010/pets
[CLI] ●  note      POST       http://127.0.0.1:4010/pets
[CLI] ●  note      GET        http://127.0.0.1:4010/pets/{id}
[CLI] ●  note      DELETE     http://127.0.0.1:4010/pets/{id}
[CLI] ▶  start     Prism is listening on http://127.0.0.1:4010
$ curl http://127.0.0.1:4010/pets | python -m json.tool
[
    {
        "id": -9223372036854776000,
        "name": "string",
        "tag": "string"
    }
]

# kill server


#...
# using dockerfile
$ docker build -t prism:mytag .
# ...
$ docker run -p 4010:4010 prism:mytag mock https://raw.githack.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
$ curl http://127.0.0.1:4010/pets | python -m json.tool
[
    {
        "id": -9223372036854776000,
        "name": "string",
        "tag": "string"
    }
]
```