### PR TITLE
refactor: rename fp-ts imports

### DIFF
--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -3,7 +3,7 @@ import { IHttpConfig, IHttpProxyConfig, getHttpOperationsFromResource } from '@s
 import { createServer as createHttpServer } from '@stoplight/prism-http-server';
 import * as chalk from 'chalk';
 import * as cluster from 'cluster';
-import * as Either from 'fp-ts/lib/Either';
+import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { LogDescriptor, Logger, LoggerOptions } from 'pino';
 import * as signale from 'signale';
@@ -89,7 +89,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
   operations.forEach(resource => {
     const path = pipe(
       createExamplePath(resource, attachTagsToParamsValues),
-      Either.getOrElse(() => resource.path)
+      E.getOrElse(() => resource.path)
     );
 
     logInstance.info(

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -1,8 +1,8 @@
 // @ts-ignore
 import logger from 'abstract-logging';
-import * as Either from 'fp-ts/lib/Either';
+import * as E from 'fp-ts/lib/Either';
 import { asks } from 'fp-ts/lib/ReaderEither';
-import * as TaskEither from 'fp-ts/lib/TaskEither';
+import * as TE from 'fp-ts/lib/TaskEither';
 import { Logger } from 'pino';
 import { factory, IPrismConfig } from '..';
 
@@ -11,9 +11,9 @@ describe('validation', () => {
     validateInput: jest.fn().mockReturnValue(['something']),
     validateOutput: jest.fn().mockReturnValue(['something']),
     validateSecurity: jest.fn().mockReturnValue(['something']),
-    route: jest.fn().mockReturnValue(Either.right('hey')),
+    route: jest.fn().mockReturnValue(E.right('hey')),
     forward: jest.fn().mockReturnValue(
-      TaskEither.right({
+      TE.right({
         statusCode: 200,
         headers: {},
         body: {},

--- a/packages/core/src/__tests__/utils.ts
+++ b/packages/core/src/__tests__/utils.ts
@@ -1,13 +1,13 @@
-import * as Option from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/lib/Option';
 import { noop } from 'lodash';
 import { pipe } from 'fp-ts/lib/pipeable';
-import * as Either from 'fp-ts/lib/Either';
-import * as TaskEither from 'fp-ts/lib/TaskEither';
+import * as E from 'fp-ts/lib/Either';
+import * as TE from 'fp-ts/lib/TaskEither';
 
-export function assertNone<A>(e: Option.Option<A>): asserts e is Option.None {
+export function assertNone<A>(e: O.Option<A>): asserts e is O.None {
   pipe(
     e,
-    Option.fold(
+    O.fold(
       () => ({}),
       a => {
         throw new Error('None expected, got a Some: ' + a);
@@ -16,40 +16,37 @@ export function assertNone<A>(e: Option.Option<A>): asserts e is Option.None {
   );
 }
 
-export function assertSome<A>(e: Option.Option<A>, onSome: (a: A) => void = noop): asserts e is Option.Some<A> {
+export function assertSome<A>(e: O.Option<A>, onSome: (a: A) => void = noop): asserts e is O.Some<A> {
   pipe(
     e,
-    Option.fold(() => {
+    O.fold(() => {
       throw new Error('Some expected, got a None');
     }, onSome)
   );
 }
 
-export function assertRight<L, A>(
-  e: Either.Either<L, A>,
-  onRight: (a: A) => void = noop
-): asserts e is Either.Right<A> {
+export function assertRight<L, A>(e: E.Either<L, A>, onRight: (a: A) => void = noop): asserts e is E.Right<A> {
   pipe(
     e,
-    Either.fold(l => {
+    E.fold(l => {
       throw new Error('Right expected, got a Left: ' + l);
     }, onRight)
   );
 }
 
-export function assertLeft<L, A>(e: Either.Either<L, A>, onLeft: (a: L) => void = noop): asserts e is Either.Left<L> {
+export function assertLeft<L, A>(e: E.Either<L, A>, onLeft: (a: L) => void = noop): asserts e is E.Left<L> {
   pipe(
     e,
-    Either.fold(onLeft, a => {
+    E.fold(onLeft, a => {
       throw new Error('Left expected, got a Right: ' + a);
     })
   );
 }
 
-export async function assertResolvesRight<L, A>(e: TaskEither.TaskEither<L, A>, onRight: (a: A) => void = noop) {
+export async function assertResolvesRight<L, A>(e: TE.TaskEither<L, A>, onRight: (a: A) => void = noop) {
   assertRight(await e(), onRight);
 }
 
-export async function assertResolvesLeft<L, A>(e: TaskEither.TaskEither<L, A>, onLeft: (a: L) => void = noop) {
+export async function assertResolvesLeft<L, A>(e: TE.TaskEither<L, A>, onLeft: (a: L) => void = noop) {
   assertLeft(await e(), onLeft);
 }

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -111,7 +111,7 @@ Note: the `request` method returns a [`TaskEither` monad](https://gcanti.github.
       },
       operations
     ),
-    TaskEither.fold(console.error, console.log);
+    TE.fold(console.error, console.log);
   )(); // returns a Promise
 ```
 

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -2,9 +2,9 @@ import { IPrismComponents } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 import fetch from 'node-fetch';
 import { pipe } from 'fp-ts/lib/pipeable';
-import * as Either from 'fp-ts/lib/Either';
-import * as TaskEither from 'fp-ts/lib/TaskEither';
-import * as ReaderTaskEither from 'fp-ts/lib/ReaderTaskEither';
+import * as E from 'fp-ts/lib/Either';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as RTE from 'fp-ts/lib/ReaderTaskEither';
 import { defaults, omit } from 'lodash';
 import { format, parse } from 'url';
 import { posix } from 'path';
@@ -17,11 +17,11 @@ const { version: prismVersion } = require('../../package.json');
 const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>['forward'] = (
   input: IHttpRequest,
   baseUrl: string
-): ReaderTaskEither.ReaderTaskEither<Logger, Error, IHttpResponse> => logger =>
+): RTE.ReaderTaskEither<Logger, Error, IHttpResponse> => logger =>
   pipe(
-    TaskEither.fromEither(serializeBody(input.body)),
-    TaskEither.chain(body =>
-      TaskEither.tryCatch(async () => {
+    TE.fromEither(serializeBody(input.body)),
+    TE.chain(body =>
+      TE.tryCatch(async () => {
         const partialUrl = parse(baseUrl);
         const url = format({
           ...partialUrl,
@@ -39,19 +39,19 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
             'user-agent': `Prism/${prismVersion}`,
           }),
         });
-      }, Either.toError)
+      }, E.toError)
     ),
-    TaskEither.chain(parseResponse)
+    TE.chain(parseResponse)
   );
 
 export default forward;
 
 function serializeBody(body: unknown) {
   if (typeof body === 'string') {
-    return Either.right(body);
+    return E.right(body);
   }
 
-  if (body) return Either.stringifyJSON(body, Either.toError);
+  if (body) return E.stringifyJSON(body, E.toError);
 
-  return Either.right(undefined);
+  return E.right(undefined);
 }

--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -1,7 +1,7 @@
 import { createLogger, IPrismInput } from '@stoplight/prism-core';
 import { IHttpOperation, INodeExample, DiagnosticSeverity } from '@stoplight/types';
 import { right } from 'fp-ts/lib/ReaderEither';
-import * as Either from 'fp-ts/lib/Either';
+import * as E from 'fp-ts/lib/Either';
 import { flatMap } from 'lodash';
 import mock from '../../mocker';
 import * as JSONSchemaGenerator from '../../mocker/generator/JSONSchema';
@@ -296,7 +296,7 @@ describe('mocker', () => {
           })
         );
 
-        jest.spyOn(JSONSchemaGenerator, 'generate').mockReturnValue(Either.right('example value chelsea'));
+        jest.spyOn(JSONSchemaGenerator, 'generate').mockReturnValue(E.right('example value chelsea'));
 
         const mockResult = mock({
           config: { dynamic: true },
@@ -314,7 +314,7 @@ describe('mocker', () => {
           const generatedExample = { hello: 'world' };
 
           beforeAll(() => {
-            jest.spyOn(JSONSchemaGenerator, 'generate').mockReturnValue(Either.right(generatedExample));
+            jest.spyOn(JSONSchemaGenerator, 'generate').mockReturnValue(E.right(generatedExample));
             jest.spyOn(JSONSchemaGenerator, 'generateStatic');
           });
 

--- a/packages/http/src/mocker/generator/HttpParamGenerator.ts
+++ b/packages/http/src/mocker/generator/HttpParamGenerator.ts
@@ -1,5 +1,5 @@
 import { IHttpContent, IHttpParam, INodeExample, INodeExternalExample } from '@stoplight/types';
-import * as Option from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { JSONSchema } from '../../types';
 import { generate as generateDynamicExample } from './JSONSchema';
@@ -41,25 +41,23 @@ export function improveSchema(schema: JSONSchema): JSONSchema {
   return newSchema;
 }
 
-function pickStaticExample(
-  examples: Option.Option<Array<INodeExample | INodeExternalExample>>
-): Option.Option<unknown> {
+function pickStaticExample(examples: O.Option<Array<INodeExample | INodeExternalExample>>): O.Option<unknown> {
   return pipe(
     examples,
-    Option.mapNullable(exs => exs[Math.floor(Math.random() * exs.length)]),
-    Option.mapNullable(example => (example as INodeExample).value)
+    O.mapNullable(exs => exs[Math.floor(Math.random() * exs.length)]),
+    O.mapNullable(example => (example as INodeExample).value)
   );
 }
 
-export function generate(param: IHttpParam | IHttpContent): Option.Option<unknown> {
+export function generate(param: IHttpParam | IHttpContent): O.Option<unknown> {
   return pipe(
-    Option.fromNullable(param.examples),
+    O.fromNullable(param.examples),
     pickStaticExample,
-    Option.alt(() =>
+    O.alt(() =>
       pipe(
-        Option.fromNullable(param.schema),
-        Option.map(improveSchema),
-        Option.chain(schema => Option.fromEither(generateDynamicExample(schema)))
+        O.fromNullable(param.schema),
+        O.map(improveSchema),
+        O.chain(schema => O.fromEither(generateDynamicExample(schema)))
       )
     )
   );

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -7,7 +7,7 @@ import {
   INodeExternalExample,
 } from '@stoplight/types';
 import { Chance } from 'chance';
-import * as Either from 'fp-ts/lib/Either';
+import * as E from 'fp-ts/lib/Either';
 import { left, right } from 'fp-ts/lib/ReaderEither';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import helpers from '../NegotiatorHelpers';
@@ -16,7 +16,7 @@ import { IHttpNegotiationResult, NegotiationOptions } from '../types';
 const chance = new Chance();
 const logger = createLogger('TEST', { enabled: false });
 
-const assertPayloadlessResponse = (actualResponse: Either.Either<Error, IHttpNegotiationResult>) => {
+const assertPayloadlessResponse = (actualResponse: E.Either<Error, IHttpNegotiationResult>) => {
   assertRight(actualResponse, response => {
     expect(response).not.toHaveProperty('bodyExample');
     expect(response).not.toHaveProperty('mediaType');
@@ -472,9 +472,7 @@ describe('NegotiatorHelpers', () => {
           mediaType: desiredOptions.mediaTypes[0],
           headers: [],
         };
-        jest
-          .spyOn(helpers, 'negotiateByPartialOptionsAndHttpContent')
-          .mockReturnValue(Either.right(fakeOperationConfig));
+        jest.spyOn(helpers, 'negotiateByPartialOptionsAndHttpContent').mockReturnValue(E.right(fakeOperationConfig));
         jest.spyOn(helpers, 'negotiateDefaultMediaType');
 
         const actualOperationConfig = helpers.negotiateOptionsBySpecificResponse(
@@ -588,7 +586,7 @@ describe('NegotiatorHelpers', () => {
             httpResponseSchema
           )(logger);
 
-          expect(Either.isLeft(actualResponse)).toBeTruthy();
+          expect(E.isLeft(actualResponse)).toBeTruthy();
         });
       });
 
@@ -640,7 +638,7 @@ describe('NegotiatorHelpers', () => {
         };
 
         jest.spyOn(helpers, 'negotiateByPartialOptionsAndHttpContent');
-        jest.spyOn(helpers, 'negotiateDefaultMediaType').mockReturnValue(Either.right(fakeOperationConfig));
+        jest.spyOn(helpers, 'negotiateDefaultMediaType').mockReturnValue(E.right(fakeOperationConfig));
 
         const actualOperationConfig = helpers.negotiateOptionsBySpecificResponse(
           httpOperation,
@@ -698,9 +696,7 @@ describe('NegotiatorHelpers', () => {
           headers: [],
         };
 
-        jest
-          .spyOn(helpers, 'negotiateByPartialOptionsAndHttpContent')
-          .mockReturnValue(Either.right(fakeOperationConfig));
+        jest.spyOn(helpers, 'negotiateByPartialOptionsAndHttpContent').mockReturnValue(E.right(fakeOperationConfig));
 
         const actualOperationConfig = helpers.negotiateDefaultMediaType(partialOptions, response);
 

--- a/packages/http/src/utils/parseResponse.ts
+++ b/packages/http/src/utils/parseResponse.ts
@@ -1,7 +1,7 @@
 import { Response } from 'node-fetch';
 import { is as typeIs } from 'type-is';
-import * as Either from 'fp-ts/lib/Either';
-import * as TaskEither from 'fp-ts/lib/TaskEither';
+import * as E from 'fp-ts/lib/Either';
+import * as TE from 'fp-ts/lib/TaskEither';
 import { mapValues } from 'lodash';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { Dictionary } from '@stoplight/types';
@@ -9,13 +9,13 @@ import { IHttpResponse } from '../types';
 
 export const parseResponseBody = (
   response: Pick<Response, 'headers' | 'json' | 'text'>
-): TaskEither.TaskEither<Error, unknown> =>
-  TaskEither.tryCatch(
+): TE.TaskEither<Error, unknown> =>
+  TE.tryCatch(
     () =>
       typeIs(response.headers.get('content-type') || '', ['application/json', 'application/*+json'])
         ? response.json()
         : response.text(),
-    Either.toError
+    E.toError
   );
 
 export const parseResponseHeaders = (headers: Dictionary<string[]>): Dictionary<string> =>
@@ -23,10 +23,10 @@ export const parseResponseHeaders = (headers: Dictionary<string[]>): Dictionary<
 
 export const parseResponse = (
   response: Pick<Response, 'headers' | 'json' | 'text' | 'status'>
-): TaskEither.TaskEither<Error, IHttpResponse> =>
+): TE.TaskEither<Error, IHttpResponse> =>
   pipe(
     parseResponseBody(response),
-    TaskEither.map(body => ({
+    TE.map(body => ({
       statusCode: response.status,
       headers: parseResponseHeaders(response.headers.raw()),
       body,

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { DiagnosticSeverity, IHttpOperation, HttpParamStyles } from '@stoplight/types';
-import * as Either from 'fp-ts/lib/Either';
+import * as E from 'fp-ts/lib/Either';
 import { IHttpRequest } from '../../types';
 import * as validator from '../index';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
@@ -38,10 +38,10 @@ const mockError: IPrismDiagnostic = {
 describe('HttpValidator', () => {
   describe('validator.validateInput()', () => {
     beforeAll(() => {
-      jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(Either.left([mockError]));
-      jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(Either.left([mockError]));
-      jest.spyOn(validator.queryValidator, 'validate').mockReturnValue(Either.left([mockError]));
-      jest.spyOn(validator.pathValidator, 'validate').mockReturnValue(Either.left([mockError]));
+      jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(E.left([mockError]));
+      jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(E.left([mockError]));
+      jest.spyOn(validator.queryValidator, 'validate').mockReturnValue(E.left([mockError]));
+      jest.spyOn(validator.pathValidator, 'validate').mockReturnValue(E.left([mockError]));
     });
 
     afterAll(() => jest.restoreAllMocks());
@@ -140,9 +140,9 @@ describe('HttpValidator', () => {
   describe('validateOutput()', () => {
     describe('output is set', () => {
       beforeAll(() => {
-        jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(Either.left([mockError]));
-        jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(Either.left([mockError]));
-        jest.spyOn(validator.queryValidator, 'validate').mockReturnValue(Either.left([mockError]));
+        jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(E.left([mockError]));
+        jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(E.left([mockError]));
+        jest.spyOn(validator.queryValidator, 'validate').mockReturnValue(E.left([mockError]));
       });
 
       afterAll(() => jest.restoreAllMocks());
@@ -189,8 +189,8 @@ describe('HttpValidator', () => {
 
     describe('cannot match status code with responses', () => {
       beforeEach(() => {
-        jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(Either.right({}));
-        jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(Either.right({}));
+        jest.spyOn(validator.bodyValidator, 'validate').mockReturnValue(E.right({}));
+        jest.spyOn(validator.headersValidator, 'validate').mockReturnValue(E.right({}));
       });
 
       afterEach(() => jest.clearAllMocks());

--- a/packages/http/src/validator/validators/__tests__/headers.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/headers.spec.ts
@@ -3,7 +3,7 @@ import { query as registry } from '../../deserializers';
 import { HttpHeadersValidator } from '../headers';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as Option from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/lib/Option';
 
 describe('HttpHeadersValidator', () => {
   const httpHeadersValidator = new HttpHeadersValidator(registry, 'header');
@@ -49,7 +49,7 @@ describe('HttpHeadersValidator', () => {
                 ])
               );
 
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
             });
           });
 
@@ -66,7 +66,7 @@ describe('HttpHeadersValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
               });
             });
           });
@@ -83,7 +83,7 @@ describe('HttpHeadersValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/path.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/path.spec.ts
@@ -3,7 +3,7 @@ import { path as registry } from '../../deserializers';
 import { HttpPathValidator } from '../path';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
-import * as Option from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/lib/Option';
 
 describe('HttpPathValidator', () => {
   const httpPathValidator = new HttpPathValidator(registry, 'path');
@@ -47,7 +47,7 @@ describe('HttpPathValidator', () => {
               };
 
               assertRight(httpPathValidator.validate({ param: 'abc' }, [param]));
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
             });
           });
 
@@ -64,7 +64,7 @@ describe('HttpPathValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
               });
             });
           });
@@ -81,7 +81,7 @@ describe('HttpPathValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
           });
         });
 

--- a/packages/http/src/validator/validators/__tests__/query.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/query.spec.ts
@@ -3,7 +3,7 @@ import { query as registry } from '../../deserializers';
 import { HttpQueryValidator } from '../query';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as Option from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/lib/Option';
 
 describe('HttpQueryValidator', () => {
   const httpQueryValidator = new HttpQueryValidator(registry, 'query');
@@ -40,7 +40,7 @@ describe('HttpQueryValidator', () => {
 
               assertRight(httpQueryValidator.validate({ param: 'abc' }, [param]));
 
-              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+              expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
             });
           });
 
@@ -57,7 +57,7 @@ describe('HttpQueryValidator', () => {
                   ])
                 );
 
-                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+                expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
               });
             });
           });
@@ -74,7 +74,7 @@ describe('HttpQueryValidator', () => {
               ])
             );
 
-            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(Option.none);
+            expect(validateAgainstSchemaModule.validateAgainstSchema).toReturnWith(O.none);
           });
         });
 

--- a/packages/http/src/validator/validators/params.ts
+++ b/packages/http/src/validator/validators/params.ts
@@ -1,7 +1,7 @@
 import { DiagnosticSeverity, HttpParamStyles, IHttpParam } from '@stoplight/types';
 import { compact, keyBy, mapKeys, mapValues, pickBy, upperFirst } from 'lodash';
-import * as Either from 'fp-ts/lib/Either';
-import * as Option from 'fp-ts/lib/Option';
+import * as E from 'fp-ts/lib/Either';
+import * as O from 'fp-ts/lib/Option';
 import { fromArray } from 'fp-ts/lib/NonEmptyArray';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { JSONSchema4 } from 'json-schema';
@@ -57,11 +57,11 @@ export class HttpParamsValidator<Target> implements IHttpValidator<Target, IHttp
 
     return pipe(
       validateAgainstSchema(parameterValues, schema, prefix),
-      Option.map(schemaDiagnostic => schemaDiagnostic.concat(deprecatedWarnings)),
-      Option.chain(fromArray),
-      Option.alt(() => fromArray(deprecatedWarnings)),
-      Either.fromOption(() => target),
-      Either.swap
+      O.map(schemaDiagnostic => schemaDiagnostic.concat(deprecatedWarnings)),
+      O.chain(fromArray),
+      O.alt(() => fromArray(deprecatedWarnings)),
+      E.fromOption(() => target),
+      E.swap
     );
   }
 }

--- a/packages/http/src/validator/validators/security/index.ts
+++ b/packages/http/src/validator/validators/security/index.ts
@@ -1,6 +1,6 @@
 import { IHttpOperation, HttpSecurityScheme } from '@stoplight/types';
-import * as Either from 'fp-ts/lib/Either';
-import * as Option from 'fp-ts/lib/Option';
+import * as E from 'fp-ts/lib/Either';
+import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { flatten } from 'lodash';
 import { set } from 'lodash/fp';
@@ -12,7 +12,7 @@ import { IHttpRequest } from '../../../types';
 
 type HeadersAndUrl = Pick<IHttpRequest, 'headers' | 'url'>;
 
-const EitherValidation = Either.getValidation(getSemigroup<IPrismDiagnostic>());
+const EitherValidation = E.getValidation(getSemigroup<IPrismDiagnostic>());
 const eitherSequence = array.sequence(EitherValidation);
 
 function getValidationResults(securitySchemes: HttpSecurityScheme[][], input: HeadersAndUrl) {
@@ -30,8 +30,8 @@ function getAuthenticationArray(securitySchemes: HttpSecurityScheme[][], input: 
     const authResults = securitySchemePairs.map(securityScheme =>
       pipe(
         findSecurityHandler(securityScheme),
-        Either.chain(securityHandler => securityHandler(input, 'name' in securityScheme ? securityScheme.name : '')),
-        Either.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(e => [e])
+        E.chain(securityHandler => securityHandler(input, 'name' in securityScheme ? securityScheme.name : '')),
+        E.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(e => [e])
       )
     );
 
@@ -41,14 +41,14 @@ function getAuthenticationArray(securitySchemes: HttpSecurityScheme[][], input: 
 
 export const validateSecurity: ValidatorFn<Pick<IHttpOperation, 'security'>, HeadersAndUrl> = ({ element, resource }) =>
   pipe(
-    Option.fromNullable(resource.security),
-    Option.chain(Option.fromPredicate(isNonEmpty)),
-    Option.fold(
-      () => Either.right(element),
+    O.fromNullable(resource.security),
+    O.chain(O.fromPredicate(isNonEmpty)),
+    O.fold(
+      () => E.right(element),
       securitySchemes =>
         pipe(
           getValidationResults(securitySchemes, element),
-          Either.bimap(
+          E.bimap(
             e => [setErrorTag(e)],
             () => element
           )

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -2,7 +2,7 @@ import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { DiagnosticSeverity } from '@stoplight/types';
 import { getSemigroup, NonEmptyArray, fromArray, map } from 'fp-ts/lib/NonEmptyArray';
 import { getValidation } from 'fp-ts/lib/Either';
-import * as Option from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { sequenceT } from 'fp-ts/lib/Apply';
 import * as Ajv from 'ajv';
@@ -34,14 +34,14 @@ export const convertAjvErrors = (
 
 export const validateAgainstSchema = (value: unknown, schema: JSONSchema, prefix?: string) =>
   pipe(
-    Option.tryCatch(() => ajv.compile(schema)),
-    Option.mapNullable(validate => {
+    O.tryCatch(() => ajv.compile(schema)),
+    O.mapNullable(validate => {
       validate(value);
       return validate.errors;
     }),
-    Option.chain(fromArray),
-    Option.map(errors => convertAjvErrors(errors, DiagnosticSeverity.Error, prefix))
+    O.chain(fromArray),
+    O.map(errors => convertAjvErrors(errors, DiagnosticSeverity.Error, prefix))
   );
 
-export const sequenceOption = sequenceT(Option.option);
+export const sequenceOption = sequenceT(O.option);
 export const sequenceValidation = sequenceT(getValidation(getSemigroup<IPrismDiagnostic>()));


### PR DESCRIPTION
Let's use the same conventions that all the other projects using fp-ts are using.