### PR TITLE
fix: docker image restore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,8 @@
 **/__tests__
 **/test-harness
 **/.tsbuildinfo
+**/.git
+install
+jest.*
+*.md
+azure-pipelines.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,19 @@ FROM node:12 as dependencies
 WORKDIR /usr/src/prism/
 
 COPY package.json /usr/src/prism/
+RUN mkdir -p /usr/src/prism/node_modules
+
 COPY packages/core/package.json /usr/src/prism/packages/core/
+RUN mkdir -p /usr/src/prism/packages/core/node_modules
+
 COPY packages/http/package.json /usr/src/prism/packages/http/
-COPY packages/http-server/package.json /usr/src/prism/packages/http-server
+RUN mkdir -p /usr/src/prism/packages/http/node_modules
+
+COPY packages/http-server/package.json /usr/src/prism/packages/http-server/
+RUN mkdir -p /usr/src/prism/packages/http-server/node_modules
+
 COPY packages/cli/package.json /usr/src/prism/packages/cli/
+RUN mkdir -p /usr/src/prism/packages/cli/node_modules
 
 ENV NODE_ENV production
 RUN yarn --production
@@ -45,6 +54,7 @@ COPY --from=compiler /usr/src/prism/packages/cli/dist /usr/src/prism/packages/cl
 COPY --from=dependencies /usr/src/prism/node_modules/ /usr/src/prism/node_modules/
 COPY --from=dependencies /usr/src/prism/packages/core/node_modules/ /usr/src/prism/packages/core/node_modules/
 COPY --from=dependencies /usr/src/prism/packages/http/node_modules/ /usr/src/prism/packages/http/node_modules/
+COPY --from=dependencies /usr/src/prism/packages/http-server/node_modules/ /usr/src/prism/packages/http-server/node_modules/
 COPY --from=dependencies /usr/src/prism/packages/cli/node_modules/ /usr/src/prism/packages/cli/node_modules/
 
 WORKDIR /usr/src/prism/packages/cli/


### PR DESCRIPTION
This pull request will modify the docker ignore file to remove some of the stuff we do not need to build the docker image for Prism, moving the context from 16Mb to 1Mb.

This is a byproduct of a more important bug that I fixed here — yarn, when used in workspace mode, will always try to hoist everything in the main `node_modules` directory — which is great.

The problem is that Dockerfile's copy for the children `node_modules`, in such case, might fail (because the hoisting has changed the game).

This PR makes sure that in the dev image a `node_modules` directory is always present — so that the copy will never fail.

On a different topic, I think the requirements for our docker images have changed a bit and most likely we can find a better way to organize this. Not now though.