### PR TITLE
fix: returning actual body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - Correctly evaluate the `ServerMatch` property so that Prism will prefer concrete matches over templated ones [#983](https://github.com/stoplightio/prism/pull/983)
+- HTTP Client now correctly return empty bodies [#993](https://github.com/stoplightio/prism/pull/993)
 
 # 3.2.8 (2020-02-11)
 

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -62,7 +62,7 @@ function createClientFromOperations(resources: IHttpOperation[], defaultConfig: 
             Task.of({
               status: data.output.statusCode,
               headers: data.output.headers || {},
-              data: data.output.body || {},
+              data: data.output.body,
               config: mergedConf,
               request: { ...input, url: httpUrl },
               violations: data.validations,


### PR DESCRIPTION
Prism's http-client is no longer returning `{}` when the body is empty.