### PR TITLE
refactor: handle validation exception correctly

### DIFF
--- a/packages/http/src/validator/validators/__tests__/__snapshots__/utils.spec.ts.snap
+++ b/packages/http/src/validator/validators/__tests__/__snapshots__/utils.spec.ts.snap
@@ -27,17 +27,3 @@ Array [
   },
 ]
 `;
-
-exports[`validateAgainstSchema() has validation errors returns validation errors 1`] = `
-Array [
-  Object {
-    "message": "should be number",
-    "name": "type",
-    "path": Array [
-      "pfx",
-    ],
-    "severity": 0,
-    "summary": "should be number",
-  },
-]
-`;

--- a/packages/http/src/validator/validators/__tests__/headers.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/headers.spec.ts
@@ -3,6 +3,7 @@ import { query as registry } from '../../deserializers';
 import { HttpHeadersValidator } from '../headers';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
+import { some } from 'fp-ts/lib/Option';
 
 describe('HttpHeadersValidator', () => {
   const httpHeadersValidator = new HttpHeadersValidator(registry, 'header');
@@ -48,7 +49,7 @@ describe('HttpHeadersValidator', () => {
                 ])
               );
 
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
             });
           });
 
@@ -65,7 +66,7 @@ describe('HttpHeadersValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
               });
             });
           });
@@ -82,7 +83,7 @@ describe('HttpHeadersValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/headers.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/headers.spec.ts
@@ -3,7 +3,7 @@ import { query as registry } from '../../deserializers';
 import { HttpHeadersValidator } from '../headers';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import { some } from 'fp-ts/lib/Option';
+import * as Option from 'fp-ts/lib/Option';
 
 describe('HttpHeadersValidator', () => {
   const httpHeadersValidator = new HttpHeadersValidator(registry, 'header');
@@ -49,7 +49,7 @@ describe('HttpHeadersValidator', () => {
                 ])
               );
 
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
             });
           });
 
@@ -66,7 +66,7 @@ describe('HttpHeadersValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
               });
             });
           });
@@ -83,7 +83,7 @@ describe('HttpHeadersValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/path.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/path.spec.ts
@@ -3,7 +3,7 @@ import { path as registry } from '../../deserializers';
 import { HttpPathValidator } from '../path';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
-import { some } from 'fp-ts/lib/Option';
+import * as Option from 'fp-ts/lib/Option';
 
 describe('HttpPathValidator', () => {
   const httpPathValidator = new HttpPathValidator(registry, 'path');
@@ -47,7 +47,7 @@ describe('HttpPathValidator', () => {
               };
 
               assertRight(httpPathValidator.validate({ param: 'abc' }, [param]));
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
             });
           });
 
@@ -64,7 +64,7 @@ describe('HttpPathValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
               });
             });
           });
@@ -81,7 +81,7 @@ describe('HttpPathValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/path.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/path.spec.ts
@@ -3,6 +3,7 @@ import { path as registry } from '../../deserializers';
 import { HttpPathValidator } from '../path';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
+import { some } from 'fp-ts/lib/Option';
 
 describe('HttpPathValidator', () => {
   const httpPathValidator = new HttpPathValidator(registry, 'path');
@@ -46,7 +47,7 @@ describe('HttpPathValidator', () => {
               };
 
               assertRight(httpPathValidator.validate({ param: 'abc' }, [param]));
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
             });
           });
 
@@ -63,7 +64,7 @@ describe('HttpPathValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
               });
             });
           });
@@ -80,7 +81,7 @@ describe('HttpPathValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(some([]));
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/query.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/query.spec.ts
@@ -3,6 +3,7 @@ import { query as registry } from '../../deserializers';
 import { HttpQueryValidator } from '../query';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
+import * as Option from 'fp-ts/lib/Option';
 
 describe('HttpQueryValidator', () => {
   const httpQueryValidator = new HttpQueryValidator(registry, 'query');
@@ -39,7 +40,7 @@ describe('HttpQueryValidator', () => {
 
               assertRight(httpQueryValidator.validate({ param: 'abc' }, [param]));
 
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
             });
           });
 
@@ -56,7 +57,7 @@ describe('HttpQueryValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
               });
             });
           });
@@ -73,7 +74,7 @@ describe('HttpQueryValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith([]);
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.some([]));
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -66,7 +66,10 @@ describe('validateAgainstSchema()', () => {
           summary: 'should be number',
         },
       ]);
-      assertSome(validateAgainstSchema('test', { type: 'number' }, 'pfx'), e => expect(e).toMatchSnapshot());
+      assertSome(validateAgainstSchema('test', { type: 'number' }, 'pfx'), error =>
+        expect(error).toContainEqual(expect.objectContaining({ message: 'should be number' }))
+      );
+
       expect(convertAjvErrorsModule.convertAjvErrors).toHaveBeenCalledWith(
         [
           {

--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -2,6 +2,7 @@ import { DiagnosticSeverity } from '@stoplight/types';
 import * as convertAjvErrorsModule from '../utils';
 import { convertAjvErrors, validateAgainstSchema } from '../utils';
 import { ErrorObject } from 'ajv';
+import { assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 
 describe('convertAjvErrors()', () => {
   const errorObjectFixture: ErrorObject = {
@@ -49,7 +50,7 @@ describe('validateAgainstSchema()', () => {
 
   describe('has no validation errors', () => {
     it('returns no validation errors', () => {
-      expect(validateAgainstSchema('test', { type: 'string' }, 'pfx')).toEqual([]);
+      assertSome(validateAgainstSchema('test', { type: 'string' }, 'pfx'), e => expect(e).toEqual([]));
       expect(convertAjvErrorsModule.convertAjvErrors).not.toHaveBeenCalled();
     });
   });
@@ -65,7 +66,7 @@ describe('validateAgainstSchema()', () => {
           summary: 'should be number',
         },
       ]);
-      expect(validateAgainstSchema('test', { type: 'number' }, 'pfx')).toMatchSnapshot();
+      assertSome(validateAgainstSchema('test', { type: 'number' }, 'pfx'), e => expect(e).toMatchSnapshot());
       expect(convertAjvErrorsModule.convertAjvErrors).toHaveBeenCalledWith(
         [
           {

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -68,7 +68,7 @@ function validateBodyIfNotFormEncoded(mediaType: string, schema: JSONSchema, tar
   return pipe(
     mediaType,
     Option.fromPredicate(mt => !typeIs.is(mt, ['application/x-www-form-urlencoded'])),
-    Option.map(() => validateAgainstSchema(target, schema))
+    Option.chain(() => validateAgainstSchema(target, schema))
   );
 }
 
@@ -80,7 +80,10 @@ function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, 
     validateAgainstReservedCharacters(encodedUriParams, encodings),
     Either.map(decodeUriEntities),
     Either.map(decodedUriEntities => deserializeFormBody(schema, encodings, decodedUriEntities)),
-    Either.fold(e => Option.some(e), deserialised => Option.some(validateAgainstSchema(deserialised, schema)))
+    Either.fold(
+      e => Option.some(e),
+      deserialised => validateAgainstSchema(deserialised, schema)
+    )
   );
 }
 


### PR DESCRIPTION
Get rid of the throw statement and handle it correctly with the helper provided by the Option monad.