### PR TITLE
fix: use points to separate paths

### DIFF
--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -94,7 +94,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         }
 
         inputOutputValidationErrors.forEach(validation => {
-          const message = `Violation: ${validation.location || ''} ${validation.message}`;
+          const message = `Violation: ${validation.location.join('.') || ''} ${validation.message}`;
           if (validation.severity === DiagnosticSeverity[DiagnosticSeverity.Error]) {
             request.log.error({ name: 'VALIDATOR' }, message);
           } else if (validation.severity === DiagnosticSeverity[DiagnosticSeverity.Warning]) {


### PR DESCRIPTION
```diff
- Violation: response,body,id should match format "int64"
+ Violation: response.body.id should match format "int64"
```