### PR TITLE
Callback delays implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+## Added
+
+- Support for advanced callbacks configuration [#833](https://github.com/stoplightio/prism/pull/833)
+
 # 3.2.0 (2019-11-21)
 
 ## Added

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -46,7 +46,7 @@ There is no need to manually stop and start a Prism server after a change to a s
 In case of removing all of the operations in a document, Prism will not be reloaded.
 In such a case, Prism will keep serving operations loaded with the previous restart.
 
-## Modifying Responses
+### Modifying Responses
 
 #### Force Response Status
 
@@ -79,6 +79,24 @@ You can override the `--dynamic|-d` CLI param (which decides whether the generat
 ```bash
 curl -v http://127.0.0.1:4010/pets/123?__dynamic=false
 ```
+
+### Advanced Callback configuration
+
+By default, a callback is executed once and immediately after making the base endpoint call. There are two options to override that behavior and make Prism act in a more realistic way.
+
+- `--callback-count` - specifies a count of times a callback should be executed
+- `--callback-delay` - defines a time (in seconds) to wait before executing a callback
+
+Both values can be either exact or specified as a range. Once specified as a range, the actual value will be randomized to fit into that range.
+
+#### Example 
+
+```bash
+prism mock --callback-delay=5-10 --callback-count=3 https://raw.githubusercontent.com/stoplightio/prism/master/examples/callbacks/payment-service.oas3.yaml
+```
+
+The above example configures callbacks to be executed always `3` times with a random delay within `5` and `10` seconds.
+
 
 ## Proxy
 

--- a/packages/cli/src/commands/__tests__/commands.spec.ts
+++ b/packages/cli/src/commands/__tests__/commands.spec.ts
@@ -71,3 +71,30 @@ describe.each<{ 0: string; 1: string; 2: unknown }>([
     expect(createMultiProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ errors: true }));
   });
 });
+
+describe('callback configuration', () => {
+  test(`starts mock server with callback defaults`, () => {
+    parser.parse(`mock /path/to`);
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: 0, callbackCount: 1 }));
+  });
+
+  test(`starts mock server with callback delay`, () => {
+    parser.parse(`mock --callback-delay=1 /path/to`);
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: 1 }));
+  });
+
+  test(`starts mock server with callback delay range`, () => {
+    parser.parse(`mock --callback-delay=1-5 /path/to`);
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: [1, 5] }));
+  });
+
+  test(`starts mock server with callback count`, () => {
+    parser.parse(`mock --callback-count=10 /path/to`);
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackCount: 10 }));
+  });
+
+  test(`starts mock server with callback count range`, () => {
+    parser.parse(`mock --callback-count=1-10 /path/to`);
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackCount: [1, 10] }));
+  });
+});

