### PR TITLE
Keep proxying if resource is not found

### DIFF
--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -70,6 +70,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     validateRequest: true,
     validateResponse: true,
     checkSecurity: true,
+    errors: false,
   };
 
   const config: IHttpProxyConfig | IHttpConfig = isProxyServerOptions(options)

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -24,7 +24,7 @@ describe('validation', () => {
   };
 
   const prismInstance = factory<string, string, string, IPrismConfig>(
-    { mock: { dynamic: false }, validateRequest: false, validateResponse: false, checkSecurity: true },
+    { mock: { dynamic: false }, validateRequest: false, validateResponse: false, checkSecurity: true, errors: false },
     components
   );
 

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -84,7 +84,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
                     input: [
                       {
                         message:
-                          "The selected route hasn't been found and the errors is set false. Prims will proxy the request to the upstream server but no validation will happen",
+                          "The selected route hasn't been found and the errors is set false. Prism will proxy the request to the upstream server but no validation will happen",
                         severity: DiagnosticSeverity.Warning,
                       },
                     ],

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -76,7 +76,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
           error => {
             if (!config.errors && isProxyConfig(config)) {
               return pipe(
-                components.forward(input, config.upstream.href),
+                components.forward(input, config.upstream.href)(components.logger.child({ name: 'PROXY' })),
                 TaskEither.map<Output, IPrismOutput<Output>>(output => ({
                   input,
                   output,
@@ -84,7 +84,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
                     input: [
                       {
                         message:
-                          "The selected route hasn't been found and the errors is set false. Prism will proxy the request to the upstream server but no validation will happen",
+                          "The selected route hasn't been found and the errors is set false. Prism has proxied the request to the upstream server but no validation will happen",
                         severity: DiagnosticSeverity.Warning,
                       },
                     ],

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -73,7 +73,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
         TaskEither.fromEither(components.route({ resources, input })),
         TaskEither.fold(
           error => {
-            if (config.errors && isProxyConfig(config)) {
+            if (!config.errors && isProxyConfig(config)) {
               components.logger.warn(
                 `The selected route hasn't been found and the errors is set false. Prims will proxy the request to the upstream server but no validation will happen`
               );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,7 @@ export interface IPrismConfig {
   checkSecurity: boolean;
   validateRequest: boolean;
   validateResponse: boolean;
+  errors: boolean;
 }
 
 export type ValidatorFn<Resource, T> = (opts: {

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -15,6 +15,7 @@ function instantiatePrism2(operations: IHttpOperation[]) {
       validateRequest: true,
       validateResponse: true,
       mock: { dynamic: false },
+      errors: false,
     },
     errors: false,
   });

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -23,6 +23,7 @@ async function instantiatePrism(specPath: string) {
       checkSecurity: true,
       validateRequest: true,
       validateResponse: true,
+      errors: false,
       mock: { dynamic: false },
     },
     errors: false,

--- a/packages/http/src/__tests__/__snapshots__/http-prism-instance.spec.ts.snap
+++ b/packages/http/src/__tests__/__snapshots__/http-prism-instance.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Http Client .request given no-refs-petstore-minimal.oas2.json when requesting GET /pet/findByStatus w/o required params throws a validation error 1`] = `
+exports[`Http Client .request given no-refs-petstore-minimal.oas2.json when requesting GET /pet/findByStatus with valid query params returns generated body 1`] = `
 Object {
   "input": Object {
     "method": "get",

--- a/packages/http/src/__tests__/client.spec.ts
+++ b/packages/http/src/__tests__/client.spec.ts
@@ -11,6 +11,7 @@ describe('User Http Client', () => {
         mock: { dynamic: false },
         validateRequest: true,
         validateResponse: true,
+        errors: false,
         checkSecurity: true,
       };
 

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -59,7 +59,7 @@ describe('Http Client .request', () => {
   `('given spec $specName', ({ specPath }) => {
     beforeAll(async () => {
       prism = createInstance(
-        { validateRequest: true, checkSecurity: true, validateResponse: true, mock: { dynamic: false } },
+        { validateRequest: true, checkSecurity: true, validateResponse: true, mock: { dynamic: false }, errors: false },
         { logger }
       );
       resources = await getHttpOperationsFromResource(specPath);
@@ -149,6 +149,7 @@ describe('Http Client .request', () => {
         checkSecurity: true,
         validateRequest: true,
         validateResponse: true,
+        errors: false,
         upstream: new URL(baseUrl),
       };
 
@@ -208,7 +209,7 @@ describe('Http Client .request', () => {
   describe('given no-refs-petstore-minimal.oas2.json', () => {
     beforeAll(async () => {
       prism = createInstance(
-        { checkSecurity: true, validateRequest: true, validateResponse: true, mock: { dynamic: false } },
+        { checkSecurity: true, validateRequest: true, validateResponse: true, mock: { dynamic: false }, errors: false },
         { logger }
       );
       resources = await getHttpOperationsFromResource(noRefsPetstoreMinimalOas2Path);
@@ -343,7 +344,7 @@ describe('Http Client .request', () => {
 
   it('returns stringified static example when one defined in spec', async () => {
     prism = createInstance(
-      { mock: { dynamic: false }, checkSecurity: true, validateRequest: true, validateResponse: true },
+      { mock: { dynamic: false }, checkSecurity: true, validateRequest: true, validateResponse: true, errors: false },
       { logger }
     );
     resources = await getHttpOperationsFromResource(staticExamplesOas2Path);
@@ -380,7 +381,14 @@ describe('proxy server', () => {
   describe('when the base URL has a different port', () => {
     it('will take in account when proxying', async () => {
       const prism = createInstance(
-        { mock: false, checkSecurity: true, validateRequest: true, validateResponse: true, upstream: new URL(baseUrl) },
+        {
+          mock: false,
+          checkSecurity: true,
+          validateRequest: true,
+          validateResponse: true,
+          upstream: new URL(baseUrl),
+          errors: false,
+        },
         { logger }
       );
 

--- a/packages/http/src/mocker/generator/__tests__/HttpParamGenerator.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/HttpParamGenerator.spec.ts
@@ -5,26 +5,22 @@ describe('HttpParamGenerator', () => {
   describe('generate()', () => {
     describe('example is present', () => {
       it('uses static example', () => {
-        assertSome(generate({ examples: [{ key: 'foo', value: 'test' }] }), v =>
-          expect(v).toEqual('test')
-        );
+        assertSome(generate({ examples: [{ key: 'foo', value: 'test' }] }), v => expect(v).toEqual('test'));
       });
     });
 
     describe('schema and example is present', () => {
       it('prefers static example', () => {
-        assertSome(
-          generate({ schema: { type: 'string' }, examples: [{ key: 'foo', value: 'test' }] }),
-          v => expect(v).toEqual('test')
+        assertSome(generate({ schema: { type: 'string' }, examples: [{ key: 'foo', value: 'test' }] }), v =>
+          expect(v).toEqual('test')
         );
       });
     });
 
     describe('schema is present', () => {
       it('generates example from schema', () => {
-        assertSome(
-          generate({ schema: { type: 'string', format: 'email' } }),
-          v => expect(v).toEqual(expect.stringMatching(/@/))
+        assertSome(generate({ schema: { type: 'string', format: 'email' } }), v =>
+          expect(v).toEqual(expect.stringMatching(/@/))
         );
       });
     });
@@ -56,7 +52,7 @@ describe('HttpParamGenerator', () => {
         });
       });
 
-      describe.each<{ 0: string; 1: object }>([
+      describe.each<[string, object]>([
         ['format', { format: 'email' }],
         ['enum', { enum: [1, 2, 3] }],
         ['pattern', { pattern: '^[A-Z]+$' }],

--- a/packages/http/src/validator/validators/security/handlers/index.ts
+++ b/packages/http/src/validator/validators/security/handlers/index.ts
@@ -4,7 +4,7 @@ import { httpDigest } from './digestAuth';
 import { bearer, oauth2, openIdConnect } from './bearer';
 import { HttpSecurityScheme, DiagnosticSeverity } from '@stoplight/types';
 import { ValidateSecurityFn } from './utils';
-import { Either, right, fromNullable } from 'fp-ts/lib/Either';
+import { Either, fromNullable } from 'fp-ts/lib/Either';
 import { IPrismDiagnostic } from '@stoplight/prism-core';
 
 const securitySchemeHandlers: {

--- a/test-harness/specs/proxy/proxy.passthrough-no-route.txt
+++ b/test-harness/specs/proxy/proxy.passthrough-no-route.txt
@@ -1,0 +1,21 @@
+====test====
+Receiving a response we cannot serialize but it's a string gets passed through
+====spec====
+swagger: "2.0"
+paths:
+  /html:
+    get:
+      produces:
+        - application/html
+      responses:
+        200:
+          description: OK
+====server====
+proxy -p 4010 ${document} http://httpbin
+====command====
+curl -i http://localhost:4010/json
+====expect====
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"slideshow":{"author":"Yours Truly","date":"date of publication","slides":[{"title":"Wake up to WonderWidgets!","type":"all"},{"items":["Why <em>WonderWidgets</em> are great","Who <em>buys</em> WonderWidgets"],"title":"Overview","type":"all"}],"title":"Sample Slide Show"}}


### PR DESCRIPTION
#805 point 3

[Review with no whitespaces](https://github.com/stoplightio/prism/pull/808/files?utf8=✓&diff=unified&w=1)

This PR will short circuit the error handler in case the `errors` flag is set to false and the proxy is on — so we can still proxy the request although all the validation checks will not be performed since we have no idea what resource the user is trying to hit.