### PR TITLE
fix local docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN ./bin/node-prune
 FROM node:12-alpine
 
 WORKDIR /usr/src/prism
+ARG BUILD_TYPE=development
 ENV NODE_ENV production
 
 COPY package.json /usr/src/prism/
@@ -47,6 +48,13 @@ COPY --from=dependencies /usr/src/prism/packages/http/node_modules/ /usr/src/pri
 COPY --from=dependencies /usr/src/prism/packages/cli/node_modules/ /usr/src/prism/packages/cli/node_modules/
 
 WORKDIR /usr/src/prism/packages/cli/
+
+RUN if [ "$BUILD_TYPE" = "development" ] ; then \
+    cd /usr/src/prism/packages/core && yarn link && \
+    cd /usr/src/prism/packages/http && yarn link @stoplight/prism-core && yarn link && \
+    cd /usr/src/prism/packages/http-server && yarn link @stoplight/prism-core && yarn link @stoplight/prism-http && yarn link && \
+    cd /usr/src/prism/packages/cli && yarn link @stoplight/prism-core && yarn link @stoplight/prism-http && yarn link @stoplight/prism-http-server && yarn link ; \
+fi
 
 EXPOSE 4010
 


### PR DESCRIPTION
This PR will add a small check so that when the build arg is `development` the built docker image will link the local source instead of installing the remote npm package.

I've already modified DockerHub so that it's set to a different value and using the npm packages.

On a different note, I think it's time to rethink the docker image we're building since it's not in the way it should be. I have a 8h flight on my way, I'll probably hack something while in there.