### PR TITLE
Fix "Cannot write file ... because it would overwrite..." errors

### DIFF
--- a/packages/tsconfig.build.json
+++ b/packages/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["**/__tests__"],
+  "exclude": ["**/__tests__", "*/dist"],
   "include": [],
   "extends": "./tsconfig.json",
   "references": [


### PR DESCRIPTION
`yarn build` would fail after the first invocation, because it tries to compile the - already existing - output files as well.

Fixed that by explicitly excluding the _dist_ folders from the typescript build.