### PR TITLE
Use type-is for content type comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - Prism's proxy will now strip all the Hop By Hop headers [#921](https://github.com/stoplightio/prism/pull/921)
+- Prism is now normalising the media types so that when looking for compatible contents charsets and other parameters are not taken in consideration [#944](https://github.com/stoplightio/prism/pull/944)
 
 # 3.2.3 (2019-12-19)
 

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -24,7 +24,7 @@ export function hasContents(v: IHttpOperationResponse): v is PickRequired<IHttpO
 
 export function findBestHttpContentByMediaType(
   response: PickRequired<IHttpOperationResponse, 'contents'>,
-  mediaType: string[],
+  mediaType: string[]
 ): Option<IMediaTypeContent> {
   const bestType = accepts({
     headers: {
@@ -34,59 +34,56 @@ export function findBestHttpContentByMediaType(
 
   return pipe(
     response.contents,
-    findFirst(content => content.mediaType === bestType),
+    findFirst(content => content.mediaType === bestType)
   );
 }
 
 export function findDefaultContentType(
-  response: PickRequired<IHttpOperationResponse, 'contents'>,
+  response: PickRequired<IHttpOperationResponse, 'contents'>
 ): Option<IMediaTypeContent> {
   return pipe(
     response.contents,
-    findFirst(content => content.mediaType === '*/*'),
+    findFirst(content => content.mediaType === '*/*')
   );
 }
 
 const byResponseCode = ord.contramap<number, IHttpOperationResponse>(ordNumber, response => parseInt(response.code));
 
-export function findLowest2xx(httpResponses: IHttpOperationResponse[]): Option<IHttpOperationResponse> {
+export function findLowest2xx(httpResponses: NonEmptyArray<IHttpOperationResponse>): Option<IHttpOperationResponse> {
   const generic2xxResponse = () =>
     pipe(
       findResponseByStatusCode(httpResponses, '2XX'),
-      alt(() => createResponseFromDefault(httpResponses, '200')),
+      alt(() => createResponseFromDefault(httpResponses, '200'))
     );
 
   const first2xxResponse = pipe(
     httpResponses,
     filter(response => /2\d\d/.test(response.code)),
     sort(byResponseCode),
-    head,
+    head
   );
 
-  return pipe(
-    first2xxResponse,
-    alt(generic2xxResponse),
-  );
+  return pipe(first2xxResponse, alt(generic2xxResponse));
 }
 
 export function findResponseByStatusCode(
-  responses: IHttpOperationResponse[],
-  statusCode: string,
+  responses: NonEmptyArray<IHttpOperationResponse>,
+  statusCode: string
 ): Option<IHttpOperationResponse> {
   return pipe(
     responses,
-    findFirst(response => response.code.toLowerCase() === statusCode.toLowerCase()),
+    findFirst(response => response.code.toLowerCase() === statusCode.toLowerCase())
   );
 }
 
 export function createResponseFromDefault(
-  responses: IHttpOperationResponse[],
-  statusCode: string,
+  responses: NonEmptyArray<IHttpOperationResponse>,
+  statusCode: string
 ): Option<IHttpOperationResponse> {
   return pipe(
     responses,
     findFirst(response => response.code === 'default'),
-    map(response => Object.assign({}, response, { code: statusCode })),
+    map(response => Object.assign({}, response, { code: statusCode }))
   );
 }
 

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -278,7 +278,7 @@ const helpers = {
   },
 
   findResponse(
-    httpResponses: IHttpOperationResponse[],
+    httpResponses: NonEmptyArray<IHttpOperationResponse>,
     statusCodes: NonEmptyArray<string>
   ): R.Reader<Logger, O.Option<IHttpOperationResponse>> {
     const [first, ...others] = statusCodes;
@@ -320,7 +320,7 @@ const helpers = {
   },
 
   negotiateOptionsForInvalidRequest(
-    httpResponses: IHttpOperationResponse[],
+    httpResponses: NonEmptyArray<IHttpOperationResponse>,
     statusCodes: NonEmptyArray<string>
   ): RE.ReaderEither<Logger, Error, IHttpNegotiationResult> {
     return pipe(

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -12,6 +12,7 @@ import { left, right } from 'fp-ts/lib/ReaderEither';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import helpers from '../NegotiatorHelpers';
 import { IHttpNegotiationResult, NegotiationOptions } from '../types';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 
 const chance = new Chance();
 const logger = createLogger('TEST', { enabled: false });
@@ -39,7 +40,7 @@ function anHttpOperation(givenHttpOperation?: IHttpOperation) {
     instance() {
       return httpOperation;
     },
-    withResponses(responses: IHttpOperationResponse[] & { 0: IHttpOperationResponse }) {
+    withResponses(responses: NonEmptyArray<IHttpOperationResponse>) {
       httpOperation.responses = responses;
       return this;
     },

--- a/packages/http/src/validator/utils/spec.ts
+++ b/packages/http/src/validator/utils/spec.ts
@@ -1,7 +1,6 @@
 import { IHttpOperationResponse } from '@stoplight/types';
 import { head } from 'fp-ts/lib/Array';
 import { Option } from 'fp-ts/lib/Option';
-import { pipe } from 'fp-ts/lib/pipeable';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 
 export function findOperationResponse(
@@ -24,5 +23,5 @@ export function findOperationResponse(
       return s1.code.split('X').length - s2.code.split('X').length;
     });
 
-  return pipe(sortedSpecs, head);
+  return head(sortedSpecs);
 }

--- a/packages/http/src/validator/utils/spec.ts
+++ b/packages/http/src/validator/utils/spec.ts
@@ -2,14 +2,15 @@ import { IHttpOperationResponse } from '@stoplight/types';
 import { head } from 'fp-ts/lib/Array';
 import { Option } from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
+import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 
 export function findOperationResponse(
-  responseSpecs: IHttpOperationResponse[],
-  statusCode: number,
+  responseSpecs: NonEmptyArray<IHttpOperationResponse>,
+  statusCode: number
 ): Option<IHttpOperationResponse> {
   const sortedSpecs = responseSpecs
     .filter(
-      spec => new RegExp(`^${spec.code.replace(/X/g, '\\d')}$`).test(String(statusCode)) || spec.code === 'default',
+      spec => new RegExp(`^${spec.code.replace(/X/g, '\\d')}$`).test(String(statusCode)) || spec.code === 'default'
     )
     .sort((s1, s2) => {
       if (s1.code === 'default') {
@@ -23,8 +24,5 @@ export function findOperationResponse(
       return s1.code.split('X').length - s2.code.split('X').length;
     });
 
-  return pipe(
-    sortedSpecs,
-    head,
-  );
+  return pipe(sortedSpecs, head);
 }

--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -1,7 +1,7 @@
-import { HttpParamStyles } from '@stoplight/types';
+import { HttpParamStyles, IMediaTypeContent } from '@stoplight/types';
 import { JSONSchema } from '../../..';
-import { HttpBodyValidator } from '../body';
-import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
+import { HttpBodyValidator, findContentByMediaTypeOrFirst } from '../body';
+import { assertRight, assertLeft, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 
 describe('HttpBodyValidator', () => {
   const httpBodyValidator = new HttpBodyValidator('body');
@@ -113,6 +113,23 @@ describe('HttpBodyValidator', () => {
               })
             )
         );
+      });
+    });
+  });
+
+  describe('findContentByMediaTypeOrFirst()', () => {
+    describe('when a spec has a content type', () => {
+      const content: IMediaTypeContent = {
+        mediaType: 'application/x-www-form-urlencoded',
+      };
+
+      describe('and I request for the content type with the charset', () => {
+        const foundContent = findContentByMediaTypeOrFirst(
+          [content],
+          'application/x-www-form-urlencoded; charset=UTF-8'
+        );
+
+        it('should return the generic content', () => assertSome(foundContent));
       });
     });
   });

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -9,6 +9,7 @@ import { JSONSchema } from '../../types';
 import { body } from '../deserializers';
 import { IHttpValidator } from './types';
 import { validateAgainstSchema } from './utils';
+import { is } from 'type-is';
 import * as NonEmptyArray from 'fp-ts/lib/NonEmptyArray';
 
 export function deserializeFormBody(
@@ -57,7 +58,7 @@ export function decodeUriEntities(target: Dictionary<string>) {
 export function findContentByMediaTypeOrFirst(specs: IMediaTypeContent[], mediaType: string) {
   return pipe(
     specs,
-    Array.findFirst(spec => spec.mediaType === mediaType),
+    Array.findFirst(spec => !!is(mediaType, [spec.mediaType])),
     O.alt(() => Array.head(specs)),
     O.map(content => ({ mediaType, content }))
   );
@@ -104,7 +105,7 @@ export class HttpBodyValidator implements IHttpValidator<any, IMediaTypeContent>
         ({ content, mediaType: mt, schema }) =>
           pipe(
             mt,
-            O.fromPredicate(mediaType => mediaType === 'application/x-www-form-urlencoded'),
+            O.fromPredicate(mediaType => !!is(mediaType, ['application/x-www-form-urlencoded'])),
             O.fold(
               () =>
                 pipe(


### PR DESCRIPTION
This PR will replace different checks we were doing in places to look for content so that instead of using regular string comparison we use the type-is library which will normalise content types with charset and so on

Closes #943 