### PR TITLE
fix: treat emtpy Accept header as */*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - By upgrading Json Schema Faker to the latest version, now the schemas with `additionalProperties:false` / `additionalProperties:true` / `additionalProperties:object` will be correctly handled when dynamic mocking is enabled [#719](https://github.com/stoplightio/prism/pull/719)
 - Making a request to an operation with a `deprecated` parameter is no longer causing Prism to return a 422 response [#721](https://github.com/stoplightio/prism/pull/721)
 - The `access-control-allow-origin` header, when CORS is enabled, will now reflect the request origin _AND_ set the Credentials header [#797](https://github.com/stoplightio/prism/pull/797)
+- When the request is missing the `Accept` header, Prism will now effectively treat it as a `*/*`, according to the respective CFP [#802](https://github.com/stoplightio/prism/pull/802)
 
 # 3.1.1 (2019-09-23)
 

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -112,7 +112,7 @@ const helpers = {
     const httpContent = hasContents(response)
       ? pipe(
           findDefaultContentType(response),
-          Option.alt(() => findBestHttpContentByMediaType(response, ['application/json']))
+          Option.alt(() => findBestHttpContentByMediaType(response, ['application/json', '*/*']))
         )
       : Option.none;
 

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -11,7 +11,7 @@ import * as Either from 'fp-ts/lib/Either';
 import { left, right } from 'fp-ts/lib/ReaderEither';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import helpers from '../NegotiatorHelpers';
-import { IHttpNegotiationResult, NegotiationOptions, NegotiatePartialOptions } from '../types';
+import { IHttpNegotiationResult, NegotiationOptions } from '../types';
 
 const chance = new Chance();
 const logger = createLogger('TEST', { enabled: false });
@@ -240,7 +240,7 @@ describe('NegotiatorHelpers', () => {
   describe('negotiateOptionsForValidRequest()', () => {
     it('given status code enforced should negotiate a specific code', () => {
       const options = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         dynamic: false,
       };
 
@@ -267,7 +267,7 @@ describe('NegotiatorHelpers', () => {
       const options = { dynamic: false };
 
       const expectedResult = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         mediaType: 'application/json',
         headers: [],
       };
@@ -462,7 +462,7 @@ describe('NegotiatorHelpers', () => {
         };
 
         const httpResponseSchema: IHttpOperationResponse = {
-          code: chance.integer({ min: 100, max: 599 }).toString(),
+          code: '200',
           contents: [contents],
           headers: [],
         };
@@ -512,7 +512,7 @@ describe('NegotiatorHelpers', () => {
           }));
 
           const httpResponseSchema: IHttpOperationResponse = {
-            code: chance.integer({ min: 100, max: 599 }).toString(),
+            code: '200',
             contents,
             headers: [],
           };
@@ -539,7 +539,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const httpResponseSchema: IHttpOperationResponse = {
-            code: chance.integer({ min: 100, max: 599 }).toString(),
+            code: '200',
             contents: [content],
             headers: [],
           };
@@ -629,7 +629,7 @@ describe('NegotiatorHelpers', () => {
         };
 
         const httpResponseSchema: IHttpOperationResponse = {
-          code: chance.integer({ min: 100, max: 599 }).toString(),
+          code: '200',
           contents: [],
           headers: [],
         };
@@ -794,7 +794,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
     it('and example exists should return that example', () => {
       const exampleKey = chance.string();
       const partialOptions = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         exampleKey,
         dynamic: chance.bool(),
       };
@@ -825,7 +825,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
     it('and example not exist should throw an error', () => {
       const exampleKey = chance.string();
       const partialOptions = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         exampleKey,
         dynamic: chance.bool(),
       };
@@ -845,7 +845,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
   describe('given exampleKey not forced but dynamic forced', () => {
     it('and httpContent has schema return that contents', () => {
       const partialOptions = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
@@ -868,7 +868,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
 
     it('and httpContent has no schema throw error', () => {
       const partialOptions = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
@@ -890,7 +890,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
   describe('given neither exampleKey nor dynamic forced', () => {
     it('and can find other example return that example', () => {
       const partialOptions = {
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
         dynamic: false,
       };
       const bodyExample: INodeExample | INodeExternalExample = {
@@ -926,7 +926,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
     it('and cannot find example but schema exists return dynamic', () => {
       const partialOptions = {
         dynamic: false,
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
       };
       const httpContent: IMediaTypeContent = {
         mediaType: chance.string(),
@@ -949,7 +949,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
     it('and cannot find example and dynamic does not exist throw error', () => {
       const partialOptions = {
         dynamic: false,
-        code: chance.integer({ min: 100, max: 599 }).toString(),
+        code: '200',
       };
 
       const httpContent: IMediaTypeContent = {

--- a/test-harness/specs/content-negotiation/E2E-Accept-Content-Negotiation.empty.oas3.txt
+++ b/test-harness/specs/content-negotiation/E2E-Accept-Content-Negotiation.empty.oas3.txt
@@ -1,0 +1,24 @@
+====test====
+When the request has an empty or invalid Accept header
+Prism will fallback to application/json first, and then */*
+if nothing is found
+====spec====
+openapi: "3.0.1"
+paths:
+  "/path":
+      get:
+        responses:
+          '200':
+            content:
+              text/plain:
+                schema:
+                  type: string
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -H "Accept:" http://localhost:4010/path
+====expect====
+HTTP/1.1 200 OK
+content-type: text/plain
+
+string


### PR DESCRIPTION
This PR modifies the negotiation in the way it looks for content in case the `Accept` header is invalid or not provided.

1. It will look for an _explicit_ `*/*` content type in the current response
2. If not found, it will look for an `application/json` one
3. If not found, it will take the first one on the list.

Closes #500

For some reason Prettier decided to reformat the whole file so please review from here: https://github.com/stoplightio/prism/pull/802/files?utf8=✓&diff=unified&w=1