### PR TITLE
Refactor: move CLI specific logging options

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,11 +23,11 @@ Note, the binaries do _not_ auto-update, so you will need to run it again to ins
 Prism is available as a Docker Image as well under the `3` tag.
 
 ```bash
-docker run --rm -it -p 4010:4010 stoplight/prism:3 mock -h 0.0.0.0 api.oas3.yml
+docker run --init --rm -p 4010:4010 stoplight/prism:3 mock -h 0.0.0.0 api.oas3.yml
 ```
 
 If the specification you want to mock is on your computer, you'll need to mount the directory where the file resides as a volume
 
 ```bash
-docker run --rm -it -p 4010:4010 -v $(pwd):/tmp stoplight/prism:3 mock -h 0.0.0.0 "/tmp/api.oas3.yml"
+docker run --init --rm -p 4010:4010 -v $(pwd):/tmp stoplight/prism:3 mock -h 0.0.0.0 "/tmp/api.oas3.yml"
 ```

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import * as cluster from 'cluster';
 import * as Either from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { LogDescriptor, Logger } from 'pino';
+import { LogDescriptor, Logger, LoggerOptions } from 'pino';
 import * as signale from 'signale';
 import * as split from 'split2';
 import { PassThrough, Readable } from 'stream';
@@ -15,9 +15,10 @@ import { attachTagsToParamsValues, transformPathParamsValues } from './colorizer
 
 signale.config({ displayTimestamp: true });
 
-const cliSpecificLoggerOptions = {
-  customLevels: { start: 12 },
+const cliSpecificLoggerOptions: LoggerOptions = {
+  customLevels: { start: 11 },
   useLevelLabels: true,
+  level: 'start',
 };
 
 async function createMultiProcessPrism(options: CreateBaseServerOptions) {

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -9,9 +9,10 @@ function createLogger(
   const options: pino.LoggerOptions = defaultsDeep(overrideOptions, {
     name,
     customLevels: {
-      success: 11,
+      success: 12,
     },
-    base: null,
+    level: 'success',
+    base: {},
     timestamp: false,
   });
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,33 +1,22 @@
 import * as pino from 'pino';
-import { levels } from 'pino';
-
-levels.labels[10] = 'note';
-levels.values.note = 10;
-levels.labels[11] = 'success';
-levels.values.success = 11;
-levels.labels[12] = 'start';
-levels.values.start = 12;
+import { defaultsDeep } from 'lodash';
 
 function createLogger(
   name: string,
   overrideOptions: pino.LoggerOptions = {},
-  destination?: pino.DestinationStream,
+  destination?: pino.DestinationStream
 ): pino.Logger {
-  const options: pino.LoggerOptions = {
-    ...overrideOptions,
+  const options: pino.LoggerOptions = defaultsDeep(overrideOptions, {
     name,
     customLevels: {
-      note: 10,
       success: 11,
-      start: 12,
     },
-    level: 'note',
-    base: {},
+    base: null,
     timestamp: false,
-  };
+  });
 
   if (destination) return pino(options, destination);
   return pino(options);
 }
 
-export { levels as logLevels, createLogger };
+export { createLogger };


### PR DESCRIPTION
This PR moves away some CLI specific things from the core package and puts them in the CLI.