### PR TITLE
automatic docs deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  stoplight: stoplight/cli@0.0.x
 executors:
   docker-node:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,3 +140,15 @@ workflows:
             - harness
             - harness-macos
             - publish
+      - stoplight/analyze:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+          requires:
+            - build
+            - harness
+            - harness-macos
+            - publish
+            - upload_artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  stoplight: stoplight/cli@0.0.x
+  stoplight: stoplight/cli@0.0.2
 executors:
   docker-node:
     docker:


### PR DESCRIPTION
Closes #585

## Changes

This PR introduces automatic docs deployment.

## Testing

1. I added a private repo of mine to Studio.
2. That repo was also connected to CircleCI.
3. Took the token and url from `Publish` tab in Studio and created env variables in CircleCI.

When a change to `/docs` files or `README.md` was pushed to the repository with a new tag, the docs were published and visible to the world.


This `config.yml` was used for the mentioned repo.
```yml
version: 2.1
orbs:
  stoplight: stoplight/cli@0.0.2

jobs:
  build:
    docker:
      - image: circleci/node:10

    steps:
      - checkout

      - run:
          name: Greeting
          command: echo Hello, world.

      - run:
          name: Print the Current Time
          command: date

workflows:
  version: 2
  build:
    jobs:
      - build:
          filters:
            branches:
              ignore: /.*/
            tags:
              only: /^v.*/
      - stoplight/analyze:
          filters:
            branches:
              ignore: /.*/
            tags:
              only: /^v.*/
          requires:
            - build
```