### PR TITLE
fix: 500 only for output validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+# 3.2.2 (2019-12-13)
+
 ## Fixed
 
-Correctly handle the possibility of a body/headers generation failure [#875](https://github.com/stoplightio/prism/pull/875)
+- Correctly handle the possibility of a body/headers generation failure [#875](https://github.com/stoplightio/prism/pull/875)
+- Input validation errors should not trigger a `500` status code when the `--errors` flag is set to true [#892](https://github.com/stoplightio/prism/pull/892)
 
 # 3.2.1 (2019-11-21)
 

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "independent": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.1",
-    "@stoplight/prism-http-server": "^3.2.1",
+    "@stoplight/prism-core": "^3.2.2",
+    "@stoplight/prism-http-server": "^3.2.2",
     "chalk": "^3.0.0",
     "chokidar": "^3.2.1",
     "fp-ts": "^2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.1",
-    "@stoplight/prism-http": "^3.2.1",
+    "@stoplight/prism-core": "^3.2.2",
+    "@stoplight/prism-http": "^3.2.2",
     "fast-xml-parser": "^3.12.20",
     "fastify": "^2.7.1",
     "fastify-cors": "^3.0.0",

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -72,16 +72,17 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
       TaskEither.chain(response => {
         const { output } = response;
 
-        const inputOutputValidationErrors = response.validations.output
-          .map(createErrorObjectWithPrefix('response'))
-          .concat(response.validations.input.map(createErrorObjectWithPrefix('request')));
+        const inputValidationErrors = response.validations.input.map(createErrorObjectWithPrefix('request'));
+        const outputValidationErrors = response.validations.output.map(createErrorObjectWithPrefix('response'));
+        const inputOutputValidationErrors = inputValidationErrors.concat(outputValidationErrors);
 
         if (inputOutputValidationErrors.length > 0) {
           reply.header('sl-violations', JSON.stringify(inputOutputValidationErrors));
 
-          const errorViolations = inputOutputValidationErrors.filter(
+          const errorViolations = outputValidationErrors.filter(
             v => v.severity === DiagnosticSeverity[DiagnosticSeverity.Error]
           );
+
           if (opts.errors && errorViolations.length > 0) {
             return TaskEither.left(
               ProblemJsonError.fromTemplate(

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.1.2",
     "@stoplight/json-ref-readers": "^1.1.1",
     "@stoplight/json-ref-resolver": "^3.0.1",
-    "@stoplight/prism-core": "^3.2.1",
+    "@stoplight/prism-core": "^3.2.2",
     "@stoplight/yaml": "^3.0.2",
     "abstract-logging": "^2.0.0",
     "accepts": "^1.3.7",

--- a/test-harness/specs/violations/input-only-no-500.txt
+++ b/test-harness/specs/violations/input-only-no-500.txt
@@ -1,0 +1,30 @@
+====test====
+If Prism detects an input violation, but not an output violiation, the status code should not be modified to be a 500
+====spec====
+openapi: 3.0.0
+paths:
+  '/pet/{petId}':
+    get:
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        default: {}
+      security:
+        - api_key: []
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+====server====
+mock -p 4010 ${document} --errors
+====command====
+curl -i "http://localhost:4010/pet/10"
+====expect-loose====
+HTTP/1.1 401 Unauthorized
+sl-violations: [{"location":["request"],"severity":"Error","code":401,"message":"Invalid security scheme used"}]


### PR DESCRIPTION
It turns out that we were returning a 500 even if there were just Input violations in the current request — but in that case the negotiation process is already giving us the response we want to return; the 500 transformation is only required for *output* violations.

Please approve but do not merge, so I can bundle this in a patch release. 