### PR TITLE
refactor: no await for assertResolvesLeft

### DIFF
--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -66,8 +66,8 @@ describe('Http Client .request', () => {
     });
 
     describe('baseUrl not set', () => {
-      it('ignores server validation and returns 200', async () => {
-        await assertResolvesRight(
+      it('ignores server validation and returns 200', () =>
+        assertResolvesRight(
           prism.request(
             {
               method: 'get',
@@ -81,13 +81,12 @@ describe('Http Client .request', () => {
             expect(result.output).toBeDefined();
             expect(result.output.statusCode).toBe(200);
           }
-        );
-      });
+        ));
     });
 
     describe('valid baseUrl set', () => {
-      it('validates server and returns 200', async () => {
-        await assertResolvesRight(
+      it('validates server and returns 200', () =>
+        assertResolvesRight(
           prism.request(
             {
               method: 'get',
@@ -102,13 +101,12 @@ describe('Http Client .request', () => {
             expect(result.output).toBeDefined();
             expect(result.output.statusCode).toBe(200);
           }
-        );
-      });
+        ));
     });
 
     describe('invalid host of baseUrl set', () => {
-      it('resolves with an error', async () => {
-        await assertResolvesLeft(
+      it('resolves with an error', () =>
+        assertResolvesLeft(
           prism.request(
             {
               method: 'get',
@@ -120,13 +118,12 @@ describe('Http Client .request', () => {
             resources
           ),
           e => expect(e).toMatchObject(ProblemJsonError.fromTemplate(NO_SERVER_MATCHED_ERROR))
-        );
-      });
+        ));
     });
 
     describe('invalid host and basePath of baseUrl set', () => {
-      it('resolves with an error', async () => {
-        await assertResolvesLeft(
+      it('resolves with an error', () =>
+        assertResolvesLeft(
           prism.request(
             {
               method: 'get',
@@ -138,8 +135,7 @@ describe('Http Client .request', () => {
             resources
           ),
           e => expect(e).toMatchObject(ProblemJsonError.fromTemplate(NO_SERVER_MATCHED_ERROR))
-        );
-      });
+        ));
     });
 
     describe('mocking is off', () => {
@@ -178,7 +174,7 @@ describe('Http Client .request', () => {
 
           it(testText, () => {
             const op = prism.request(request, resources, config);
-            errors
+            return errors
               ? assertResolvesLeft(op, e =>
                   expect(e).toMatchObject(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR))
                 )
@@ -234,8 +230,8 @@ describe('Http Client .request', () => {
     });
 
     describe('path is invalid', () => {
-      it('resolves with an error', async () => {
-        await assertResolvesLeft(
+      it('resolves with an error', () =>
+        assertResolvesLeft(
           prism.request(
             {
               method: 'get',
@@ -246,13 +242,12 @@ describe('Http Client .request', () => {
             resources
           ),
           e => expect(e).toMatchObject(ProblemJsonError.fromTemplate(NO_PATH_MATCHED_ERROR))
-        );
-      });
+        ));
     });
 
     describe('when requesting GET /pet/findByStatus', () => {
-      it('with valid query params returns generated body', async () => {
-        await assertResolvesRight(
+      it('with valid query params returns generated body', () =>
+        assertResolvesRight(
           prism.request(
             {
               method: 'get',
@@ -269,11 +264,10 @@ describe('Http Client .request', () => {
             expect(response).toHaveProperty('output.body');
             expect(typeof response.output.body).toBe('string');
           }
-        );
-      });
+        ));
 
-      it('w/o required params throws a validation error', async () => {
-        await assertResolvesLeft(
+      it('w/o required params throws a validation error', () =>
+        assertResolvesLeft(
           prism.request(
             {
               method: 'get',
@@ -284,11 +278,10 @@ describe('Http Client .request', () => {
             resources
           ),
           e => expect(e).toMatchObject(ProblemJsonError.fromTemplate(UNPROCESSABLE_ENTITY))
-        );
-      });
+        ));
 
-      it('with valid body param then returns no validation issues', async () => {
-        await assertResolvesRight(
+      it('with valid body param then returns no validation issues', () =>
+        assertResolvesRight(
           prism.request(
             {
               method: 'get',
@@ -311,14 +304,13 @@ describe('Http Client .request', () => {
               input: [],
               output: [],
             })
-        );
-      });
+        ));
     });
   });
 
   describe('headers validation', () => {
-    it('validates the headers even if casing does not match', async () => {
-      await assertResolvesRight(
+    it('validates the headers even if casing does not match', () =>
+      assertResolvesRight(
         prism.request(
           {
             method: 'get',
@@ -332,11 +324,10 @@ describe('Http Client .request', () => {
           resources
         ),
         response => expect(response.output).toHaveProperty('statusCode', 200)
-      );
-    });
+      ));
 
-    it('returns an error if the the header is missing', async () => {
-      await assertResolvesLeft(
+    it('returns an error if the the header is missing', () =>
+      assertResolvesLeft(
         prism.request(
           {
             method: 'get',
@@ -346,8 +337,7 @@ describe('Http Client .request', () => {
           },
           resources
         )
-      );
-    });
+      ));
   });
 
   it('loads spec provided in yaml', () => {
@@ -405,7 +395,7 @@ describe('proxy server', () => {
       );
 
       const resources = await getHttpOperationsFromResource(petStoreOas2Path);
-      await assertResolvesRight(prism.request({ method: 'get', url: { path: '/pets' } }, resources), response => {
+      return assertResolvesRight(prism.request({ method: 'get', url: { path: '/pets' } }, resources), response => {
         expect(response.output.statusCode).toBe(200);
         expect(response.output.body).toBe('<html><h1>Hello</h1>');
       });

--- a/packages/http/src/utils/__tests__/parseResponse.spec.ts
+++ b/packages/http/src/utils/__tests__/parseResponse.spec.ts
@@ -1,80 +1,74 @@
 import { parseResponse, parseResponseBody, parseResponseHeaders } from '../parseResponse';
 import { assertResolvesLeft, assertResolvesRight } from '@stoplight/prism-core/src/__tests__/utils';
 import { Headers } from 'node-fetch';
-import { Dictionary } from '@stoplight/types';
 
 describe('parseResponseBody()', () => {
   describe('body is json', () => {
     describe('body is parseable', () => {
-      it('returns parsed body', async () => {
+      it('returns parsed body', () => {
         const response = {
           headers: new Headers({ 'content-type': 'application/json' }),
           json: jest.fn().mockResolvedValue({ test: 'test' }),
           text: jest.fn(),
         };
 
-        await assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual({ test: 'test' }));
-
         expect(response.text).not.toHaveBeenCalled();
+        return assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual({ test: 'test' }));
       });
     });
 
     describe('body is not parseable', () => {
-      it('returns error', async () => {
+      it('returns error', () => {
         const response = {
           headers: new Headers({ 'content-type': 'application/json' }),
           json: jest.fn().mockRejectedValue(new Error('Big Bada Boom')),
           text: jest.fn(),
         };
 
-        await assertResolvesLeft(parseResponseBody(response), error => expect(error.message).toEqual('Big Bada Boom'));
-
         expect(response.text).not.toHaveBeenCalled();
+        return assertResolvesLeft(parseResponseBody(response), error => expect(error.message).toEqual('Big Bada Boom'));
       });
     });
   });
 
   describe('body is not json', () => {
     describe('body is readable', () => {
-      it('returns body text', async () => {
+      it('returns body text', () => {
         const response = {
           headers: new Headers({ 'content-type': 'text/html' }),
           json: jest.fn(),
           text: jest.fn().mockResolvedValue('<html>Test</html>'),
         };
 
-        await assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual('<html>Test</html>'));
-
         expect(response.json).not.toHaveBeenCalled();
+        return assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual('<html>Test</html>'));
       });
     });
 
     describe('body is not readable', () => {
-      it('returns error', async () => {
+      it('returns error', () => {
         const response = {
           headers: new Headers(),
           json: jest.fn(),
           text: jest.fn().mockRejectedValue(new Error('Big Bada Boom')),
         };
 
-        await assertResolvesLeft(parseResponseBody(response), error => expect(error.message).toEqual('Big Bada Boom'));
-
         expect(response.json).not.toHaveBeenCalled();
+        return assertResolvesLeft(parseResponseBody(response), error => expect(error.message).toEqual('Big Bada Boom'));
       });
     });
   });
 
   describe('content-type header not set', () => {
-    it('returns body text', async () => {
+    it('returns body text', () => {
       const response = {
         headers: new Headers(),
         json: jest.fn(),
         text: jest.fn().mockResolvedValue('Plavalaguna'),
       };
 
-      await assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual('Plavalaguna'));
-
       expect(response.json).not.toHaveBeenCalled();
+      return assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual('Plavalaguna'));
     });
   });
 });
@@ -90,8 +84,8 @@ describe('parseResponseHeaders()', () => {
 
 describe('parseResponse()', () => {
   describe('response is correct', () => {
-    it('returns parsed response', () => {
-      return assertResolvesRight(
+    it('returns parsed response', () =>
+      assertResolvesRight(
         parseResponse({
           status: 200,
           headers: new Headers({ 'content-type': 'application/json', test: 'test' }),
@@ -105,13 +99,12 @@ describe('parseResponse()', () => {
             body: { test: 'test' },
           });
         }
-      );
-    });
+      ));
   });
 
   describe('response is invalid', () => {
-    it('returns error', () => {
-      return assertResolvesLeft(
+    it('returns error', () =>
+      assertResolvesLeft(
         parseResponse({
           status: 200,
           headers: new Headers(),
@@ -121,7 +114,6 @@ describe('parseResponse()', () => {
         error => {
           expect(error.message).toEqual('Big Bada Boom');
         }
-      );
-    });
+      ));
   });
 });


### PR DESCRIPTION
Return from `assertResolvesLeft` instead of using async await