### PR TITLE
Restore/refactor the forwarder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,6 @@ executors:
   macos:
     macos:
       xcode: 10.2.1
-commands:
-  early_return_for_forked_pull_requests:
-    description: >-
-      If this build is from a fork, stop executing the current job and return success.
-      This is useful to avoid steps that will fail due to missing credentials.
-    steps:
-      - run:
-          name: Early return if this build is from a forked PR
-          command: |
-            if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              echo "Nothing to do for forked PRs, so marking this step successful"
-              circleci step halt
-            fi
 jobs:
   build:
     executor: docker-node
@@ -42,7 +29,6 @@ jobs:
       - run:
           name: Run build
           command: yarn build
-      - early_return_for_forked_pull_requests
   harness:
     parameters:
       executor:
@@ -59,7 +45,6 @@ jobs:
       - run:
           name: Run Harness
           command: yarn test.harness
-
   publish:
     executor: docker-node
     steps:
@@ -95,7 +80,6 @@ jobs:
       - run:
           name: "Publish Release artifacts on GitHub"
           command: ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG} /tmp/cli-binaries
-
 workflows:
   version: 2
   build:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/signale": "^1.2.1",
     "@types/split2": "^2.1.6",
     "@types/type-is": "^1.6.3",
+    "@types/urijs": "^1.19.4",
     "abstract-logging": "^1.0.0",
     "chance": "^1.0.18",
     "diff-js-xml": "^1.0.5",

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -1,7 +1,8 @@
 // @ts-ignore
 import logger from 'abstract-logging';
-import { right } from 'fp-ts/lib/Either';
+import * as Either from 'fp-ts/lib/Either';
 import { asks } from 'fp-ts/lib/ReaderEither';
+import * as TaskEither from 'fp-ts/lib/TaskEither';
 import { Logger } from 'pino';
 import { factory, IPrismConfig } from '..';
 
@@ -9,7 +10,14 @@ describe('validation', () => {
   const components = {
     validateInput: jest.fn().mockReturnValue(['something']),
     validateOutput: jest.fn().mockReturnValue(['something']),
-    route: jest.fn().mockReturnValue(right('hey')),
+    route: jest.fn().mockReturnValue(Either.right('hey')),
+    forward: jest.fn().mockReturnValue(
+      TaskEither.right({
+        statusCode: 200,
+        headers: {},
+        body: {},
+      }),
+    ),
     logger: { ...logger, child: jest.fn().mockReturnValue(logger) },
     mock: jest.fn().mockReturnValue(asks<Logger, Error, string>(r => 'hey')),
   };

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -75,21 +75,6 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
             },
           };
         }),