--- a/packages/cli/src/commands/__tests__/commands.spec.ts
+++ b/packages/cli/src/commands/__tests__/commands.spec.ts
@@ -80,12 +80,12 @@ describe('callback configuration', () => {
 
   test(`starts mock server with callback delay`, () => {
     parser.parse(`mock --callback-delay=1 /path/to`);
-    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: 1 }));
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: 1000 }));
   });
 
   test(`starts mock server with callback delay range`, () => {
     parser.parse(`mock --callback-delay=1-5 /path/to`);
-    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: [1, 5] }));
+    expect(createSingleProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ callbackDelay: [1000, 5000] }));
   });
 
   test(`starts mock server with callback count`, () => {

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -2,6 +2,7 @@ import { CommandModule } from 'yargs';
 import { CreateMockServerOptions, createMultiProcessPrism, createSingleProcessPrism } from '../util/createServer';
 import sharedOptions from './sharedOptions';
 import { runPrismAndSetupWatcher } from '../util/runner';
+import { RangeOrNumber } from '@stoplight/prism-core';
 
 const mockCommand: CommandModule = {
   describe: 'Start a mock server with the given document file',
@@ -24,7 +25,7 @@ const mockCommand: CommandModule = {
           description: 'Number of seconds to wait before executing callbacks',
           default: '0',
           string: true,
-          coerce: coerceRange,
+          coerce: (input: string) => toMillis(coerceRange(input)),
         },
         ['callback-count']: {
           description: 'How many times a callback should be executed',
@@ -53,13 +54,19 @@ const mockCommand: CommandModule = {
   },
 };
 
-function coerceRange(input: string) {
+function coerceRange(input: string): RangeOrNumber {
   const matches = /^([0-9]+)(-([0-9]+))?$/.exec(input);
   if (!matches) {
     throw new Error(`Cannot parse range: ${input}`);
   }
 
-  return matches[3] ? [parseInt(matches[1], 10), parseInt(matches[3], 10)].sort() : parseInt(matches[1], 10);
+  return matches[3]
+    ? ([parseInt(matches[1], 10), parseInt(matches[3], 10)].sort() as [number, number])
+    : parseInt(matches[1], 10);
+}
+
+function toMillis(input: RangeOrNumber) {
+  return typeof input === 'number' ? input * 1000 : input.map(r => r * 1000);
 }
 
 export default mockCommand;

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -21,13 +21,13 @@ const mockCommand: CommandModule = {
           boolean: true,
           default: false,
         },
-        callbackDelay: {
+        ['callback-delay']: {
           description: 'Number of seconds to wait before executing callbacks',
           default: '0',
           string: true,
           coerce: coerceRange,
         },
-        callbackCount: {
+        ['callback-count']: {
           description: 'How many times a callback should be executed',
           default: '1',
           string: true,

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -64,4 +64,3 @@ function coerceRange(input: string) {
 }
 
 export default mockCommand;
-

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -1,5 +1,4 @@
 import { CommandModule } from 'yargs';
-import { RangeOrNumber } from '@stoplight/prism-core';
 import { CreateMockServerOptions, createMultiProcessPrism, createSingleProcessPrism } from '../util/createServer';
 import sharedOptions from './sharedOptions';
 import { runPrismAndSetupWatcher } from '../util/runner';

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -21,13 +21,13 @@ const mockCommand: CommandModule = {
           boolean: true,
           default: false,
         },
-        ['callback-delay']: {
+        'callback-delay': {
           description: 'Number of seconds to wait before executing callbacks',
           default: '0',
           string: true,
           coerce: (input: string) => toMillis(coerceRange(input)),
         },
-        ['callback-count']: {
+        'callback-count': {
           description: 'How many times a callback should be executed',
           default: '1',
           string: true,

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@stoplight/prism-core';
+import { createLogger, RangeOrNumber } from '@stoplight/prism-core';
 import { IHttpConfig, IHttpProxyConfig, getHttpOperationsFromResource } from '@stoplight/prism-http';
 import { createServer as createHttpServer } from '@stoplight/prism-http-server';
 import chalk from 'chalk';
@@ -75,7 +75,15 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
 
   const config: IHttpProxyConfig | IHttpConfig = isProxyServerOptions(options)
     ? { ...shared, mock: false, upstream: options.upstream }
-    : { ...shared, mock: { dynamic: options.dynamic } };
+    : {
+        ...shared,
+        mock: {
+          dynamic: options.dynamic,
+
+          callbackDelay: (options as CreateMockServerOptions).callbackDelay,
+          callbackCount: (options as CreateMockServerOptions).callbackCount,
+        },
+      };
 
   const server = createHttpServer(operations, {
     cors: options.cors,
@@ -122,7 +130,7 @@ function isProxyServerOptions(options: CreateBaseServerOptions): options is Crea
   return 'upstream' in options;
 }
 
-type CreateBaseServerOptions = {
+export type CreateBaseServerOptions = {
   dynamic: boolean;
   cors: boolean;
   host: string;
@@ -137,6 +145,9 @@ export interface CreateProxyServerOptions extends CreateBaseServerOptions {
   upstream: URL;
 }
 
-export type CreateMockServerOptions = CreateBaseServerOptions;
+export interface CreateMockServerOptions extends CreateBaseServerOptions {
+  callbackDelay: RangeOrNumber;
+  callbackCount: RangeOrNumber;
+}
 
 export { createMultiProcessPrism, createSingleProcessPrism };

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -143,11 +143,11 @@ export type CreateBaseServerOptions = {
 export type CreateProxyServerOptions = CreateBaseServerOptions & {
   dynamic: false;
   upstream: URL;
-}
+};
 
 export type CreateMockServerOptions = CreateBaseServerOptions & {
   callbackDelay: RangeOrNumber;
   callbackCount: RangeOrNumber;
-}
+};
 
 export { createMultiProcessPrism, createSingleProcessPrism };

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -140,12 +140,12 @@ export type CreateBaseServerOptions = {
   errors: boolean;
 };
 
-export interface CreateProxyServerOptions extends CreateBaseServerOptions {
+export type CreateProxyServerOptions = CreateBaseServerOptions & {
   dynamic: false;
   upstream: URL;
 }
 
-export interface CreateMockServerOptions extends CreateBaseServerOptions {
+export type CreateMockServerOptions = CreateBaseServerOptions & {
   callbackDelay: RangeOrNumber;
   callbackCount: RangeOrNumber;
 }

--- a/packages/cli/src/util/runner.ts
+++ b/packages/cli/src/util/runner.ts
@@ -2,11 +2,11 @@ import { getHttpOperationsFromResource } from '@stoplight/prism-http';
 import { IPrismHttpServer } from '@stoplight/prism-http-server/src/types';
 import * as chokidar from 'chokidar';
 import * as os from 'os';
-import { CreateMockServerOptions } from './createServer';
+import { CreateBaseServerOptions } from './createServer';
 
-type CreatePrism = (options: CreateMockServerOptions) => Promise<IPrismHttpServer | void>;
+type CreatePrism = (options: CreateBaseServerOptions) => Promise<IPrismHttpServer | void>;
 
-export function runPrismAndSetupWatcher(createPrism: CreatePrism, options: CreateMockServerOptions) {
+export function runPrismAndSetupWatcher(createPrism: CreatePrism, options: CreateBaseServerOptions) {
   return createPrism(options).then(possiblyServer => {
     if (possiblyServer) {
       let server: IPrismHttpServer = possiblyServer;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,3 +90,5 @@ export class ProblemJsonError extends Error {
     Error.captureStackTrace(this, ProblemJsonError);
   }
 }
+
+export type RangeOrNumber = [number, number] | number;

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -7,7 +7,7 @@ import * as JSONSchemaGenerator from '../../mocker/generator/JSONSchema';
 import { IHttpRequest, JSONSchema } from '../../types';
 import helpers from '../negotiator/NegotiatorHelpers';
 import { assertRight } from '@stoplight/prism-core/src/__tests__/utils';
-import { scheduleCallback } from '../callback/callbacks';
+import { scheduleCallback } from '../callback/scheduler';
 
 jest.mock('../callback/callbacks', () => ({
   scheduleCallback: jest.fn(() => () => () => undefined),

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -9,7 +9,7 @@ import helpers from '../negotiator/NegotiatorHelpers';
 import { assertRight } from '@stoplight/prism-core/src/__tests__/utils';
 import { scheduleCallback } from '../callback/scheduler';
 
-jest.mock('../callback/callbacks', () => ({
+jest.mock('../callback/scheduler', () => ({
   scheduleCallback: jest.fn(() => () => () => undefined),
 }));
 

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -7,10 +7,10 @@ import * as JSONSchemaGenerator from '../../mocker/generator/JSONSchema';
 import { IHttpRequest, JSONSchema } from '../../types';
 import helpers from '../negotiator/NegotiatorHelpers';
 import { assertRight } from '@stoplight/prism-core/src/__tests__/utils';
-import { runCallback } from '../callback/callbacks';
+import { scheduleCallback } from '../callback/callbacks';
 
 jest.mock('../callback/callbacks', () => ({
-  runCallback: jest.fn(() => () => () => undefined),
+  scheduleCallback: jest.fn(() => () => () => undefined),
 }));
 
 const logger = createLogger('TEST', { enabled: false });
@@ -167,12 +167,12 @@ describe('mocker', () => {
         })(logger);
 
         assertRight(response, result => {
-          expect(runCallback).toHaveBeenCalledTimes(2);
-          expect(runCallback).toHaveBeenNthCalledWith(
+          expect(scheduleCallback).toHaveBeenCalledTimes(2);
+          expect(scheduleCallback).toHaveBeenNthCalledWith(
             1,
             expect.objectContaining({ callback: expect.objectContaining({ callbackName: 'c1' }) })
           );
-          expect(runCallback).toHaveBeenNthCalledWith(
+          expect(scheduleCallback).toHaveBeenNthCalledWith(
             2,
             expect.objectContaining({ callback: expect.objectContaining({ callbackName: 'c2' }) })
           );

--- a/packages/http/src/mocker/callback/__tests__/runner.spec.ts
+++ b/packages/http/src/mocker/callback/__tests__/runner.spec.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import { runCallback } from '../callbacks';
+import { runCallback } from '../runner';
 import { mapValues } from 'lodash';
 import { HttpParamStyles } from '@stoplight/types';
 

--- a/packages/http/src/mocker/callback/__tests__/scheduler.spec.ts
+++ b/packages/http/src/mocker/callback/__tests__/scheduler.spec.ts
@@ -1,0 +1,106 @@
+import { runCallback } from '../runner';
+import { scheduleCallback } from '../scheduler';
+
+jest.mock('../runner', () => ({ runCallback: jest.fn(() => () => async () => ({})) }));
+jest.useFakeTimers();
+
+describe('scheduleCallback()', () => {
+  beforeEach(() => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+  });
+
+  describe('neither delay nor count is specified', () => {
+    it('runs callback immediately', () => {
+      scheduleCallback({
+        config: {},
+        response: {} as any,
+        request: {} as any,
+        callback: {} as any,
+      } )({} as any);
+
+      expect(runCallback).not.toHaveBeenCalled();
+      jest.advanceTimersToNextTimer();
+      expect(runCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('1 second delay is specified', () => {
+    it('runs callback after 1 second', () => {
+      scheduleCallback({
+        config: { callbackDelay: 1 },
+        response: {} as any,
+        request: {} as any,
+        callback: {} as any,
+      } )({} as any);
+
+      expect(runCallback).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(1000);
+      expect(runCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('delay range is specified', () => {
+    it('runs callback within given delay', () => {
+      scheduleCallback({
+        config: { callbackDelay: [1, 10] },
+        response: {} as any,
+        request: {} as any,
+        callback: {} as any,
+      } )({} as any);
+
+      expect(runCallback).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(10 * 1000);
+      expect(runCallback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('count of 3 calls is specified', () => {
+    it('runs callback given count of times', async () => {
+      scheduleCallback({
+        config: { callbackCount: 3 },
+        response: {} as any,
+        request: {} as any,
+        callback: {} as any,
+      } )({} as any);
+
+      expect(runCallback).not.toHaveBeenCalled();
+
+      jest.advanceTimersToNextTimer();
+      await Promise.resolve();
+
+      jest.advanceTimersToNextTimer();
+      await Promise.resolve();
+
+      jest.advanceTimersToNextTimer();
+      await Promise.resolve();
+
+      expect(runCallback).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('count range and delay range is specified', () => {
+    it('runs callback both within given ranges of count and delay', async () => {
+      scheduleCallback({
+        config: { callbackCount: [3, 3], callbackDelay: [1, 10] },
+        response: {} as any,
+        request: {} as any,
+        callback: {} as any,
+      } )({} as any);
+
+      expect(runCallback).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(10 * 1000);
+      await Promise.resolve();
+
+      jest.advanceTimersByTime(10 * 1000);
+      await Promise.resolve();
+
+      jest.advanceTimersByTime(10 * 1000);
+      await Promise.resolve();
+
+      // I don't have idea how to make jest expect number of calls being a range
+      expect(runCallback).toHaveBeenCalledTimes(3)
+    });
+  });
+});

--- a/packages/http/src/mocker/callback/__tests__/scheduler.spec.ts
+++ b/packages/http/src/mocker/callback/__tests__/scheduler.spec.ts
@@ -28,7 +28,7 @@ describe('scheduleCallback()', () => {
   describe('1 second delay is specified', () => {
     it('runs callback after 1 second', () => {
       scheduleCallback({
-        config: { callbackDelay: 1 },
+        config: { callbackDelay: 1000 },
         response: {} as any,
         request: {} as any,
         callback: {} as any,
@@ -43,14 +43,14 @@ describe('scheduleCallback()', () => {
   describe('delay range is specified', () => {
     it('runs callback within given delay', () => {
       scheduleCallback({
-        config: { callbackDelay: [1, 10] },
+        config: { callbackDelay: [1000, 10000] },
         response: {} as any,
         request: {} as any,
         callback: {} as any,
       } )({} as any);
 
       expect(runCallback).not.toHaveBeenCalled();
-      jest.advanceTimersByTime(10 * 1000);
+      jest.advanceTimersByTime(10000);
       expect(runCallback).toHaveBeenCalledTimes(1);
     });
   });
@@ -82,7 +82,7 @@ describe('scheduleCallback()', () => {
   describe('count range and delay range is specified', () => {
     it('runs callback both within given ranges of count and delay', async () => {
       scheduleCallback({
-        config: { callbackCount: [3, 3], callbackDelay: [1, 10] },
+        config: { callbackCount: [3, 3], callbackDelay: [1000, 10000] },
         response: {} as any,
         request: {} as any,
         callback: {} as any,
@@ -90,13 +90,13 @@ describe('scheduleCallback()', () => {
 
       expect(runCallback).not.toHaveBeenCalled();
 
-      jest.advanceTimersByTime(10 * 1000);
+      jest.advanceTimersByTime(10000);
       await Promise.resolve();
 
-      jest.advanceTimersByTime(10 * 1000);
+      jest.advanceTimersByTime(10000);
       await Promise.resolve();
 
-      jest.advanceTimersByTime(10 * 1000);
+      jest.advanceTimersByTime(10000);
       await Promise.resolve();
 
       // I don't have idea how to make jest expect number of calls being a range

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -30,7 +30,7 @@ export function scheduleCallback({
   config: Pick<IHttpOperationConfig, 'callbackDelay' | 'callbackCount'>
 }) {
   return withLogger(logger => {
-    let executionsLeft = reduceRange(config.callbackCount);
+    let executionsLeft = reduceRange(config.callbackCount || 1);
 
     const execute = () => {
       if (executionsLeft > 0) {
@@ -39,7 +39,7 @@ export function scheduleCallback({
 
           runCallback({ callback, request, response })(logger)()
             .finally(execute);
-        }, reduceRange(config.callbackDelay) * 1000);
+        }, reduceRange(config.callbackDelay || 0) * 1000);
       }
     };
 

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -1,6 +1,4 @@
 import { IHttpCallbackOperation, IHttpOperationRequest } from '@stoplight/types';
-import { resolveRuntimeExpressions } from '../../utils/runtimeExpression';
-import { IHttpRequest, IHttpResponse } from '../../types';
 import fetch from 'node-fetch';
 import * as Option from 'fp-ts/lib/Option';
 import * as Either from 'fp-ts/lib/Either';
@@ -9,12 +7,45 @@ import * as TaskEither from 'fp-ts/lib/TaskEither';
 import * as ReaderTaskEither from 'fp-ts/lib/ReaderTaskEither';
 import { head } from 'fp-ts/lib/Array';
 import { pipe } from 'fp-ts/lib/pipeable';
+
+import { resolveRuntimeExpressions } from '../../utils/runtimeExpression';
+import { IHttpOperationConfig, IHttpRequest, IHttpResponse } from '../../types';
 import { generate as generateHttpParam } from '../generator/HttpParamGenerator';
 import { validateOutput } from '../../validator';
 import { parseResponse } from '../../utils/parseResponse';
 import withLogger from '../../withLogger';
 import { violationLogger } from '../../utils/logger';
 import { Logger } from 'pino';
+import { RangeOrNumber } from '@stoplight/prism-core';
+
+export function scheduleCallback({
+  callback,
+  request,
+  response,
+  config,
+}: {
+  callback: IHttpCallbackOperation;
+  request: IHttpRequest;
+  response: IHttpResponse;
+  config: Pick<IHttpOperationConfig, 'callbackDelay' | 'callbackCount'>
+}) {
+  return withLogger(logger => {
+    let executionsLeft = reduceRange(config.callbackCount);
+
+    const execute = () => {
+      if (executionsLeft > 0) {
+        setTimeout(() => {
+          executionsLeft--;
+
+          runCallback({ callback, request, response })(logger)()
+            .finally(execute);
+        }, reduceRange(config.callbackDelay) * 1000);
+      }
+    };
+
+    execute();
+  });
+}
 
 export function runCallback({
   callback,
@@ -124,5 +155,14 @@ function assembleHeaders(
       ),
       (mediaTypeHeader, headers) => ({ ...headers, ...mediaTypeHeader })
     )
+  );
+}
+
+function reduceRange(rangeOrNumber: RangeOrNumber): number {
+  return pipe(
+    rangeOrNumber,
+    Option.fromPredicate(Array.isArray),
+    Option.map(range => range[0] + Math.round(Math.random() * (range[1] - range[0]))),
+    Option.getOrElse(() => rangeOrNumber as number),
   );
 }

--- a/packages/http/src/mocker/callback/runner.ts
+++ b/packages/http/src/mocker/callback/runner.ts
@@ -9,43 +9,13 @@ import { head } from 'fp-ts/lib/Array';
 import { pipe } from 'fp-ts/lib/pipeable';
 
 import { resolveRuntimeExpressions } from '../../utils/runtimeExpression';
-import { IHttpOperationConfig, IHttpRequest, IHttpResponse } from '../../types';
+import { IHttpRequest, IHttpResponse } from '../../types';
 import { generate as generateHttpParam } from '../generator/HttpParamGenerator';
 import { validateOutput } from '../../validator';
 import { parseResponse } from '../../utils/parseResponse';
 import withLogger from '../../withLogger';
 import { violationLogger } from '../../utils/logger';
 import { Logger } from 'pino';
-import { RangeOrNumber } from '@stoplight/prism-core';
-
-export function scheduleCallback({
-  callback,
-  request,
-  response,
-  config,
-}: {
-  callback: IHttpCallbackOperation;
-  request: IHttpRequest;
-  response: IHttpResponse;
-  config: Pick<IHttpOperationConfig, 'callbackDelay' | 'callbackCount'>
-}) {
-  return withLogger(logger => {
-    let executionsLeft = reduceRange(config.callbackCount || 1);
-
-    const execute = () => {
-      if (executionsLeft > 0) {
-        setTimeout(() => {
-          executionsLeft--;
-
-          runCallback({ callback, request, response })(logger)()
-            .finally(execute);
-        }, reduceRange(config.callbackDelay || 0) * 1000);
-      }
-    };
-
-    execute();
-  });
-}
 
 export function runCallback({
   callback,
@@ -155,14 +125,5 @@ function assembleHeaders(
       ),
       (mediaTypeHeader, headers) => ({ ...headers, ...mediaTypeHeader })
     )
-  );
-}
-
-function reduceRange(rangeOrNumber: RangeOrNumber): number {
-  return pipe(
-    rangeOrNumber,
-    Option.fromPredicate(Array.isArray),
-    Option.map(range => range[0] + Math.round(Math.random() * (range[1] - range[0]))),
-    Option.getOrElse(() => rangeOrNumber as number),
   );
 }

--- a/packages/http/src/mocker/callback/scheduler.ts
+++ b/packages/http/src/mocker/callback/scheduler.ts
@@ -1,0 +1,45 @@
+import { IHttpCallbackOperation, IHttpOperationRequest } from '@stoplight/types';
+import { IHttpOperationConfig, IHttpRequest, IHttpResponse } from '../../types';
+import withLogger from '../../withLogger';
+import { runCallback } from './runner';
+import { RangeOrNumber } from '@stoplight/prism-core';
+import { pipe } from 'fp-ts/lib/pipeable';
+import * as Option from 'fp-ts/lib/Option';
+
+export function scheduleCallback({
+                                   callback,
+                                   request,
+                                   response,
+                                   config,
+                                 }: {
+  callback: IHttpCallbackOperation;
+  request: IHttpRequest;
+  response: IHttpResponse;
+  config: Pick<IHttpOperationConfig, 'callbackDelay' | 'callbackCount'>
+}) {
+  return withLogger(logger => {
+    let executionsLeft = reduceRange(config.callbackCount || 1);
+
+    const execute = () => {
+      if (executionsLeft > 0) {
+        setTimeout(() => {
+          executionsLeft--;
+
+          runCallback({ callback, request, response })(logger)()
+            .finally(execute);
+        }, reduceRange(config.callbackDelay || 0) * 1000);
+      }
+    };
+
+    execute();
+  });
+}
+
+function reduceRange(rangeOrNumber: RangeOrNumber): number {
+  return pipe(
+    rangeOrNumber,
+    Option.fromPredicate(Array.isArray),
+    Option.map(range => range[0] + Math.round(Math.random() * (range[1] - range[0]))),
+    Option.getOrElse(() => rangeOrNumber as number),
+  );
+}

--- a/packages/http/src/mocker/callback/scheduler.ts
+++ b/packages/http/src/mocker/callback/scheduler.ts
@@ -27,7 +27,7 @@ export function scheduleCallback({
 
           runCallback({ callback, request, response })(logger)()
             .finally(execute);
-        }, reduceRange(config.callbackDelay || 0) * 1000);
+        }, reduceRange(config.callbackDelay || 0));
       }
     };
 

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -24,7 +24,7 @@ import { UNAUTHORIZED, UNPROCESSABLE_ENTITY } from './errors';
 import { generate, generateStatic } from './generator/JSONSchema';
 import helpers from './negotiator/NegotiatorHelpers';
 import { IHttpNegotiationResult } from './negotiator/types';
-import { scheduleCallback } from './callback/callbacks';
+import { scheduleCallback } from './callback/scheduler';
 
 const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IMockHttpConfig>['mock'] = ({
   resource,

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -11,8 +11,8 @@ export interface IHttpOperationConfig {
   code?: string;
   exampleKey?: string;
   dynamic: boolean;
-  callbackDelay: RangeOrNumber;
-  callbackCount: RangeOrNumber;
+  callbackDelay?: RangeOrNumber;
+  callbackCount?: RangeOrNumber;
 }
 
 export interface IHttpConfig extends IPrismConfig {

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -1,4 +1,4 @@
-import { IPrism, IPrismComponents, IPrismConfig } from '@stoplight/prism-core';
+import { IPrism, IPrismComponents, IPrismConfig, RangeOrNumber } from '@stoplight/prism-core';
 import { Dictionary, HttpMethod, IHttpOperation, INodeExample, INodeExternalExample } from '@stoplight/types';
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 
@@ -11,6 +11,8 @@ export interface IHttpOperationConfig {
   code?: string;
   exampleKey?: string;
   dynamic: boolean;
+  callbackDelay: RangeOrNumber;
+  callbackCount: RangeOrNumber;
 }
 
 export interface IHttpConfig extends IPrismConfig {


### PR DESCRIPTION
Closes #775 

## Checklist

- [x] Tests have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

_feature_

## What is the current behavior? What is the new behavior?

This PR introduces two new cli options:
`--callback-delay=n(-m)?`, where:
- `n` is number of seconds to wait (defaults to `0`), 
- `m` is optional and if set means that time to wait is randomized between `n` and `m`

`--callback-count=n(-m)?`, where:
- `n` is number of times to run a callback (defaults to `1`, `0` means infinitely), 
- `m` is optional and if set means that number of calls is randomized between `n` and `m`

## Does this PR introduce a breaking change?

No