### PR TITLE
Fix: check server presence correctly in disambiguiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+## Fixed
+
+- Correctly evaluate the `ServerMatch` property so that Prism will prefer concrete matches over templated ones [#983](https://github.com/stoplightio/prism/pull/983)
+
 # 3.2.8 (2020-02-11)
 
 ## Fixed

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -459,7 +459,7 @@ describe('http router', () => {
           );
         });
 
-        test('given two methods, no baseUrl and a matching path and method it should match by path', () => {
+        test('given two methods, no baseUrl, a matching path and method it should match by path', () => {
           const path = randomPath({ includeTemplates: false });
           const alternativeMethod = pickOneHttpMethod();
 
@@ -477,6 +477,28 @@ describe('http router', () => {
             }),
             resource => expect(resource).toBe(resources[1])
           );
+        });
+
+        describe('given a concrete and a templated path', () => {
+          const path = '/test/fixed';
+          const templatedPath = '/test/{userId}';
+
+          const resources = [createResource(method, templatedPath, []), createResource(method, path, [])];
+
+          it('should prefer the concrete path when the concrete is asked', () => {
+            assertRight(
+              route({
+                resources,
+                input: {
+                  method,
+                  url: {
+                    path: path,
+                  },
+                },
+              }),
+              resource => expect(resource).toBe(resources[1])
+            );
+          });
         });
       });
 

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -162,7 +162,7 @@ function disambiguateMatches(matches: IMatch[]): IHttpOperation {
 
 function areServerAndPath(match: IMatch, serverType: MatchType, pathType: MatchType) {
   const serverMatch = match.serverMatch;
-  if (serverMatch === null) {
+  if (!serverMatch) {
     // server match will only be null if server matching is disabled.
     // therefore skip comparison.
     return match.pathMatch === pathType;

--- a/test-harness/specs/routing/prefer-concrete-path.oas3.txt
+++ b/test-harness/specs/routing/prefer-concrete-path.oas3.txt
@@ -26,6 +26,6 @@ mock -p 4010 ${document}
 curl -i -X GET http://localhost:4010/test/fixed
 ====expect====
 HTTP/1.1 200 OK
-content-type: text/plain
+content-type: application/json
 
 0

--- a/test-harness/specs/routing/prefer-concrete-path.oas3.txt
+++ b/test-harness/specs/routing/prefer-concrete-path.oas3.txt
@@ -1,0 +1,31 @@
+====test====
+When a path has multiple matches it selects the concrete first
+====spec====
+openapi: 3.0.0
+paths:
+  /test/{id}:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: string
+  /test/fixed:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: number
+
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -X GET http://localhost:4010/test/fixed
+====expect====
+HTTP/1.1 200 OK
+content-type: text/plain
+
+0


### PR DESCRIPTION
Closes #981 

ServerMatch is `undefined`, not null.