### PR TITLE
fix: more comprensive import rewrite

### DIFF
--- a/packages/http/tsconfig.build.json
+++ b/packages/http/tsconfig.build.json
@@ -9,7 +9,7 @@
         "transform": "ts-transform-import-path-rewrite",
         "import": "transform",
         "alias": {
-          "^../../core/src$": "@stoplight/prism-core"
+          "(../)*core/src$": "@stoplight/prism-core"
         },
         "after": false,
         "afterDeclarations": true,


### PR DESCRIPTION
It turns out the Regex I was using was too loose and missing different rewrites that we need. This PR will enlarge the captured stuff so no matter how far you are from `core/src`, it will be correctly rewritten into `@stoplight/prism-core`