### PR TITLE
fix: trigger media type validation only when defined in the response

### DIFF
--- a/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
+++ b/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
@@ -39,7 +39,7 @@ Object {
   "_tag": "Left",
   "left": Array [
     Object {
-      "message": "The received media type \\"\\" does not match the one specified in the document",
+      "message": "The received media type \\"application/something\\" does not match the one specified in the current response: application/json,application/xml",
       "severity": 0,
     },
     Object {

--- a/packages/http/src/validator/__tests__/functional.spec.ts
+++ b/packages/http/src/validator/__tests__/functional.spec.ts
@@ -15,7 +15,7 @@ const GOOD_INPUT = Object.assign({}, httpInputs[2], {
 
 const BAD_OUTPUT = Object.assign({}, httpOutputs[1], {
   body: { name: 'Shopping', completed: 'yes' },
-  headers: { 'x-todos-publish': 'yesterday' },
+  headers: { 'x-todos-publish': 'yesterday', 'content-type': 'application/something' },
 });
 
 describe('HttpValidator', () => {

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -163,7 +163,7 @@ describe('HttpValidator', () => {
             },
             element: { statusCode: 200 },
           }),
-          error => expect(error).toHaveLength(3)
+          error => expect(error).toHaveLength(2)
         );
 
         expect(bodyValidator.validate).toHaveBeenCalledWith(undefined, [], undefined);
@@ -242,7 +242,8 @@ describe('HttpValidator', () => {
             error =>
               expect(error).toEqual([
                 {
-                  message: 'The received media type "application/xml" does not match the one specified in the document',
+                  message:
+                    'The received media type "application/xml" does not match the one specified in the current response: application/json',
                   severity: DiagnosticSeverity.Error,
                 },
               ])

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -2,14 +2,7 @@ import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { DiagnosticSeverity, IHttpOperation, HttpParamStyles } from '@stoplight/types';
 import * as Either from 'fp-ts/lib/Either';
 import { IHttpRequest } from '../../types';
-import {
-  bodyValidator,
-  headersValidator,
-  queryValidator,
-  pathValidator,
-  validateInput,
-  validateOutput,
-} from '../index';
+import * as validator from '../index';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 
 const validate = (
@@ -17,7 +10,7 @@ const validate = (
   inputExtension?: Partial<IHttpRequest>,
   length = 3
 ) => () => {
-  const validationResult = validateInput({
+  const validationResult = validator.validateInput({
     resource: Object.assign<IHttpOperation, unknown>(
       {
         method: 'get',
@@ -43,12 +36,12 @@ const mockError: IPrismDiagnostic = {
 };
 
 describe('HttpValidator', () => {
-  describe('validateInput()', () => {
+  describe('validator.validateInput()', () => {
     beforeAll(() => {
-      jest.spyOn(bodyValidator, 'validate').mockReturnValue(Either.left([mockError]));
-      jest.spyOn(headersValidator, 'validate').mockReturnValue(Either.left([mockError]));
-      jest.spyOn(queryValidator, 'validate').mockReturnValue(Either.left([mockError]));
-      jest.spyOn(pathValidator, 'validate').mockReturnValue(Either.left([mockError]));
+      jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(Either.left([mockError]));
+      jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(Either.left([mockError]));
+      jest.spyOn(validator.queryValidator, 'validate').mockReturnValue(Either.left([mockError]));
+      jest.spyOn(validator.pathValidator, 'validate').mockReturnValue(Either.left([mockError]));
     });
 
     afterAll(() => jest.restoreAllMocks());
@@ -118,7 +111,7 @@ describe('HttpValidator', () => {
       describe('request is set', () => {
         describe('request.path is set', () => {
           it('calls the path validator', () => {
-            validateInput({
+            validator.validateInput({
               resource: {
                 method: 'get',
                 path: '/a/{a}/b/{b}',
@@ -131,7 +124,7 @@ describe('HttpValidator', () => {
               element: { method: 'get', url: { path: '/a/1/b/;b=2' } },
             });
 
-            expect(pathValidator.validate).toHaveBeenCalledWith({ a: '1', b: ';b=2' }, [
+            expect(validator.pathValidator.validate).toHaveBeenCalledWith({ a: '1', b: ';b=2' }, [
               { name: 'a', style: HttpParamStyles.Simple },
               { name: 'b', style: HttpParamStyles.Matrix },
             ]);
@@ -144,37 +137,57 @@ describe('HttpValidator', () => {
   describe('validateOutput()', () => {
     describe('output is set', () => {
       beforeAll(() => {
-        jest.spyOn(bodyValidator, 'validate').mockReturnValue(Either.left([mockError]));
-        jest.spyOn(headersValidator, 'validate').mockReturnValue(Either.left([mockError]));
-        jest.spyOn(queryValidator, 'validate').mockReturnValue(Either.left([mockError]));
+        jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(Either.left([mockError]));
+        jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(Either.left([mockError]));
+        jest.spyOn(validator.queryValidator, 'validate').mockReturnValue(Either.left([mockError]));
       });
 
       afterAll(() => jest.restoreAllMocks());
 
-      it('validates the body and headers', () => {
-        assertLeft(
-          validateOutput({
-            resource: {
-              method: 'get',
-              path: '/',
-              id: '1',
-              request: {},
-              responses: [{ code: '200' }],
-            },
-            element: { statusCode: 200 },
-          }),
-          error => expect(error).toHaveLength(2)
-        );
+      describe('the output does not have the media type header', () => {
+        it('validates the body and headers, but not the media type', () => {
+          assertLeft(
+            validator.validateOutput({
+              resource: {
+                method: 'get',
+                path: '/',
+                id: '1',
+                request: {},
+                responses: [{ code: '200' }],
+              },
+              element: { statusCode: 200 },
+            }),
+            error => expect(error).toHaveLength(2)
+          );
 
-        expect(bodyValidator.validate).toHaveBeenCalledWith(undefined, [], undefined);
-        expect(headersValidator.validate).toHaveBeenCalled();
+          expect(validator.bodyValidator.validate).toHaveBeenCalledWith(undefined, [], undefined);
+          expect(validator.headersValidator.validate).toHaveBeenCalled();
+        });
+      });
+
+      describe('the output has the media type header', () => {
+        it('should validate the media type as well', () => {
+          assertLeft(
+            validator.validateOutput({
+              resource: {
+                method: 'get',
+                path: '/',
+                id: '1',
+                request: {},
+                responses: [{ code: '200', contents: [{ mediaType: 'application/json' }] }],
+              },
+              element: { statusCode: 200, headers: { 'content-type': 'text/plain' } },
+            }),
+            e => expect(e).toHaveLength(3)
+          );
+        });
       });
     });
 
     describe('cannot match status code with responses', () => {
       beforeEach(() => {
-        jest.spyOn(bodyValidator, 'validate').mockReturnValue(Either.right({}));
-        jest.spyOn(headersValidator, 'validate').mockReturnValue(Either.right({}));
+        jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(Either.right({}));
+        jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(Either.right({}));
       });
 
       afterEach(() => jest.clearAllMocks());
@@ -189,7 +202,7 @@ describe('HttpValidator', () => {
 
       describe('when the desidered response is between 200 and 300', () => {
         it('returns an error', () => {
-          assertLeft(validateOutput({ resource, element: { statusCode: 201 } }), error =>
+          assertLeft(validator.validateOutput({ resource, element: { statusCode: 201 } }), error =>
             expect(error).toEqual([
               {
                 message: 'Unable to match the returned status code with those defined in spec',
@@ -202,7 +215,7 @@ describe('HttpValidator', () => {
 
       describe('when the desidered response is over 300', () => {
         it('returns an error', () => {
-          assertLeft(validateOutput({ resource, element: { statusCode: 400 } }), error =>
+          assertLeft(validator.validateOutput({ resource, element: { statusCode: 400 } }), error =>
             expect(error).toEqual([
               {
                 message: 'Unable to match the returned status code with those defined in spec',
@@ -238,7 +251,10 @@ describe('HttpValidator', () => {
       describe('when the response has a content type not declared in the spec', () => {
         it('returns an error', () => {
           assertLeft(
-            validateOutput({ resource, element: { statusCode: 200, headers: { 'content-type': 'application/xml' } } }),
+            validator.validateOutput({
+              resource,
+              element: { statusCode: 200, headers: { 'content-type': 'application/xml' } },
+            }),
             error =>
               expect(error).toEqual([
                 {
@@ -254,7 +270,10 @@ describe('HttpValidator', () => {
       describe('when the response has a content type declared in the spec', () => {
         it('returns an error', () => {
           assertRight(
-            validateOutput({ resource, element: { statusCode: 200, headers: { 'content-type': 'application/json' } } }),
+            validator.validateOutput({
+              resource,
+              element: { statusCode: 200, headers: { 'content-type': 'application/json' } },
+            }),
             () => {}
           );
         });

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -1,9 +1,16 @@
 import { IPrismDiagnostic, ValidatorFn } from '@stoplight/prism-core';
-import { DiagnosticSeverity, IHttpOperation, IHttpOperationResponse, IHttpOperationRequest } from '@stoplight/types';
+import {
+  DiagnosticSeverity,
+  IHttpOperation,
+  IHttpOperationResponse,
+  IHttpOperationRequest,
+  IMediaTypeContent,
+} from '@stoplight/types';
 import * as caseless from 'caseless';
-import { findFirst } from 'fp-ts/lib/Array';
+import { findFirst, isNonEmpty } from 'fp-ts/lib/Array';
 import * as Option from 'fp-ts/lib/Option';
 import * as Either from 'fp-ts/lib/Either';
+import * as typeIs from 'type-is';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { inRange } from 'lodash';
 // @ts-ignore
@@ -84,14 +91,14 @@ const findResponseByStatus = (responses: NonEmptyArray<IHttpOperationResponse>, 
     Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(error => [error])
   );
 
-const mismatchMediaType = (response: IHttpOperationResponse, mediaType: string) =>
+const mismatchMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
-    Option.fromNullable(response.contents),
-    Option.chain(findFirst(c => c.mediaType === mediaType)),
+    contents,
+    findFirst(c => !!typeIs.is(mediaType, [c.mediaType])),
     Either.fromOption<IPrismDiagnostic>(() => ({
-      message: `The received media type "${
-        mediaType ? mediaType : ''
-      }" does not match the one specified in the document`,
+      message: `The received media type "${mediaType}" does not match the one specified in the current response: ${contents
+        .map(c => c.mediaType)
+        .join(',')}`,
       severity: DiagnosticSeverity.Error,
     })),
     Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(e => [e])
@@ -103,7 +110,19 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
     findResponseByStatus(resource.responses, element.statusCode),
     Either.chain(response =>
       sequenceValidation(
-        mismatchMediaType(response, mediaType),
+        pipe(
+          Option.fromNullable(response.contents),
+          Option.chain(contents =>
+            pipe(
+              contents,
+              Option.fromPredicate(isNonEmpty)
+            )
+          ),
+          Option.fold(
+            () => Either.right<NonEmptyArray<IPrismDiagnostic>, unknown>(undefined),
+            contents => mismatchMediaType(contents, mediaType)
+          )
+        ),
         bodyValidator.validate(element.body, response.contents || [], mediaType),
         headersValidator.validate(element.headers || {}, response.headers || [])
       )

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -96,9 +96,8 @@ const mismatchMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType
     contents,
     findFirst(c => !!typeIs.is(mediaType, [c.mediaType])),
     Either.fromOption<IPrismDiagnostic>(() => ({
-      message: `The received media type "${mediaType}" does not match the one specified in the current response: ${contents
-        .map(c => c.mediaType)
-        .join(',')}`,
+      message: `The received media type "${mediaType ||
+        ''}" does not match the one specified in the current response: ${contents.map(c => c.mediaType).join(',')}`,
       severity: DiagnosticSeverity.Error,
     })),
     Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(e => [e])

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -91,7 +91,7 @@ const findResponseByStatus = (responses: NonEmptyArray<IHttpOperationResponse>, 
     Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(error => [error])
   );
 
-const mismatchMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
+const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
     contents,
     findFirst(c => !!typeIs.is(mediaType, [c.mediaType])),
@@ -119,7 +119,7 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
           ),
           Option.fold(
             () => Either.right<NonEmptyArray<IPrismDiagnostic>, unknown>(undefined),
-            contents => mismatchMediaType(contents, mediaType)
+            contents => validateMediaType(contents, mediaType)
           )
         ),
         bodyValidator.validate(element.body, response.contents || [], mediaType),

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -97,7 +97,7 @@ const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType
     findFirst(c => !!typeIs.is(mediaType, [c.mediaType])),
     Either.fromOption<IPrismDiagnostic>(() => ({
       message: `The received media type "${mediaType ||
-        ''}" does not match the one specified in the current response: ${contents.map(c => c.mediaType).join(',')}`,
+        ''}" does not match the one${contents.length ? 's' : ''} specified in the current response: ${contents.map(c => c.mediaType).join(', ')}`,
       severity: DiagnosticSeverity.Error,
     })),
     Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(e => [e])


### PR DESCRIPTION
Closes #774

* Calls the media type return validator only if the selected response has contents with a media type
* Uses now `typeIs.is` function library so that we can match stuff with charset headers as well instead of a simple equality check