### PR TITLE
fix: logger component is always required

### DIFF
--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -9,7 +9,7 @@ import { createServer } from '@stoplight/prism-http-server';
 
 const server = createServer({
   path: './api.oas2.json',
-  {}
+  {logger: createLoggerInstance() }
 });
 
 server.listen(3000).then(() => {

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -7,6 +7,7 @@ Usage:
 ```js
 import { createServer } from '@stoplight/prism-http-server';
 
+const operations = await getHttpOperationsFromResource('./api.oas2.json');
 const server = createServer({
   operations,
   { logger: createLoggerInstance() }

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -8,8 +8,8 @@ Usage:
 import { createServer } from '@stoplight/prism-http-server';
 
 const server = createServer({
-  path: './api.oas2.json',
-  {logger: createLoggerInstance() }
+  operations,
+  { logger: createLoggerInstance() }
 });
 
 server.listen(3000).then(() => {

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -17,12 +17,11 @@ function checkErrorPayloadShape(payload: string) {
 
 async function instantiatePrism(specPath: string) {
   const operations = await getHttpOperationsFromResource(specPath);
-  const server = createServer(operations, {
+  return createServer(operations, {
     components: { logger },
     config: { checkSecurity: true, validateRequest: true, validateResponse: true, mock: { dynamic: false } },
     cors: true,
   });
-  return server;
 }
 
 describe('GET /pet?__server', () => {

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -14,7 +14,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
   const { components, config } = opts;
 
   const server = fastify({
-    logger: (components && components.logger) || createLogger('HTTP SERVER'),
+    logger: components.logger,
     disableRequestLogging: true,
     modifyCoreObjects: false,
   });

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -2,7 +2,7 @@ import { IHttpConfig, PickRequired, PrismHttpComponents, PrismHttpInstance } fro
 import { FastifyInstance } from 'fastify';
 
 export interface IPrismHttpServerOpts {
-  components?: PickRequired<Partial<PrismHttpComponents>, 'logger'>;
+  components: PickRequired<Partial<PrismHttpComponents>, 'logger'>;
   config: IHttpConfig;
   cors: boolean;
 }

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -14,7 +14,7 @@ import { IHttpConfig, IHttpRequest, IHttpResponse, PickRequired, PrismHttpCompon
 
 export const createInstance = (
   defaultConfig: IHttpConfig,
-  components?: PickRequired<Partial<PrismHttpComponents>, 'logger'>,
+  components: PickRequired<Partial<PrismHttpComponents>, 'logger'>
 ) =>
   factory<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>(
     defaultConfig,


### PR DESCRIPTION
It turns out that although we're claiming that the `components` object is not required, it is indeed required because the logger instance is always required. 

This PR fixes this so that when using the http raw client package to have the hosted Prism version I do not incur in the problem of having something required not passed because of TypeScript not complaining.