### PR TITLE
Use node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   docker-node:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
   macos:
     macos:
       xcode: 10.2.1


### PR DESCRIPTION
Our docker images are based on node 12 and Windows tests run on node 12. We're on node 12, let's claim that.