### PR TITLE
fix(build): Use ttsc for compiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           command: yarn --frozen-lockfile
       - run:
           name: Build all code to JavaScript
-          command: npx ttsc --build ./packages/tsconfig.build.json
+          command: yarn build
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: Publish

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "lint": "eslint ./packages/**/src/**/*.ts",
     "lint.fix": "yarn lint --fix",
-    "build": "tsc --build ./packages/tsconfig.build.json",
+    "build": "ttsc --build ./packages/tsconfig.build.json",
     "posttest": "yarn lint",
     "test": "jest --maxWorkers=2",
     "test.watch": "yarn test --watchAll",


### PR DESCRIPTION
#701 introduced a change to fix imports like `"../../core/src"` showing up in `.d.ts` files. However, if you install the latest version (v3.1.1) of `stoplight/prism-cli`, you'll see that the relative imports still exist in the built package, as no version has been published after this change.

Additionally, the `build` step in `package.json` still reads: `tsc --build ./packages/tsconfig.build.json`; this PR updates it to use `ttsc` instead, so that type files are created correctly when building locally. The CircleCI config has also been updated to use this build script instead of the one-off `npx` command.