### PR TITLE
fix: type import rewrite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           command: yarn
       - run:
           name: Build all code to JavaScript
-          command: yarn build
+          command: npx ttsc --build ./packages/tsconfig.build.json
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: Publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Killing sub-process only if Prism is running in multi-process mode [#645](https://github.com/stoplightio/prism/pull/645)
 - UUIDs are never generated as URNs [#661](https://github.com/stoplightio/prism/pull/661)
+- Core types are now correctly referenced in the HTTP package, restoring the type checks when using the package separately [#701](https://github.com/stoplightio/prism/pull/701)
 
 # 3.1.1 (2019-09-23)
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "tmp": "^0.1.0",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
+    "ts-transform-import-path-rewrite": "^0.2.1",
     "tsconfig-paths": "^3.8.0",
+    "ttypescript": "^1.5.7",
     "typescript": "^3.6.4"
   },
   "prettier": {

--- a/packages/http/tsconfig.build.json
+++ b/packages/http/tsconfig.build.json
@@ -4,6 +4,18 @@
   "exclude": ["src/**/__tests__/**/*.ts"],
   "compilerOptions": {
     "composite": true,
+    "plugins": [
+      {
+        "transform": "ts-transform-import-path-rewrite",
+        "import": "transform",
+        "alias": {
+          "^../../core/src$": "@stoplight/prism-core"
+        },
+        "after": false,
+        "afterDeclarations": true,
+        "type": "config"
+      }
+    ],
     "rootDir": "src",
     "outDir": "dist"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3870,14 +3870,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
-  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
-  dependencies:
-    is-glob "^4.0.1"
-
-glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
   integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
@@ -7299,7 +7292,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
+resolve@1.x, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -8207,6 +8200,13 @@ ts-node@^8.3.0:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+ts-transform-import-path-rewrite@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ts-transform-import-path-rewrite/-/ts-transform-import-path-rewrite-0.2.1.tgz#ca38fd47731bd8e8ef6175eccd5058ab44ed5713"
+  integrity sha512-9MJ66a4cSbQLLsY3ZGBXjsFbjm3B/bJ9Or08sDChiN1BQGDFBJGopjtp648rCixlvePovDY5lQRZcoWpJDN4Ww==
+  dependencies:
+    typescript "3"
+
 tsconfig-paths@^3.8.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
@@ -8228,6 +8228,13 @@ tsutils@^3.17.1:
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   dependencies:
     tslib "^1.8.1"
+
+ttypescript@^1.5.7:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/ttypescript/-/ttypescript-1.5.7.tgz#76bb96765b331194b58a4e7d79fae82b886fc29a"
+  integrity sha512-qloW8S60+xWVC2bQWldYQfESNFkIgDL5/M+vAOOsuLJ1pQu0SG2vQx5DNJO2nlwSrHxD8cDuF2sVDXg6v3GG3Q==
+  dependencies:
+    resolve "^1.9.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -8281,7 +8288,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.6.4:
+typescript@3, typescript@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==


### PR DESCRIPTION
This is kind of a nasty TS to JS bug I found while trying to use Prism for its hosted version

Fundamentally given that it is a monorepo when generating the types for the current project the references points to the source code:

![image](https://user-images.githubusercontent.com/1416224/66754316-02251300-ee96-11e9-85d0-6de92c888884.png)

It goes without saying that such path does not exist in the published package, since that is instead found in `@stoplight/prism-core` package.

If you're using JavaScript, you won't even notice this bug. However, if you're using TypeScript and the `http` package, you'll notice some functions will return `any` instead of the correct interface (because TypeScript can't find the types, it will assume `any`).

This PR will use `ttypescript` project (a declarative wrapper for the TS compiler API) and adding a dropbox developed plugin that will rewrite the generated files path correctly

![image](https://user-images.githubusercontent.com/1416224/66754332-081af400-ee96-11e9-8eac-0701d1566fe7.png)
