### PR TITLE
refactor: make security validations easier to reason about

### DIFF
--- a/packages/http/src/validator/validators/security/index.ts
+++ b/packages/http/src/validator/validators/security/index.ts
@@ -19,23 +19,18 @@ function getValidationResults(securitySchemes: HttpSecurityScheme[][], input: Pi
   const invalidSecuritySchemes = authResults.filter(Either.isLeft);
 
   if (!validSecurityScheme && invalidSecuritySchemes.length > 0) {
-    return Option.some(
-      getWWWAuthHeader(
-        invalidSecuritySchemes.map(t => t.left),
-        ['tags']
-      )
-    );
+    return Option.some(getWWWAuthHeader(invalidSecuritySchemes.map(t => t.left)));
   } else {
     return Option.none;
   }
 }
 
-function getWWWAuthHeader(authResults: IPrismDiagnostic[], pathToHeader: string[]) {
+function getWWWAuthHeader(authResults: IPrismDiagnostic[]) {
   if (authResults.length === 1) {
     return authResults[0];
   } else {
     const wwwAuthenticateHeaders = authResults.map(authResult => authResult.tags || []);
-    const firstAuthErrWithAuthHeader = set(pathToHeader, flatten(wwwAuthenticateHeaders), authResults[0]);
+    const firstAuthErrWithAuthHeader = set(['tags'], flatten(wwwAuthenticateHeaders), authResults[0]);
 
     return wwwAuthenticateHeaders.every(identity) ? firstAuthErrWithAuthHeader : authResults[0];
   }
@@ -52,12 +47,7 @@ function getAuthResults(securitySchemes: HttpSecurityScheme[][], input: Pick<IHt
 
     return pipe(
       eitherSequence(authResults),
-      Either.mapLeft(() =>
-        getWWWAuthHeader(
-          authResults.filter(Either.isLeft).map(t => t.left),
-          ['tags']
-        )
-      )
+      Either.mapLeft(() => getWWWAuthHeader(authResults.filter(Either.isLeft).map(t => t.left)))
     );
   });
 }

--- a/packages/http/src/validator/validators/security/index.ts
+++ b/packages/http/src/validator/validators/security/index.ts
@@ -6,6 +6,7 @@ import { flatten, identity } from 'lodash';
 import { noop, set } from 'lodash/fp';
 import { findSecurityHandler } from './handlers';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { isNonEmpty } from 'fp-ts/lib/Array';
 import { IPrismDiagnostic, ValidatorFn } from '@stoplight/prism-core';
 import { IHttpRequest } from '../../../types';
 
@@ -97,14 +98,14 @@ export const validateSecurity: ValidatorFn<Pick<IHttpOperation, 'security'>, Pic
 }) => {
   const securitySchemes = resource.security;
 
-  if (!securitySchemes || !securitySchemes.length) {
-    return Either.right(element);
-  } else {
+  if (securitySchemes && isNonEmpty(securitySchemes)) {
     return pipe(
       gatherValidationResults(securitySchemes, element),
       Either.fromOption(() => element),
       Either.swap,
       Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(e => [e])
     );
+  } else {
+    return Either.right(element);
   }
 };

--- a/packages/http/src/validator/validators/security/index.ts
+++ b/packages/http/src/validator/validators/security/index.ts
@@ -1,7 +1,7 @@
 import { IHttpOperation, HttpSecurityScheme } from '@stoplight/types';
 import * as Either from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { flatten, identity } from 'lodash';
+import { flatten } from 'lodash';
 import { set } from 'lodash/fp';
 import { findSecurityHandler } from './handlers';
 import { NonEmptyArray, getSemigroup } from 'fp-ts/lib/NonEmptyArray';
@@ -17,15 +17,9 @@ function getValidationResults(securitySchemes: HttpSecurityScheme[][], input: Pi
   return others.reduce((prev, current) => EitherValidation.alt(prev, () => current), first);
 }
 
-function getWWWAuthHeader(authResults: IPrismDiagnostic[]) {
-  if (authResults.length === 1) {
-    return authResults[0];
-  } else {
-    const wwwAuthenticateHeaders = authResults.map(authResult => authResult.tags || []);
-    const firstAuthErrWithAuthHeader = set(['tags'], flatten(wwwAuthenticateHeaders), authResults[0]);
-
-    return wwwAuthenticateHeaders.every(identity) ? firstAuthErrWithAuthHeader : authResults[0];
-  }
+function getWWWAuthHeader(authResults: NonEmptyArray<IPrismDiagnostic>) {
+  const tags = authResults.map(authResult => authResult.tags || []);
+  return set(['tags'], flatten(tags), authResults[0]);
 }
 
 function getAuthResultsAND(securitySchemes: HttpSecurityScheme[][], input: Pick<IHttpRequest, 'headers' | 'url'>) {


### PR DESCRIPTION
The following PR brings some significant simplification to the security checks that were made in Prism.

It literally took me ages to understand what was going on and why some choices were made so far — I guess this part definitely went out of control.

Hopefully this PR, although not 100% complete (but honestly I'm so tired of working on this section) will bring some clarity and order so that in the next flight refactor it one more time will be easier.