### PR TITLE
refactor: remove double error definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+# 3.2.7 (2020-02-06)
+
+## Fixed
+
+- Removed double definition of the `ProblemJsonError` [#965](https://github.com/stoplightio/prism/pull/965)
+
 # 3.2.6 (2020-02-03)
 
 ## Fixed

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.2.6",
+  "version": "3.2.7",
   "independent": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.6",
-    "@stoplight/prism-http-server": "^3.2.6",
+    "@stoplight/prism-core": "^3.2.7",
+    "@stoplight/prism-http-server": "^3.2.7",
     "chalk": "^3.0.0",
     "chokidar": "^3.2.1",
     "fp-ts": "^2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,36 +52,3 @@ export interface IPrismOutput<O> {
     output: IPrismDiagnostic[];
   };
 }
-
-export type ProblemJson = {
-  type: string;
-  title: string;
-  status: number;
-  detail: string;
-};
-
-export class ProblemJsonError extends Error {
-  public static fromTemplate(template: Omit<ProblemJson, 'detail'>, detail?: string): ProblemJsonError {
-    const error = new ProblemJsonError(
-      `https://stoplight.io/prism/errors#${template.type}`,
-      template.title,
-      template.status,
-      detail || ''
-    );
-
-    return error;
-  }
-
-  public static fromPlainError(error: Error & { detail?: string; status?: number }): ProblemJson {
-    return {
-      type: error.name && error.name !== 'Error' ? error.name : 'https://stoplight.io/prism/errors#UNKNOWN',
-      title: error.message,
-      status: error.status || 500,
-      detail: error.detail || '',
-    };
-  }
-
-  constructor(readonly name: string, readonly message: string, readonly status: number, readonly detail: string) {
-    super(message);
-  }
-}

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.2.6",
-    "@stoplight/prism-http": "^3.2.6",
+    "@stoplight/prism-core": "^3.2.7",
+    "@stoplight/prism-http": "^3.2.7",
     "fast-xml-parser": "^3.12.20",
     "fp-ts": "^2.1.1",
     "micri": "^2.0.1",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.1.2",
     "@stoplight/json-ref-readers": "^1.1.1",
     "@stoplight/json-ref-resolver": "^3.0.1",
-    "@stoplight/prism-core": "^3.2.6",
+    "@stoplight/prism-core": "^3.2.7",
     "@stoplight/yaml": "^3.0.2",
     "abstract-logging": "^2.0.0",
     "accepts": "^1.3.7",

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -1,9 +1,7 @@
-import { ProblemJsonError } from '@stoplight/prism-core';
-import { IHttpOperation, IHttpOperationResponse, IMediaTypeContent } from '@stoplight/types';
-import { IHttpHeaderParam } from '@stoplight/types';
+import { IHttpOperation, IHttpOperationResponse, IMediaTypeContent, IHttpHeaderParam } from '@stoplight/types';
 import * as E from 'fp-ts/lib/Either';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
-import { isEmpty, findIndex } from 'fp-ts/lib/Array';
+import { findIndex } from 'fp-ts/lib/Array';
 import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as R from 'fp-ts/lib/Reader';
@@ -24,6 +22,7 @@ import {
   hasContents,
 } from './InternalHelpers';
 import { IHttpNegotiationResult, NegotiatePartialOptions, NegotiationOptions } from './types';
+import { ProblemJsonError } from '../../types';
 
 const outputNoContentFoundMessage = (contentTypes: string[]) => `Unable to find content for ${contentTypes}`;
 

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -52,7 +52,7 @@ export type ProblemJson = {
   type: string;
   title: string;
   status: number;
-  detail: unknown;
+  detail: string;
 };
 
 export class ProblemJsonError extends Error {
@@ -68,7 +68,6 @@ export class ProblemJsonError extends Error {
       detail || '',
       additional
     );
-    Error.captureStackTrace(error, ProblemJsonError);
 
     return error;
   }


### PR DESCRIPTION
I figured that we have defined the error class twice, for no reason. This PR removes the duplicate.