### PR TITLE
Add Access-Control-Expose-Headers for prism mock server

### DIFF
--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -150,6 +150,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
           res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] || '*');
           res.setHeader('Access-Control-Allow-Credentials', 'true');
           res.setHeader('Access-Control-Allow-Methods', 'GET,DELETE,HEAD,PATCH,POST,PUT');
+          res.setHeader('Access-Control-Expose-Headers', req.headers['access-control-request-headers'] || '*');
           res.setHeader('Vary', 'origin');
           res.setHeader('Content-Length', '0');
           send(res, 204);
@@ -159,6 +160,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         if (opts.cors) {
           res.setHeader('Access-Control-Allow-Origin', req.headers['origin'] || '*');
           res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] || '*');
+          res.setHeader('Access-Control-Expose-Headers', req.headers['access-control-request-headers'] || '*');
         }
         return handler(req, res, options);
       })

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -150,7 +150,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
           res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] || '*');
           res.setHeader('Access-Control-Allow-Credentials', 'true');
           res.setHeader('Access-Control-Allow-Methods', 'GET,DELETE,HEAD,PATCH,POST,PUT');
-          res.setHeader('Access-Control-Expose-Headers', req.headers['access-control-request-headers'] || '*');
+          res.setHeader('Access-Control-Expose-Headers', req.headers['access-control-expose-headers'] || '*');
           res.setHeader('Vary', 'origin');
           res.setHeader('Content-Length', '0');
           send(res, 204);
@@ -160,7 +160,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         if (opts.cors) {
           res.setHeader('Access-Control-Allow-Origin', req.headers['origin'] || '*');
           res.setHeader('Access-Control-Allow-Headers', req.headers['access-control-request-headers'] || '*');
-          res.setHeader('Access-Control-Expose-Headers', req.headers['access-control-request-headers'] || '*');
+          res.setHeader('Access-Control-Expose-Headers', req.headers['access-control-expose-headers'] || '*');
         }
         return handler(req, res, options);
       })


### PR DESCRIPTION
## Checklist

- [x] Tests have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## What kind of change does this PR introduce?

Feature

## What is the current behavior? What is the new behavior?
### current
When using axios and this prism mock server(with --cors and -d options), this prism mock server can't add response various headers.

### new
this prism mock server can add various headers.

## Does this PR introduce a breaking change?

No
