### PR TITLE
Client fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  stoplight: stoplight/cli@0.0.2
 executors:
   docker-node:
     docker:
@@ -143,11 +141,3 @@ workflows:
               only: /^v.*/
           requires:
             - publish
-      - stoplight/analyze:
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-          requires:
-            - upload_artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+# 3.2.6 (2020-02-03)
+
+## Fixed
+
+- Correctly set `access-control-expose-headers` headers for preflight and regular responses when CORS is enabled [#958](https://github.com/stoplightio/prism/pull/958)
+- Prism public HTTP Client fixes and docs improvements [#959](https://github.com/stoplightio/prism/pull/959)
+
 # 3.2.5 (2020-01-30)
 
 ## Fixed

--- a/docs/guides/http-client.md
+++ b/docs/guides/http-client.md
@@ -81,3 +81,15 @@ For the shortcut methods (since the only mandatory option is intrinsic in the fu
 ```ts
 client.get('https://google.it', { validateRequest: false }).then(response => console.log(response));
 ```
+
+You can also use relative links when doing requests. In such case you won't be able to use the proxy and the server validation will be disabled:
+
+```ts
+client.get('/users/10', { validateRequest: false }).then(response => console.log(response));
+```
+
+…or you can also set the base path in the options object:
+
+```ts
+client.get('/users/10', { baseUrl: 'https://api.stoplight.io/' }).then(response => console.log(response));
+```

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.2.5",
+  "version": "3.2.6",
   "independent": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.5",
-    "@stoplight/prism-http-server": "^3.2.5",
+    "@stoplight/prism-core": "^3.2.6",
+    "@stoplight/prism-http-server": "^3.2.6",
     "chalk": "^3.0.0",
     "chokidar": "^3.2.1",
     "fp-ts": "^2.1.1",

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -81,7 +81,6 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     cors: options.cors,
     config,
     components: { logger: logInstance.child({ name: 'HTTP SERVER' }) },
-    errors: options.errors,
   });
 
   const address = await server.listen(options.port, options.host);

--- a/packages/cli/src/util/runner.ts
+++ b/packages/cli/src/util/runner.ts
@@ -4,7 +4,7 @@ import * as chokidar from 'chokidar';
 import * as os from 'os';
 import { CreateMockServerOptions } from './createServer';
 
-type CreatePrism = (options: CreateMockServerOptions) => Promise<IPrismHttpServer | void>;
+export type CreatePrism = (options: CreateMockServerOptions) => Promise<IPrismHttpServer | void>;
 
 export function runPrismAndSetupWatcher(createPrism: CreatePrism, options: CreateMockServerOptions) {
   return createPrism(options).then(possiblyServer => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,7 +68,6 @@ export class ProblemJsonError extends Error {
       template.status,
       detail || ''
     );
-    Error.captureStackTrace(error, ProblemJsonError);
 
     return error;
   }
@@ -84,6 +83,5 @@ export class ProblemJsonError extends Error {
 
   constructor(readonly name: string, readonly message: string, readonly status: number, readonly detail: string) {
     super(message);
-    Error.captureStackTrace(this, ProblemJsonError);
   }
 }

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.5",
-    "@stoplight/prism-http": "^3.2.5",
+    "@stoplight/prism-core": "^3.2.6",
+    "@stoplight/prism-http": "^3.2.6",
     "fast-xml-parser": "^3.12.20",
     "fp-ts": "^2.1.1",
     "micri": "^2.0.1",

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -17,7 +17,6 @@ async function instantiatePrism(operations: IHttpOperation[]) {
       mock: { dynamic: false },
       errors: false,
     },
-    errors: false,
   });
 
   // be careful with selecting the port: it can't be the same in different suite because test suites run in parallel

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -27,7 +27,6 @@ async function instantiatePrism(specPath: string) {
       errors: false,
       mock: { dynamic: false },
     },
-    errors: false,
     cors: true,
   });
 

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -90,7 +90,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
             v => v.severity === DiagnosticSeverity[DiagnosticSeverity.Error]
           );
 
