### PR TITLE
feat: contract testing: add missing output checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Support for encoding > allowReserved flag when validating application/x-www-form-urlencoded body [#630](https://github.com/stoplightio/prism/pull/630)
 - Validating output status code against available response specs [#648](https://github.com/stoplightio/prism/pull/648)
+- Support for Contract Testing [#650](https://github.com/stoplightio/prism/pull/650)
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixed
 
-- Prism is now giving precedence to `application/json` instead of using it as a "fallback" serializer, fixing some conditions where it wouldn't get triggered correctly. [#604](https://github.com/stoplightio/prism/pulls/604)
-- Prism is now taking in consideration the `required` properties for combined schemas (`oneOf, allOf`). This is coming through an update to the Json Schema Faker Library [#623](https://github.com/stoplightio/prism/pulls/623)
-- Prism will never have enough information to return a `403` status code; all these occurences have been now replaced with a `401` status code which is more appropriate [#625](https://github.com/stoplightio/prism/pulls/625)
-- Prism is now negotiating the error response dynamically based on the validation result (security or schema validation) instead of always returning a static order of responses [#628](https://github.com/stoplightio/prism/pulls/628)
+- Prism is now giving precedence to `application/json` instead of using it as a "fallback" serializer, fixing some conditions where it wouldn't get triggered correctly. [#604](https://github.com/stoplightio/prism/pull/604)
+- Prism is now taking in consideration the `required` properties for combined schemas (`oneOf, allOf`). This is coming through an update to the Json Schema Faker Library [#623](https://github.com/stoplightio/prism/pull/623)
+- Prism will never have enough information to return a `403` status code; all these occurences have been now replaced with a `401` status code which is more appropriate [#625](https://github.com/stoplightio/prism/pull/625)
+- Prism is now negotiating the error response dynamically based on the validation result (security or schema validation) instead of always returning a static order of responses [#628](https://github.com/stoplightio/prism/pull/628)
 - Prism is now selecting proper serializer when Accept header contains content type which is missing in spec. This is a result of simplifying serializer selection approach. [#620](https://github.com/stoplightio/prism/pull/620)
 - HEAD requests no longer fail with 406 Not Acceptable [#603](https://github.com/stoplightio/prism/pull/603)
 
@@ -31,31 +31,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Added
 
-- Prism is now able to validate the security specification of the loaded document [#484](https://github.com/stoplightio/prism/pulls/484)
+- Prism is now able to validate the security specification of the loaded document [#484](https://github.com/stoplightio/prism/pull/484)
 
 ## Fixed
 
-- Prism is not crashing anymore when referencing the same model multiple times in the specification document [#552](https://github.com/stoplightio/prism/pulls/552)
-- Prism will now correctly use the `example` keyword for a Schema Object in OpenAPI 3.0 documents [#560](https://github.com/stoplightio/prism/pulls/560)
-- Prism won't return 406 when users request a `text/plain` response whose content is a primitive (string, number) [#560](https://github.com/stoplightio/prism/pulls/560)
-- Prism's router is now able to correctly handle a path ending with a parameter, such as `/test.{format}`, while it would previously not match with anything. [#561](https://github.com/stoplightio/prism/pulls/561)
-- Prism is correctly handling the `allowEmptyValue` property in OAS2 documents [#569](https://github.com/stoplightio/prism/pulls/569)
-- Prism is correctly handling the `csv` collection format argument property in OAS2 documents [#577](https://github.com/stoplightio/prism/pulls/577)
-- Prism is correctly returning the response when the request has `*/*` as Accept header [#578](https://github.com/stoplightio/prism/pulls/578)
-- Prism is correctly returning a single root node with the payload for XML data [#578](https://github.com/stoplightio/prism/pulls/578)
+- Prism is not crashing anymore when referencing the same model multiple times in the specification document [#552](https://github.com/stoplightio/prism/pull/552)
+- Prism will now correctly use the `example` keyword for a Schema Object in OpenAPI 3.0 documents [#560](https://github.com/stoplightio/prism/pull/560)
+- Prism won't return 406 when users request a `text/plain` response whose content is a primitive (string, number) [#560](https://github.com/stoplightio/prism/pull/560)
+- Prism's router is now able to correctly handle a path ending with a parameter, such as `/test.{format}`, while it would previously not match with anything. [#561](https://github.com/stoplightio/prism/pull/561)
+- Prism is correctly handling the `allowEmptyValue` property in OAS2 documents [#569](https://github.com/stoplightio/prism/pull/569)
+- Prism is correctly handling the `csv` collection format argument property in OAS2 documents [#577](https://github.com/stoplightio/prism/pull/577)
+- Prism is correctly returning the response when the request has `*/*` as Accept header [#578](https://github.com/stoplightio/prism/pull/578)
+- Prism is correctly returning a single root node with the payload for XML data [#578](https://github.com/stoplightio/prism/pull/578)
 - Prism is correctly returning payload-less responses #606
 
 # 3.0.4 (2019-08-20)
 
 ## Added
 
-- Prism is now returning CORS headers by default and responding to all the preflights requests. You can disable this behaviour by running Prism with the `--cors` flag set to false [#525](https://github.com/stoplightio/prism/pulls/525)
+- Prism is now returning CORS headers by default and responding to all the preflights requests. You can disable this behaviour by running Prism with the `--cors` flag set to false [#525](https://github.com/stoplightio/prism/pull/525)
 
 ## Fixed
 
-- Prism now respects the `nullable` value for OpenAPI 3.x documents when generating examples [#506](https://github.com/stoplightio/prism/pulls/506)
-- Prism now loads correctly OpenAPI 3.x documents with `encodings` with non specified `style` property [#507](https://github.com/stoplightio/prism/pulls/507)
-- Prism got rid of some big internal dependencies that now aren't required anymore, making it faster and lighter. [#490](https://github.com/stoplightio/prism/pulls/490)
+- Prism now respects the `nullable` value for OpenAPI 3.x documents when generating examples [#506](https://github.com/stoplightio/prism/pull/506)
+- Prism now loads correctly OpenAPI 3.x documents with `encodings` with non specified `style` property [#507](https://github.com/stoplightio/prism/pull/507)
+- Prism got rid of some big internal dependencies that now aren't required anymore, making it faster and lighter. [#490](https://github.com/stoplightio/prism/pull/490)
 - Prism now correctly validates OAS2 `application/x-www-urlencoded` (form data) params (#483)
 
 # 3.0.3 (2019-07-25)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After [installation](https://stoplight.io/p/docs/gh/stoplightio/prism/docs/getti
 **Cannot access mock server when using docker?**
 
 Prism uses localhost by default, which usually means 127.0.0.1. When using docker the mock server will
-be unreachable outside of the container unless you run the mock command with `-h 0.0.0.0`. 
+be unreachable outside of the container unless you run the mock command with `-h 0.0.0.0`.
 
 **Why am I getting 404 errors when I include my basePath?**
 

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -58,7 +58,7 @@ Once you've got a client instance:
 client.request('https://google.it', { method: 'get' }).then(response => console.log(response));
 ```
 
-The response object has all the informations you need, including the used configuration object.
+The response object has all the information you need, including the used configuration object.
 
 2. You can override the configuration object on the request level if you prefer
 
@@ -68,7 +68,7 @@ client
   .then(response => console.log(response));
 ```
 
-This disables the validation response _only for the current request_
+This disables response validation _only for the current request_
 
 3. You can do the same thing using the shortcut methods
 

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -1,0 +1,1 @@
+# Prism Client

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -1,6 +1,6 @@
 # Prism Client
 
-Prism inclues an Axios style HTTP Client that you can use to seamlessy perform requests to both a real server and a mocked document.
+Prism includes an full featured HTTP Client that you can use to seamlessly perform requests to both a real server and a mocked document. The client is modeled after Axios so it may feel familiar.
 
 ### Create from filename or http resource
 
@@ -12,10 +12,10 @@ const client = await createClientFromResource('examples/petstore.oas2.yaml', {
 });
 ```
 
-### Create from OAS document in string format
+### Create from OpenAPI string
 
 ```ts
-const oasFile = `
+const descriptionDoc = `
 openapi: 3.0.2
 paths:
   /hello:
@@ -25,14 +25,14 @@ paths:
           description: hello
 `;
 
-const client = await createClientFromString(oasFile, {
+const client = await createClientFromString(descriptionDoc, {
   mock: true,
   validateRequest: true,
   validateResponse: true,
 });
 ```
 
-### Create from manual Http Operations (you might want _NOT_ use this)
+### Create From Manual Http Operations
 
 ```ts
 const client = createClientFromOperations(

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -1,8 +1,8 @@
 # Prism Client
 
-Prism includes an full featured HTTP Client that you can use to seamlessly perform requests to both a real server and a mocked document. The client is modeled after Axios so it may feel familiar.
+Prism includes a fully-featured HTTP Client that you can use to seamlessly perform requests to both a real server and a mocked document. The client is modeled after Axios so it may feel familiar.
 
-### Create from filename or http resource
+### Create from a filename or http resource
 
 ```ts
 const client = await createClientFromResource('examples/petstore.oas2.yaml', {

--- a/docs/guides/client.md
+++ b/docs/guides/client.md
@@ -1,1 +1,83 @@
 # Prism Client
+
+Prism inclues an Axios style HTTP Client that you can use to seamlessy perform requests to both a real server and a mocked document.
+
+### Create from filename or http resource
+
+```ts
+const client = await createClientFromResource('examples/petstore.oas2.yaml', {
+  mock: true,
+  validateRequest: true,
+  validateResponse: true,
+});
+```
+
+### Create from OAS document in string format
+
+```ts
+const oasFile = `
+openapi: 3.0.2
+paths:
+  /hello:
+    get:
+      responses:
+        200:
+          description: hello
+`;
+
+const client = await createClientFromString(oasFile, {
+  mock: true,
+  validateRequest: true,
+  validateResponse: true,
+});
+```
+
+### Create from manual Http Operations (you might want _NOT_ use this)
+
+```ts
+const client = createClientFromOperations(
+  [
+    {
+      method: 'get',
+      path: '/hello',
+      id: 'n1',
+      responses: [{ code: '200' }],
+    },
+  ],
+  { mock: true, validateRequest: true, validateResponse: true }
+);
+```
+
+---
+
+Once you've got a client instance:
+
+1. You can perform the request using the generic method:
+
+```ts
+client.request('https://google.it', { method: 'get' }).then(response => console.log(response));
+```
+
+The response object has all the informations you need, including the used configuration object.
+
+2. You can override the configuration object on the request level if you prefer
+
+```ts
+client
+  .request('https://google.it', { method: 'get' }, { validateResponse: false })
+  .then(response => console.log(response));
+```
+
+This disables the validation response _only for the current request_
+
+3. You can do the same thing using the shortcut methods
+
+```ts
+client.get('https://google.it', { mock: false }).then(response => console.log(response));
+```
+
+For the shortcut methods (since the only mandatory option is intrinsic in the function name) the option parameter can be omitted
+
+```ts
+client.get('https://google.it', { validateRequest: false }).then(response => console.log(response));
+```

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "tslint -p packages/tsconfig.test.json --fix",
       "git add"
     ],
-    "*.json, *.md": [
+    "*.{json,md}": [
       "prettier --write",
       "git add"
     ]

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@stoplight/prism-core';
 import { createInstance, IHttpConfig, IHttpMethod, PrismHttpInstance, ProblemJsonError } from '@stoplight/prism-http';
-import { IHttpOperation } from '@stoplight/types';
+import { DiagnosticSeverity, IHttpOperation } from '@stoplight/types';
 import * as fastify from 'fastify';
 import * as fastifyCors from 'fastify-cors';
 import { IncomingMessage, ServerResponse } from 'http';
@@ -107,6 +107,13 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
           if (output.headers) {
             reply.headers(output.headers);
           }
+
+          response.validations.output.forEach(
+            validation =>
+              validation.severity === DiagnosticSeverity.Error
+                ? request.log.error(validation.message)
+                : request.log.warn(validation.message),
+          );
 
           reply.serializer((payload: unknown) => serialize(payload, reply.getHeader('content-type'))).send(output.body);
         } else {

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -108,12 +108,15 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
             reply.headers(output.headers);
           }
 
-          response.validations.output.forEach(
-            validation =>
-              validation.severity === DiagnosticSeverity.Error
-                ? request.log.error(validation.message)
-                : request.log.warn(validation.message),
-          );
+          response.validations.output.forEach(validation => {
+            if (validation.severity === DiagnosticSeverity.Error) {
+              request.log.error(validation.message);
+            } else if (validation.severity === DiagnosticSeverity.Warning) {
+              request.log.warn(validation.message);
+            } else {
+              request.log.info(validation.message);
+            }
+          });
 
           reply.serializer((payload: unknown) => serialize(payload, reply.getHeader('content-type'))).send(output.body);
         } else {

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -10,6 +10,10 @@ In essence it's an HTTP client (similar to axios - in fact, we use axios to make
 
 The goal of this document is to provide you with some basic code examples to get you started and to cover some of the advanced scenarios.
 
+## Important
+
+If you're a regular user and not a PRO, you might to want to use the [User facing client](../../docs/guides/client.md) which
+
 # Table of Contents
 
 - [Installation](#installation)

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -12,7 +12,7 @@ The goal of this document is to provide you with some basic code examples to get
 
 ## Important
 
-If you're a regular user and not a PRO, you might to want to use the [User facing client](../../docs/guides/client.md) which
+If you're a regular user and not a PRO, you might to want to use the [User facing client](../../docs/guides/client.md) which provides a better an higher lever API
 
 # Table of Contents
 

--- a/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
+++ b/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
@@ -34,7 +34,7 @@ Array [
 exports[`HttpValidator validateOutput() all validations are turned on returns validation errors for whole request structure 1`] = `
 Array [
   Object {
-    "message": "The received media type undefined does not match the one specified in the document",
+    "message": "The received media type does not match the one specified in the document",
     "severity": 0,
   },
   Object {

--- a/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
+++ b/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
@@ -34,6 +34,10 @@ Array [
 exports[`HttpValidator validateOutput() all validations are turned on returns validation errors for whole request structure 1`] = `
 Array [
   Object {
+    "message": "The received media type undefined does not match the one specified in the document",
+    "severity": 0,
+  },
+  Object {
     "code": "type",
     "message": "should be boolean",
     "path": Array [

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -191,7 +191,7 @@ describe('HttpValidator', () => {
         it('returns an error', () => {
           expect(validateOutput({ resource, element: { statusCode: 201 } })).toEqual([
             {
-              message: 'Unable to match returned status code with those defined in spec',
+              message: 'Unable to match the returned status code with those defined in spec',
               severity: DiagnosticSeverity.Error,
             },
           ]);
@@ -202,7 +202,7 @@ describe('HttpValidator', () => {
         it('returns an error', () => {
           expect(validateOutput({ resource, element: { statusCode: 400 } })).toEqual([
             {
-              message: 'Unable to match returned status code with those defined in spec',
+              message: 'Unable to match the returned status code with those defined in spec',
               severity: DiagnosticSeverity.Warning,
             },
           ]);

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -237,7 +237,7 @@ describe('HttpValidator', () => {
             validateOutput({ resource, element: { statusCode: 200, headers: { 'content-type': 'application/xml' } } }),
           ).toEqual([
             {
-              message: 'The received media type application/xml does not match the one specified in the document',
+              message: 'The received media type does not match the one specified in the document',
               severity: DiagnosticSeverity.Error,
             },
           ]);

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -168,28 +168,42 @@ describe('HttpValidator', () => {
     });
 
     describe('cannot match status code with responses', () => {
-      it('returns error', () => {
-        (findResponseSpecModule.findOperationResponse as jest.Mock).mockReturnValue(none);
+      beforeEach(() => {
+        jest.spyOn(findResponseSpecModule, 'findOperationResponse').mockReturnValue(none);
         jest.spyOn(bodyValidator, 'validate').mockReturnValue([]);
         jest.spyOn(headersValidator, 'validate').mockReturnValue([]);
+      });
 
-        expect(
-          validateOutput({
-            resource: {
-              method: 'get',
-              path: '/',
-              id: '1',
-              request: {},
-              responses: [{ code: '200' }],
+      afterEach(() => jest.clearAllMocks());
+
+      const resource: IHttpOperation = {
+        method: 'get',
+        path: '/',
+        id: '1',
+        request: {},
+        responses: [{ code: '200' }],
+      };
+
+      describe('when the desidered response is between 200 and 300', () => {
+        it('returns an error', () => {
+          expect(validateOutput({ resource, element: { statusCode: 201 } })).toEqual([
+            {
+              message: 'Unable to match returned status code with those defined in spec',
+              severity: DiagnosticSeverity.Error,
             },
-            element: { statusCode: 400 },
-          }),
-        ).toEqual([
-          {
-            message: 'Unable to match returned status code with those defined in spec',
-            severity: DiagnosticSeverity.Error,
-          },
-        ]);
+          ]);
+        });
+      });
+
+      describe('when the desidered response is over 300', () => {
+        it('returns an error', () => {
+          expect(validateOutput({ resource, element: { statusCode: 400 } })).toEqual([
+            {
+              message: 'Unable to match returned status code with those defined in spec',
+              severity: DiagnosticSeverity.Warning,
+            },
+          ]);
+        });
       });
     });
   });

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -1,6 +1,5 @@
 import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { DiagnosticSeverity, IHttpOperation } from '@stoplight/types';
-import { none, some } from 'fp-ts/lib/Option';
 import { IHttpRequest } from '../../types';
 import { bodyValidator, headersValidator, queryValidator, validateInput, validateOutput } from '../index';
 import * as findResponseSpecModule from '../utils/spec';
@@ -13,15 +12,15 @@ const mockError: IPrismDiagnostic = {
 };
 
 describe('HttpValidator', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.spyOn(findResponseSpecModule, 'findOperationResponse').mockReturnValue(none);
-    jest.spyOn(bodyValidator, 'validate').mockReturnValue([mockError]);
-    jest.spyOn(headersValidator, 'validate').mockReturnValue([mockError]);
-    jest.spyOn(queryValidator, 'validate').mockReturnValue([mockError]);
-  });
-
   describe('validateInput()', () => {
+    beforeAll(() => {
+      jest.spyOn(bodyValidator, 'validate').mockReturnValue([mockError]);
+      jest.spyOn(headersValidator, 'validate').mockReturnValue([mockError]);
+      jest.spyOn(queryValidator, 'validate').mockReturnValue([mockError]);
+    });
+
+    afterAll(() => jest.restoreAllMocks());
+
     describe('body validation in enabled', () => {
       const validate = (resourceExtension: Partial<IHttpOperation> | undefined, errorsNumber: number) => () => {
         expect(
@@ -71,83 +70,89 @@ describe('HttpValidator', () => {
         });
       });
     });
-  });
 
-  describe('headers validation in enabled', () => {
-    const validate = (resourceExtension?: Partial<IHttpOperation>, length: number = 1) => () => {
-      expect(
-        validateInput({
-          resource: Object.assign(
-            {
-              method: 'get',
-              path: '/',
-              id: '1',
-              request: {},
-              responses: [{ code: '200' }],
-            },
-            resourceExtension,
-          ),
-          element: { method: 'get', url: { path: '/' } },
-        }),
-      ).toHaveLength(length);
-    };
+    describe('headers validation in enabled', () => {
+      const validate = (resourceExtension?: Partial<IHttpOperation>, length: number = 1) => () => {
+        expect(
+          validateInput({
+            resource: Object.assign(
+              {
+                method: 'get',
+                path: '/',
+                id: '1',
+                request: {},
+                responses: [{ code: '200' }],
+              },
+              resourceExtension,
+            ),
+            element: { method: 'get', url: { path: '/' } },
+          }),
+        ).toHaveLength(length);
+      };
 
-    describe('request is not set', () => {
-      it('validates headers', validate(undefined, 2));
-    });
-  });
-
-  describe('query validation in enabled', () => {
-    const validate = (
-      resourceExtension?: Partial<IHttpOperation>,
-      inputExtension?: Partial<IHttpRequest>,
-      length: number = 2,
-    ) => () => {
-      expect(
-        validateInput({
-          resource: Object.assign(
-            {
-              method: 'get',
-              path: '/',
-              id: '1',
-              request: {},
-              responses: [{ code: '200' }],
-            },
-            resourceExtension,
-          ),
-          element: Object.assign({ method: 'get', url: { path: '/', query: {} } }, inputExtension),
-        }),
-      ).toHaveLength(length);
-
-      expect(bodyValidator.validate).not.toHaveBeenCalled();
-      expect(headersValidator.validate).toHaveBeenCalled();
-      expect(queryValidator.validate).toHaveBeenCalledWith({}, []);
-    };
-
-    describe('request is not set', () => {
-      it('validates query', validate(undefined, undefined, 2));
-    });
-
-    describe('request is set', () => {
-      describe('request.query is not set', () => {
-        it('validates query', validate({ request: {} }, undefined, 2));
-      });
-
-      describe('request.query is set', () => {
-        it('validates query', validate({ request: {} }, undefined, 2));
+      describe('request is not set', () => {
+        it('validates headers', validate(undefined, 2));
       });
     });
 
-    describe('input.url.query is not set', () => {
-      it("validates query assuming it's empty", validate(undefined, { url: { path: '/' } }));
+    describe('query validation in enabled', () => {
+      const validate = (
+        resourceExtension?: Partial<IHttpOperation>,
+        inputExtension?: Partial<IHttpRequest>,
+        length: number = 2,
+      ) => () => {
+        expect(
+          validateInput({
+            resource: Object.assign(
+              {
+                method: 'get',
+                path: '/',
+                id: '1',
+                request: {},
+                responses: [{ code: '200' }],
+              },
+              resourceExtension,
+            ),
+            element: Object.assign({ method: 'get', url: { path: '/', query: {} } }, inputExtension),
+          }),
+        ).toHaveLength(length);
+
+        expect(bodyValidator.validate).not.toHaveBeenCalled();
+        expect(headersValidator.validate).toHaveBeenCalled();
+        expect(queryValidator.validate).toHaveBeenCalledWith({}, []);
+      };
+
+      describe('request is not set', () => {
+        it('validates query', validate(undefined, undefined, 2));
+      });
+
+      describe('request is set', () => {
+        describe('request.query is not set', () => {
+          it('validates query', validate({ request: {} }, undefined, 2));
+        });
+
+        describe('request.query is set', () => {
+          it('validates query', validate({ request: {} }, undefined, 2));
+        });
+      });
+
+      describe('input.url.query is not set', () => {
+        it("validates query assuming it's empty", validate(undefined, { url: { path: '/' } }));
+      });
     });
   });
 
   describe('validateOutput()', () => {
     describe('output is set', () => {
-      it('validates the body and headers', () => {
-        (findResponseSpecModule.findOperationResponse as jest.Mock).mockReturnValue(some({ statusCode: 200 }));
+      beforeAll(() => {
+        jest.spyOn(bodyValidator, 'validate').mockReturnValue([mockError]);
+        jest.spyOn(headersValidator, 'validate').mockReturnValue([mockError]);
+        jest.spyOn(queryValidator, 'validate').mockReturnValue([mockError]);
+      });
 
+      afterAll(() => jest.restoreAllMocks());
+
+      it('validates the body and headers', () => {
         expect(
           validateOutput({
             resource: {
@@ -161,7 +166,6 @@ describe('HttpValidator', () => {
           }),
         ).toHaveLength(2);
 
-        expect(findResponseSpecModule.findOperationResponse).toHaveBeenCalled();
         expect(bodyValidator.validate).toHaveBeenCalledWith(undefined, [], undefined);
         expect(headersValidator.validate).toHaveBeenCalled();
       });
@@ -169,7 +173,6 @@ describe('HttpValidator', () => {
 
     describe('cannot match status code with responses', () => {
       beforeEach(() => {
-        jest.spyOn(findResponseSpecModule, 'findOperationResponse').mockReturnValue(none);
         jest.spyOn(bodyValidator, 'validate').mockReturnValue([]);
         jest.spyOn(headersValidator, 'validate').mockReturnValue([]);
       });
@@ -203,6 +206,49 @@ describe('HttpValidator', () => {
               severity: DiagnosticSeverity.Warning,
             },
           ]);
+        });
+      });
+    });
+
+    describe('returned response media type', () => {
+      const resource: IHttpOperation = {
+        method: 'get',
+        path: '/',
+        id: '1',
+        request: {},
+        responses: [
+          {
+            code: '200',
+            contents: [
+              {
+                mediaType: 'application/json',
+                schema: {
+                  type: 'string',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      describe('when the response has a content type not declared in the spec', () => {
+        it('returns an error', () => {
+          expect(
+            validateOutput({ resource, element: { statusCode: 200, headers: { 'content-type': 'application/xml' } } }),
+          ).toEqual([
+            {
+              message: 'The received media type application/xml does not match the one specified in the document',
+              severity: DiagnosticSeverity.Error,
+            },
+          ]);
+        });
+      });
+
+      describe('when the response has a content type declared in the spec', () => {
+        it('returns an error', () => {
+          expect(
+            validateOutput({ resource, element: { statusCode: 200, headers: { 'content-type': 'application/json' } } }),
+          ).toEqual([]);
         });
       });
     });

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -159,7 +159,7 @@ describe('HttpValidator', () => {
             },
             element: { statusCode: 200 },
           }),
-        ).toHaveLength(3);
+        ).toHaveLength(2);
 
         expect(findResponseSpecModule.findOperationResponse).toHaveBeenCalled();
         expect(bodyValidator.validate).toHaveBeenCalledWith(undefined, [], undefined);

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -159,7 +159,7 @@ describe('HttpValidator', () => {
             },
             element: { statusCode: 200 },
           }),
-        ).toHaveLength(2);
+        ).toHaveLength(3);
 
         expect(findResponseSpecModule.findOperationResponse).toHaveBeenCalled();
         expect(bodyValidator.validate).toHaveBeenCalledWith(undefined, [], undefined);

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -45,7 +45,7 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
     Option.fold<IHttpOperationResponse, IPrismDiagnostic[]>(
       () => [
         {
-          message: 'Unable to match returned status code with those defined in spec',
+          message: 'Unable to match the returned status code with those defined in spec',
           severity:
             element.statusCode >= 200 && element.statusCode <= 299
               ? DiagnosticSeverity.Error

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -55,8 +55,8 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
       operationResponse => {
         const mismatchingMediaTypeError = pipe(
           Option.fromNullable(operationResponse.contents),
-          Option.map(contents => {
-            return pipe(
+          Option.map(contents =>
+            pipe(
               contents,
               findFirst(c => c.mediaType === mediaType),
               Option.map<IMediaTypeContent, IPrismDiagnostic[]>(() => []),
@@ -66,8 +66,8 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
                   severity: DiagnosticSeverity.Error,
                 },
               ]),
-            );
-          }),
+            ),
+          ),
           Option.getOrElse<IPrismDiagnostic[]>(() => []),
         );
 

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -1,8 +1,9 @@
 import { IPrismDiagnostic, ValidatorFn } from '@stoplight/prism-core';
-import { DiagnosticSeverity, IHttpOperation, IHttpOperationResponse } from '@stoplight/types';
+import { DiagnosticSeverity, IHttpOperation, IHttpOperationResponse, IMediaTypeContent } from '@stoplight/types';
 import * as caseless from 'caseless';
 
-import { fold } from 'fp-ts/lib/Option';
+import { findFirst } from 'fp-ts/lib/Array';
+import * as Option from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { IHttpRequest, IHttpResponse } from '../types';
 import { header as headerDeserializerRegistry, query as queryDeserializerRegistry } from './deserializers';
@@ -41,7 +42,7 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
 
   return pipe(
     findOperationResponse(resource.responses, element.statusCode),
-    fold<IHttpOperationResponse, IPrismDiagnostic[]>(
+    Option.fold<IHttpOperationResponse, IPrismDiagnostic[]>(
       () => [
         {
           message: 'Unable to match returned status code with those defined in spec',
@@ -51,10 +52,28 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
               : DiagnosticSeverity.Warning,
         },
       ],
-      operationResponse =>
-        bodyValidator
-          .validate(element.body, operationResponse.contents || [], mediaType)
-          .concat(headersValidator.validate(element.headers || {}, operationResponse.headers || [])),
+      operationResponse => {
+        const mismatchingMediatype = pipe(
+          Option.fromNullable(operationResponse.contents),
+          Option.chain(contents =>
+            pipe(
+              contents,
+              findFirst(c => c.mediaType === mediaType),
+            ),
+          ),
+          Option.map<IMediaTypeContent, IPrismDiagnostic[]>(() => []),
+          Option.getOrElse<IPrismDiagnostic[]>(() => [
+            {
+              message: `The received media type ${mediaType} does not match the one specified in the document`,
+              severity: DiagnosticSeverity.Error,
+            },
+          ]),
+        );
+
+        return mismatchingMediatype
+          .concat(bodyValidator.validate(element.body, operationResponse.contents || [], mediaType))
+          .concat(headersValidator.validate(element.headers || {}, operationResponse.headers || []));
+      },
     ),
   );
 };

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -42,18 +42,19 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
   return pipe(
     findOperationResponse(resource.responses, element.statusCode),
     fold<IHttpOperationResponse, IPrismDiagnostic[]>(
-      () => {
-        return [
-          {
-            message: 'Unable to match returned status code with those defined in spec',
-            severity: DiagnosticSeverity.Error,
-          },
-        ];
-      },
-      responseDescDoc =>
+      () => [
+        {
+          message: 'Unable to match returned status code with those defined in spec',
+          severity:
+            element.statusCode >= 200 && element.statusCode <= 299
+              ? DiagnosticSeverity.Error
+              : DiagnosticSeverity.Warning,
+        },
+      ],
+      operationResponse =>
         bodyValidator
-          .validate(element.body, responseDescDoc.contents || [], mediaType)
-          .concat(headersValidator.validate(element.headers || {}, responseDescDoc.headers || [])),
+          .validate(element.body, operationResponse.contents || [], mediaType)
+          .concat(headersValidator.validate(element.headers || {}, operationResponse.headers || [])),
     ),
   );
 };

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -5,6 +5,7 @@ import * as caseless from 'caseless';
 import { findFirst } from 'fp-ts/lib/Array';
 import * as Option from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
+import { inRange } from 'lodash';
 import { IHttpRequest, IHttpResponse } from '../types';
 import { header as headerDeserializerRegistry, query as queryDeserializerRegistry } from './deserializers';
 import { findOperationResponse } from './utils/spec';
@@ -46,10 +47,7 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
       () => [
         {
           message: 'Unable to match the returned status code with those defined in spec',
-          severity:
-            element.statusCode >= 200 && element.statusCode <= 299
-              ? DiagnosticSeverity.Error
-              : DiagnosticSeverity.Warning,
+          severity: inRange(element.statusCode, 200, 300) ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning,
         },
       ],
       operationResponse => {
@@ -62,7 +60,7 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
               Option.map<IMediaTypeContent, IPrismDiagnostic[]>(() => []),
               Option.getOrElse<IPrismDiagnostic[]>(() => [
                 {
-                  message: `The received media type ${mediaType} does not match the one specified in the document`,
+                  message: `The received media type does not match the one specified in the document`,
                   severity: DiagnosticSeverity.Error,
                 },
               ]),


### PR DESCRIPTION
This PR is implementing two checks missing in the output validation that are required according to #429 

1. If the media type of the response does not match the media type in the document, we add an error
2. If the returned status code is *not* the one defined in the document and it's between 200 and 299, then it's an error, otherwise a warning.

I've added tests and reorganised these since I think we were a bit too aggressive with the mocking (and not cleaning them up)

Closes #429