-        TaskEither.mapLeft(error => {
-          if (components.validateInput) {
-            const { message, name, status } = error as ProblemJsonError;
-            // let's just stack it on the inputValidations
-            // when someone simply wants to hit an URL, don't block them
-            inputValidations.push({
-              message,
-              source: name,
-              code: status,
-              severity: DiagnosticSeverity.Warning,
-            });
-
-            return error;
-          }
-        }),
       )().then(v =>
         pipe(
           v,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,7 @@ export type IPrismComponents<Resource, Input, Output, Config extends IPrismConfi
   route: (opts: { resources: Resource[]; input: Input }) => Either<Error, Resource>;
   validateInput: ValidatorFn<Resource, Input>;
   validateOutput: ValidatorFn<Resource, Output>;
-  forward: (opts: { resource?: Resource; input: IPrismInput<Input> }) => TaskEither<Error, Output>;
+  forward: (resource: Resource, input: Input) => TaskEither<Error, Output>;
   mock: (
     opts: {
       resource: Resource;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 import { IDiagnostic } from '@stoplight/types';
 import { Either } from 'fp-ts/lib/Either';
-import { Reader } from 'fp-ts/lib/Reader';
+import { ReaderEither } from 'fp-ts/lib/ReaderEither';
+import { TaskEither } from 'fp-ts/lib/TaskEither';
 import { Logger } from 'pino';
 export type IPrismDiagnostic = Omit<IDiagnostic, 'range'>;
 
@@ -9,7 +10,7 @@ export interface IPrism<Resource, Input, Output, Config extends IPrismConfig> {
 }
 
 export interface IPrismConfig {
-  mock: unknown;
+  mock: false | unknown;
   checkSecurity: boolean;
   validateRequest: boolean;
   validateResponse: boolean;
@@ -21,13 +22,14 @@ export type IPrismComponents<Resource, Input, Output, Config extends IPrismConfi
   route: (opts: { resources: Resource[]; input: Input }) => Either<Error, Resource>;
   validateInput: ValidatorFn<Resource, Input>;
   validateOutput: ValidatorFn<Resource, Output>;
+  forward: (opts: { resource?: Resource; input: IPrismInput<Input> }) => TaskEither<Error, Output>;
   mock: (
     opts: {
       resource: Resource;
       input: IPrismInput<Input>;
       config: Config['mock'];
     },
-  ) => Reader<Logger, Either<Error, Output>>;
+  ) => ReaderEither<Logger, Error, Output>;
   logger: Logger;
 };
 

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -21,11 +21,6 @@ describe('body params validation', () => {
     return server.fastify.close();
   });
 
-  describe('http operation with encodings', () => {
-    // Ref: https://github.com/stoplightio/prism/issues/496
-    test.todo('allowReserved set to true');
-  });
-
   describe('http operation with body param', () => {
     beforeEach(async () => {
       server = instantiatePrism2([

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -80,27 +80,23 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
       const { output } = response;
 
-      if (output) {
-        reply.code(output.statusCode);
+      reply.code(output.statusCode);
 
-        if (output.headers) {
-          reply.headers(output.headers);
-        }
-
-        response.validations.output.forEach(validation => {
-          if (validation.severity === DiagnosticSeverity.Error) {
-            request.log.error(`${validation.path} — ${validation.message}`);
-          } else if (validation.severity === DiagnosticSeverity.Warning) {
-            request.log.warn(`${validation.path} — ${validation.message}`);
-          } else {
-            request.log.info(`${validation.path} — ${validation.message}`);
-          }
-        });
-
-        reply.serializer((payload: unknown) => serialize(payload, reply.getHeader('content-type'))).send(output.body);
-      } else {
-        throw new Error('Unable to find any decent response for the current request.');
+      if (output.headers) {
+        reply.headers(output.headers);
       }
+
+      response.validations.output.forEach(validation => {
+        if (validation.severity === DiagnosticSeverity.Error) {
+          request.log.error(`${validation.path} — ${validation.message}`);
+        } else if (validation.severity === DiagnosticSeverity.Warning) {
+          request.log.warn(`${validation.path} — ${validation.message}`);
+        } else {
+          request.log.info(`${validation.path} — ${validation.message}`);
+        }
+      });
+
+      reply.serializer((payload: unknown) => serialize(payload, reply.getHeader('content-type'))).send(output.body);
     } catch (e) {
       if (!reply.sent) {
         const status = 'status' in e ? e.status : 500;

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@stoplight/prism-core';
-import { createInstance, IHttpConfig, ProblemJsonError } from '@stoplight/prism-http';
+import { createInstance, IHttpConfig, IHttpOperationConfig, ProblemJsonError } from '@stoplight/prism-http';
 import { DiagnosticSeverity, HttpMethod, IHttpOperation } from '@stoplight/types';
 import * as fastify from 'fastify';
 import * as fastifyCors from 'fastify-cors';
@@ -40,7 +40,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     return done(error);
   });
 
-  const mergedConfig = defaults<Partial<IHttpConfig>, IHttpConfig>(config, {
+  const mergedConfig = defaults<unknown, IHttpConfig>(config, {
     mock: { dynamic: false },
     validateRequest: true,
     validateResponse: true,
@@ -71,7 +71,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     request.log.info({ input }, 'Request received');
     try {
       const operationSpecificConfig = getHttpConfigFromRequest(input);
-      const mockConfig = { ...opts.config.mock, ...operationSpecificConfig };
+      const mockConfig = opts.config.mock === false ? false : { ...opts.config.mock, ...operationSpecificConfig };
 
       const response = await prism.request(input, operations, {
         ...opts.config,

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -89,11 +89,11 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
         response.validations.output.forEach(validation => {
           if (validation.severity === DiagnosticSeverity.Error) {
-            request.log.error(validation.message);
+            request.log.error(`${validation.path} — ${validation.message}`);
           } else if (validation.severity === DiagnosticSeverity.Warning) {
-            request.log.warn(validation.message);
+            request.log.warn(`${validation.path} — ${validation.message}`);
           } else {
-            request.log.info(validation.message);
+            request.log.info(`${validation.path} — ${validation.message}`);
           }
         });
 

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@stoplight/prism-core';
-import { createInstance, IHttpConfig, IHttpOperationConfig, ProblemJsonError } from '@stoplight/prism-http';
+import { createInstance, IHttpConfig, ProblemJsonError } from '@stoplight/prism-http';
 import { DiagnosticSeverity, HttpMethod, IHttpOperation } from '@stoplight/types';
 import * as fastify from 'fastify';
 import * as fastifyCors from 'fastify-cors';

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,8 +16,8 @@
     "node": ">=8"
   },
   "dependencies": {
-    "abstract-logging": "^1.0.0",
     "@stoplight/prism-core": "^3.1.1",
+    "abstract-logging": "^1.0.0",
     "accepts": "^1.3.7",
     "ajv": "^6.10.2",
     "ajv-oai": "^1.0.0",
@@ -28,7 +28,8 @@
     "openapi-sampler": "^1.0.0-beta.15",
     "pino": "^5.13.2",
     "tslib": "^1.10.0",
-    "type-is": "^1.6.18"
+    "type-is": "^1.6.18",
+    "urijs": "^1.19.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -130,9 +130,9 @@ describe('Http Client .request', () => {
       });
     });
 
-    describe.skip('mocking is off', () => {
+    describe('mocking is off', () => {
       const config: IHttpConfig = {
-        mock: { dynamic: false },
+        mock: false,
         checkSecurity: true,
         validateRequest: true,
         validateResponse: true,

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -74,7 +74,7 @@ describe('Http Client .request', () => {
         );
 
         expect(result.output).toBeDefined();
-        expect(result.output!.statusCode).toBe(200);
+        expect(result.output.statusCode).toBe(200);
       });
     });
 
@@ -92,7 +92,7 @@ describe('Http Client .request', () => {
         );
 
         expect(result.output).toBeDefined();
-        expect(result.output!.statusCode).toBe(200);
+        expect(result.output.statusCode).toBe(200);
       });
     });
 
@@ -157,44 +157,10 @@ describe('Http Client .request', () => {
           },
         };
 
-        it('returns input warning', async () => {
-          const result = await prism.request(request, resources, config);
-
-          expect(result.validations.input).toEqual([
-            {
-              code: 404,
-              source: 'https://stoplight.io/prism/errors#NO_PATH_MATCHED_ERROR',
-              message: 'Route not resolved, no path matched',
-              severity: DiagnosticSeverity.Warning,
-            },
-          ]);
-        });
-
-        it('makes a http request anyway', async () => {
-          // note that we are 'nocking' the request in beforeEach
-          const result = await prism.request(request, resources, config);
-
-          expect(result.output).toBeDefined();
-          expect(result.output!.statusCode).toEqual(200);
-          expect(result.output!.body).toEqual(serverReply);
-        });
-
-        describe('baseUrl is not set', () => {
-          it('throws an error', () => {
-            return expect(
-              prism.request(
-                {
-                  method: 'get',
-                  url: {
-                    path: '/x-pet',
-                  },
-                },
-                resources,
-                config,
-              ),
-            ).rejects.toThrowError(ProblemJsonError.fromTemplate(NO_BASE_URL_ERROR));
-          });
-        });
+        it('fails the operation', () =>
+          expect(prism.request(request, resources, config)).rejects.toThrowError(
+            ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR),
+          ));
       });
 
       describe('path is valid and baseUrl is not set', () => {
@@ -217,8 +183,8 @@ describe('Http Client .request', () => {
           );
 
           expect(result.output).toBeDefined();
-          expect(result.output!.statusCode).toEqual(200);
-          expect(result.output!.body).toEqual(reply);
+          expect(result.output.statusCode).toEqual(200);
+          expect(result.output.body).toEqual(reply);
         });
       });
 
@@ -269,9 +235,6 @@ describe('Http Client .request', () => {
       });
     });
 
-    // TODO will be fixed by https://stoplightio.atlassian.net/browse/SO-260
-    test.todo('GET /pet without an optional body parameter');
-
     describe('when requesting GET /pet/findByStatus', () => {
       it('with valid query params returns generated body', async () => {
         const response = await prism.request(
@@ -287,7 +250,7 @@ describe('Http Client .request', () => {
           resources,
         );
 
-        const parsedBody = response!.output!.body;
+        const parsedBody = response.output.body;
 
         expect(typeof parsedBody).toBe('string');
         expect(response).toMatchSnapshot({
@@ -392,6 +355,6 @@ describe('Http Client .request', () => {
     );
 
     expect(response.output).toBeDefined();
-    expect(response.output!.body).toBeInstanceOf(Array);
+    expect(response.output.body).toBeInstanceOf(Array);
   });
 });

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -146,9 +146,7 @@ describe('Http Client .request', () => {
           .reply(200, serverReply);
       });
 
-      afterEach(() => {
-        nock.cleanAll();
-      });
+      afterEach(() => nock.cleanAll());
 
       describe('path is not valid', () => {
         const request: IHttpRequest = {

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -7,10 +7,7 @@ import { parse as parseQueryString } from 'querystring';
 import { parse as parseUrl } from 'url';
 import { createInstance } from '.';
 import getHttpOperations, { getHttpOperationsFromResource } from './getHttpOperations';
-import mock from './mocker';
-import route from './router';
 import { IHttpConfig, IHttpRequest, IHttpResponse, IHttpUrl } from './types';
-import { validateInput, validateOutput } from './validator';
 
 interface IClientConfig extends IHttpConfig {
   baseUrl?: string;
@@ -30,13 +27,7 @@ const createClientFromString = partial(createClientFrom, getHttpOperations);
 function createClientFromOperations(resources: IHttpOperation[], defaultConfig: IClientConfig): PrismHttp {
   const lg = { ...logger, child: () => lg, success: logger.info };
 
-  const obj = createInstance(defaultConfig, {
-    logger: lg,
-    route,
-    validateInput,
-    validateOutput,
-    mock,
-  });
+  const obj = createInstance(defaultConfig, { logger: lg });
 
   type headersFromRequest = Required<Pick<IHttpRequest, 'headers'>>;
 

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -1,0 +1,58 @@
+import { IPrismComponents } from '@stoplight/prism-core';
+import { IHttpOperation, IServer } from '@stoplight/types';
+import axios from 'axios';
+import { toError } from 'fp-ts/lib/Either';
+import { TaskEither, tryCatch } from 'fp-ts/lib/TaskEither';
+import { defaults } from 'lodash';
+import { NO_BASE_URL_ERROR } from '../router/errors';
+import { IHttpConfig, IHttpRequest, IHttpResponse, ProblemJsonError } from '../types';
+const { version: prismVersion } = require('../../package.json');
+
+const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>['forward'] = (
+  resource: IHttpOperation,
+  input: IHttpRequest,
+  timeout: number = 0,
+): TaskEither<Error, IHttpResponse> => {
+  return tryCatch<Error, IHttpResponse>(async () => {
+    const baseUrl =
+      resource.servers && resource.servers.length > 0 ? resolveServerUrl(resource.servers[0]) : input.url.baseUrl;
+
+    if (!baseUrl) {
+      throw ProblemJsonError.fromTemplate(NO_BASE_URL_ERROR);
+    }
+
+    const response = await axios.request<unknown>({
+      method: input.method as any,
+      baseURL: baseUrl,
+      url: input.url.path,
+      params: input.url.query,
+      data: input.body,
+      headers: defaults(input.headers, { 'user-agent': `Prism/${prismVersion}` }),
+      validateStatus: () => true,
+      timeout: Math.max(timeout, 0),
+    });
+
+    return {
+      statusCode: response.status,
+      headers: response.headers,
+      body: response.data,
+    };
+  }, toError);
+};
+
+function resolveServerUrl(server: IServer) {
+  if (!server.variables) {
+    return server.url;
+  }
+
+  return server.url.replace(/{(.*?)}/g, (_match, variableName) => {
+    const variable = server.variables![variableName];
+    if (!variable) {
+      throw new Error(`Variable '${variableName}' is not defined, cannot parse input.`);
+    }
+
+    return variable.default || variable.enum![0];
+  });
+}
+
+export default forward;

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -2,7 +2,7 @@ import { IPrismComponents } from '@stoplight/prism-core';
 import { IHttpOperation, IServer } from '@stoplight/types';
 import axios from 'axios';
 import { toError } from 'fp-ts/lib/Either';
-import { TaskEither, tryCatch } from 'fp-ts/lib/TaskEither';
+import * as TaskEither from 'fp-ts/lib/TaskEither';
 import { defaults } from 'lodash';
 import { NO_BASE_URL_ERROR } from '../router/errors';
 import { IHttpConfig, IHttpRequest, IHttpResponse, ProblemJsonError } from '../types';
@@ -12,15 +12,15 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
   resource: IHttpOperation,
   input: IHttpRequest,
   timeout: number = 0,
-): TaskEither<Error, IHttpResponse> => {
-  return tryCatch<Error, IHttpResponse>(async () => {
-    const baseUrl =
-      resource.servers && resource.servers.length > 0 ? resolveServerUrl(resource.servers[0]) : input.url.baseUrl;
+): TaskEither.TaskEither<Error, IHttpResponse> => {
+  const baseUrl =
+    resource.servers && resource.servers.length > 0 ? resolveServerUrl(resource.servers[0]) : input.url.baseUrl;
 
-    if (!baseUrl) {
-      throw ProblemJsonError.fromTemplate(NO_BASE_URL_ERROR);
-    }
+  if (!baseUrl) {
+    return TaskEither.left(ProblemJsonError.fromTemplate(NO_BASE_URL_ERROR));
+  }
 
+  return TaskEither.tryCatch<Error, IHttpResponse>(async () => {
     const response = await axios.request<unknown>({
       method: input.method as any,
       baseURL: baseUrl,

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,6 +1,7 @@
 import { factory } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 import { defaults } from 'lodash';
+import forward from './forwarder';
 import mock from './mocker';
 import route from './router';
 import { validateInput, validateOutput } from './validator';
@@ -15,5 +16,5 @@ export const createInstance = (
 ) =>
   factory<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>(
     defaultConfig,
-    defaults(components, { route, validateInput, validateOutput, mock }),
+    defaults(components, { route, validateInput, validateOutput, mock, forward }),
   );

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -10,10 +10,10 @@ import { isEmpty, isObject, keyBy, mapValues } from 'lodash';
 import { Logger } from 'pino';
 import {
   ContentExample,
-  IHttpConfig,
   IHttpOperationConfig,
   IHttpRequest,
   IHttpResponse,
+  IMockHttpConfig,
   PayloadGenerator,
   ProblemJsonError,
 } from '../types';
@@ -23,7 +23,7 @@ import { generate, generateStatic } from './generator/JSONSchema';
 import helpers from './negotiator/NegotiatorHelpers';
 import { IHttpNegotiationResult } from './negotiator/types';
 
-const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>['mock'] = ({
+const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IMockHttpConfig>['mock'] = ({
   resource,
   input,
   config,

--- a/packages/http/src/router/errors.ts
+++ b/packages/http/src/router/errors.ts
@@ -21,7 +21,7 @@ export const NO_SERVER_MATCHED_ERROR: Omit<ProblemJson, 'detail'> = {
   status: 404,
 };
 export const NO_METHOD_MATCHED_ERROR: Omit<ProblemJson, 'detail'> = {
-  title: 'Route resolved, but no path matched',
+  title: 'Route resolved, but no method matched',
   type: 'NO_METHOD_MATCHED_ERROR',
   status: 405,
 };

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -40,7 +40,6 @@ export interface IHttpResponse {
   statusCode: number;
   headers?: IHttpNameValue;
   body?: unknown;
-  responseType?: XMLHttpRequestResponseType;
 }
 
 export type ProblemJson = {

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -14,8 +14,10 @@ export interface IHttpOperationConfig {
 }
 
 export interface IHttpConfig extends IPrismConfig {
-  mock: IHttpOperationConfig;
+  mock: false | IHttpOperationConfig;
 }
+
+export type IMockHttpConfig = IHttpConfig & { mock: IHttpOperationConfig };
 
 export type IHttpNameValues = Dictionary<string | string[]>;
 

--- a/test-harness/specs/cors/cors-headers-disabled.txt
+++ b/test-harness/specs/cors/cors-headers-disabled.txt
@@ -21,4 +21,4 @@ curl -i -X OPTIONS http://localhost:4010/todos
 ====expect====
 HTTP/1.1 405 Method Not Allowed
 
-{"type":"https://stoplight.io/prism/errors#NO_METHOD_MATCHED_ERROR","title":"Route resolved, but no path matched","status":405,"detail":"The route /todos has been matched, but it does not have \"options\" method defined"}
+{"type":"https://stoplight.io/prism/errors#NO_METHOD_MATCHED_ERROR","title":"Route resolved, but no method matched","status":405,"detail":"The route /todos has been matched, but it does not have \"options\" method defined"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,6 +1398,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/urijs@^1.19.4":
+  version "1.19.4"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.4.tgz#29c4a694d4842d7f95e359a26223fc1865f1ab13"
+  integrity sha512-uHUvuLfy4YkRHL4UH8J8oRsINhdEHd9ymag7KJZVT94CjAmY1njoUzhazJsZjwfy+IpWKQKGVyXCwzhZvg73Fg==
+
 "@types/urijs@~1.19.1":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.1.tgz#da69e8479eec0bb4580c7cc218d218f107d2d526"


### PR DESCRIPTION
This PR puts the forwarder back with the change that if requested path is not declared in the spec document (aka: there's no http operation) the request won't be executed.

It also removes some features we never used and are not even exposed in the new client (CancelToken and responseType)