-          if (opts.errors && errorViolations.length > 0) {
+          if (opts.config.errors && errorViolations.length > 0) {
             return TE.left(
               ProblemJsonError.fromTemplate(
                 VIOLATIONS,

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -6,7 +6,6 @@ export interface IPrismHttpServerOpts {
   components: PickRequired<Partial<PrismHttpComponents>, 'logger'>;
   config: IHttpConfig;
   cors: boolean;
-  errors: boolean;
 }
 
 export interface IPrismHttpServer {
@@ -16,6 +15,4 @@ export interface IPrismHttpServer {
   listen: (port: number, address?: string, backlog?: number) => Promise<string>;
 }
 
-export type ThenArg<T> = T extends Promise<infer U> ? U :
-  T extends ((...args: any[]) => Promise<infer U>) ? U :
-    T;
+export type ThenArg<T> = T extends Promise<infer U> ? U : T extends (...args: any[]) => Promise<infer U> ? U : never;

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.1.2",
     "@stoplight/json-ref-readers": "^1.1.1",
     "@stoplight/json-ref-resolver": "^3.0.1",
-    "@stoplight/prism-core": "^3.2.5",
+    "@stoplight/prism-core": "^3.2.6",
     "@stoplight/yaml": "^3.0.2",
     "abstract-logging": "^2.0.0",
     "accepts": "^1.3.7",

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -1,4 +1,4 @@
-import { IPrismOutput, createLogger } from '@stoplight/prism-core';
+import { IPrismOutput } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 import { defaults, partial } from 'lodash';
 import { parse as parseQueryString } from 'querystring';
@@ -9,8 +9,9 @@ import { IHttpConfig, IHttpRequest, IHttpResponse, IHttpUrl } from './types';
 import { fold } from 'fp-ts/lib/TaskEither';
 import * as Task from 'fp-ts/lib/Task';
 import { pipe } from 'fp-ts/lib/pipeable';
+import * as pino from 'pino';
 
-const logger = createLogger('Prism-Internal');
+const logger = pino();
 logger.success = logger.info;
 
 interface IClientConfig extends IHttpConfig {

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -1,4 +1,4 @@
-import { IPrismOutput } from '@stoplight/prism-core';
+import { IPrismOutput, createLogger } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 // @ts-ignore
 import * as logger from 'abstract-logging';
@@ -12,6 +12,9 @@ import { fold } from 'fp-ts/lib/TaskEither';
 import * as Task from 'fp-ts/lib/Task';
 import { pipe } from 'fp-ts/lib/pipeable';
 
+const logger = createLogger('Prism-Internal');
+logger.success = logger.info;
+
 interface IClientConfig extends IHttpConfig {
   baseUrl?: string;
 }
@@ -23,12 +26,6 @@ function createClientFrom(
 ): Promise<PrismHttp> {
   return getResource(document).then(resources => createClientFromOperations(resources, defaultConfig));
 }
-
-Object.defineProperties(logger, {
-  child: { get: () => () => logger },
-  success: { get: () => logger.info },
-  trace: { get: () => logger.info },
-});
 
 const createClientFromResource = partial(createClientFrom, getHttpOperationsFromResource);
 const createClientFromString = partial(createClientFrom, getHttpOperations);

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -1,7 +1,5 @@
 import { IPrismOutput, createLogger } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
-// @ts-ignore
-import * as logger from 'abstract-logging';
 import { defaults, partial } from 'lodash';
 import { parse as parseQueryString } from 'querystring';
 import { parse as parseUrl } from 'url';

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -16,7 +16,6 @@ export interface IHttpOperationConfig {
 
 export interface IHttpConfig extends IPrismConfig {
   mock: false | IHttpOperationConfig;
-  errors: boolean;
 }
 
 export interface IHttpProxyConfig extends IHttpConfig {

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -16,6 +16,7 @@ export interface IHttpOperationConfig {
 
 export interface IHttpConfig extends IPrismConfig {
   mock: false | IHttpOperationConfig;
+  errors: boolean;
 }
 
 export interface IHttpProxyConfig extends IHttpConfig {


### PR DESCRIPTION
* Adds documentation on partial urls
* Types the `CreatePrism` instances for a faster find next time I'll need to refactor them
* Moves the `errors` option (it was listed twice!) from the wrong place
* Small changes in the internal logging creation
* Removes `Error.captureStackTrace(this, ProblemJsonError);` — that function is V8 specific and does not work in other browsers