### PR TITLE
fix: http client logger creation

### DIFF
--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -12,4 +12,4 @@ jobs:
     - uses: actions/checkout@master
       with:
         fetch-depth: 1
-    - uses: gaurav-nelson/github-action-markdown-link-check@0.4.0
+    - uses: planetscale/github-action-markdown-link-check@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Prism's proxy will now strip all the Hop By Hop headers [#921](https://github.com/stoplightio/prism/pull/921)
 - Prism is now normalising the media types so that when looking for compatible contents charsets and other parameters are not taken in consideration [#944](https://github.com/stoplightio/prism/pull/944)
+- Prims's external HTTP Client is now correctly costructing the internal log object [#952](https://github.com/stoplightio/prism/pull/952)
 
 # 3.2.3 (2019-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Prism's proxy will now strip all the Hop By Hop headers [#921](https://github.com/stoplightio/prism/pull/921)
 - Prism is now normalising the media types so that when looking for compatible contents charsets and other parameters are not taken in consideration [#944](https://github.com/stoplightio/prism/pull/944)
-- Prims's external HTTP Client is now correctly costructing the internal log object [#952](https://github.com/stoplightio/prism/pull/952)
+- Prism's external HTTP Client is now correctly constructing the internal log object [#952](https://github.com/stoplightio/prism/pull/952)
 
 # 3.2.3 (2019-12-19)
 

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -28,9 +28,13 @@ const createClientFromResource = partial(createClientFrom, getHttpOperationsFrom
 const createClientFromString = partial(createClientFrom, getHttpOperations);
 
 function createClientFromOperations(resources: IHttpOperation[], defaultConfig: IClientConfig): PrismHttp {
-  const lg = { ...logger, child: () => lg, success: logger.info, trace: logger.info };
+  Object.defineProperties(logger, {
+    child: { get: () => logger, writable: false },
+    success: { get: () => logger.info, writable: false },
+    trace: { get: () => logger.info, writable: false },
+  });
 
-  const obj = createInstance(defaultConfig, { logger: lg });
+  const obj = createInstance(defaultConfig, { logger });
 
   type headersFromRequest = Required<Pick<IHttpRequest, 'headers'>>;
 

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -29,9 +29,9 @@ const createClientFromString = partial(createClientFrom, getHttpOperations);
 
 function createClientFromOperations(resources: IHttpOperation[], defaultConfig: IClientConfig): PrismHttp {
   Object.defineProperties(logger, {
-    child: { get: () => logger, writable: false },
-    success: { get: () => logger.info, writable: false },
-    trace: { get: () => logger.info, writable: false },
+    child: { get: () => logger },
+    success: { get: () => logger.info },
+    trace: { get: () => logger.info },
   });
 
   const obj = createInstance(defaultConfig, { logger });

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -24,16 +24,16 @@ function createClientFrom(
   return getResource(document).then(resources => createClientFromOperations(resources, defaultConfig));
 }
 
+Object.defineProperties(logger, {
+  child: { get: () => () => logger },
+  success: { get: () => logger.info },
+  trace: { get: () => logger.info },
+});
+
 const createClientFromResource = partial(createClientFrom, getHttpOperationsFromResource);
 const createClientFromString = partial(createClientFrom, getHttpOperations);
 
 function createClientFromOperations(resources: IHttpOperation[], defaultConfig: IClientConfig): PrismHttp {
-  Object.defineProperties(logger, {
-    child: { get: () => logger },
-    success: { get: () => logger.info },
-    trace: { get: () => logger.info },
-  });
-
   const obj = createInstance(defaultConfig, { logger });
 
   type headersFromRequest = Required<Pick<IHttpRequest, 'headers'>>;


### PR DESCRIPTION
* Changes the markdown link checker that was just broken and reporting errors anytime
* Changes the way the internal logger is constructed so it does not crash anymore — this is required for Request Maker. Will trigger a release when this gets merged.

This is not idea, in the future I will make sure the logger is passed by the caller of the client, but this at least fixes the situation introduces with abstract-logger 2.x