### PR TITLE
fix: do not coerce types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+# 3.2.3 (2019-12-19)
+
 ## Fixed
 
 - Prism will not coerce JSON Payloads anymore during the schema validation [#905](https://github.com/stoplightio/prism/pull/905)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+## Fixed
+
+- Prism will not coerce JSON Payloads anymore during the schema validation [#905](https://github.com/stoplightio/prism/pull/905)
+
 # 3.2.2 (2019-12-13)
 
 ## Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "independent": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.2",
-    "@stoplight/prism-http-server": "^3.2.2",
+    "@stoplight/prism-core": "^3.2.3",
+    "@stoplight/prism-http-server": "^3.2.3",
     "chalk": "^3.0.0",
     "chokidar": "^3.2.1",
     "fp-ts": "^2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.2",
-    "@stoplight/prism-http": "^3.2.2",
+    "@stoplight/prism-core": "^3.2.3",
+    "@stoplight/prism-http": "^3.2.3",
     "fast-xml-parser": "^3.12.20",
     "fastify": "^2.7.1",
     "fastify-cors": "^3.0.0",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.1.2",
     "@stoplight/json-ref-readers": "^1.1.1",
     "@stoplight/json-ref-resolver": "^3.0.1",
-    "@stoplight/prism-core": "^3.2.2",
+    "@stoplight/prism-core": "^3.2.3",
     "@stoplight/yaml": "^3.0.2",
     "abstract-logging": "^2.0.0",
     "accepts": "^1.3.7",

--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -79,4 +79,21 @@ describe('validateAgainstSchema()', () => {
       );
     });
   });
+
+  describe('with coercing', () => {
+    it('will not return error for convertible values', () => {
+      assertNone(
+        validateAgainstSchema({ test: 10 }, { type: 'object', properties: { test: { type: 'string' } } }, true)
+      );
+    });
+  });
+
+  describe('with no coercing', () => {
+    it('will return error for convertible values', () => {
+      assertSome(
+        validateAgainstSchema({ test: 10 }, { type: 'object', properties: { test: { type: 'string' } } }, false),
+        error => expect(error).toContainEqual(expect.objectContaining({ message: 'should be string' }))
+      );
+    });
+  });
 });

--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -44,7 +44,7 @@ describe('validateAgainstSchema()', () => {
 
   describe('has no validation errors', () => {
     it('returns no validation errors', () => {
-      assertNone(validateAgainstSchema('test', { type: 'string' }, 'pfx'));
+      assertNone(validateAgainstSchema('test', { type: 'string' }, true, 'pfx'));
       expect(convertAjvErrorsModule.convertAjvErrors).not.toHaveBeenCalled();
     });
   });
@@ -60,7 +60,7 @@ describe('validateAgainstSchema()', () => {
           summary: 'should be number',
         },
       ]);
-      assertSome(validateAgainstSchema('test', { type: 'number' }, 'pfx'), error =>
+      assertSome(validateAgainstSchema('test', { type: 'number' }, true, 'pfx'), error =>
         expect(error).toContainEqual(expect.objectContaining({ message: 'should be number' }))
       );
 

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -73,7 +73,7 @@ function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, 
     E.map(decodedUriEntities => deserializeFormBody(schema, encodings, decodedUriEntities)),
     E.chain(deserialised =>
       pipe(
-        validateAgainstSchema(deserialised, schema),
+        validateAgainstSchema(deserialised, schema, true),
         E.fromOption(() => deserialised),
         E.swap
       )
@@ -108,7 +108,7 @@ export class HttpBodyValidator implements IHttpValidator<any, IMediaTypeContent>
             O.fold(
               () =>
                 pipe(
-                  validateAgainstSchema(target, schema),
+                  validateAgainstSchema(target, schema, false),
                   E.fromOption(() => target),
                   E.swap
                 ),

--- a/packages/http/src/validator/validators/params.ts
+++ b/packages/http/src/validator/validators/params.ts
@@ -57,7 +57,7 @@ export class HttpParamsValidator<Target> implements IHttpValidator<Target, IHttp
         );
         return { parameterValues, schema };
       }),
-      O.chain(({ parameterValues, schema }) => validateAgainstSchema(parameterValues, schema, prefix)),
+      O.chain(({ parameterValues, schema }) => validateAgainstSchema(parameterValues, schema, true, prefix)),
       O.map(schemaDiagnostic => schemaDiagnostic.concat(deprecatedWarnings)),
       O.chain(fromArray),
       O.alt(() => fromArray(deprecatedWarnings)),

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -10,7 +10,7 @@ import { JSONSchema } from '../../';
 import * as AjvOAI from 'ajv-oai';
 
 const ajv = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto' });
-const ajvCoerce = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto', coerceTypes: true });
+const ajvNoCoerce = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto', coerceTypes: false });
 
 export const convertAjvErrors = (
   errors: NonEmptyArray<Ajv.ErrorObject>,
@@ -35,7 +35,7 @@ export const convertAjvErrors = (
 
 export const validateAgainstSchema = (value: unknown, schema: JSONSchema, coerce: boolean, prefix?: string) =>
   pipe(
-    O.tryCatch(() => (coerce ? ajv : ajvCoerce).compile(schema)),
+    O.tryCatch(() => (coerce ? ajv : ajvNoCoerce).compile(schema)),
     O.chain(validateFn =>
       pipe(
         O.tryCatch(() => validateFn(value)),

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -9,7 +9,8 @@ import * as Ajv from 'ajv';
 import { JSONSchema } from '../../';
 import * as AjvOAI from 'ajv-oai';
 
-const ajv = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto', coerceTypes: false });
+const ajv = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto' });
+const ajvCoerce = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto', coerceTypes: true });
 
 export const convertAjvErrors = (
   errors: NonEmptyArray<Ajv.ErrorObject>,
@@ -32,9 +33,9 @@ export const convertAjvErrors = (
     })
   );
 
-export const validateAgainstSchema = (value: unknown, schema: JSONSchema, prefix?: string) =>
+export const validateAgainstSchema = (value: unknown, schema: JSONSchema, coerce: boolean, prefix?: string) =>
   pipe(
-    O.tryCatch(() => ajv.compile(schema)),
+    O.tryCatch(() => (coerce ? ajv : ajvCoerce).compile(schema)),
     O.chain(validateFn =>
       pipe(
         O.tryCatch(() => validateFn(value)),


### PR DESCRIPTION
1. Correctly catch exception in the rare case the validation fails
2. Do not coerce the payload during the validation in case we're treating JSON stuff since the JSON parser of V8 will keep the types
3. Do not create JSON Schemas in case there are no properties in the params
4. Add tests


Closes #894 