### PR TITLE
fix: use lodash merge for header options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - Prism is now able to correctly differentiate between a preflight request and a regular `OPTIONS` request [#1031](https://github.com/stoplightio/prism/pull/1031)
+- Fixed a condition where Prism would ignore CLI flags in case the nor `Prefer` or Query String preferences were passed [#1034](https://github.com/stoplightio/prism/pull/1034)
 
 # 3.3.0 (2020-03-10)
 

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@stoplight/prism-core';
-import { getHttpOperationsFromResource } from '@stoplight/prism-http';
+import { getHttpOperationsFromResource, IHttpConfig } from '@stoplight/prism-http';
 import { resolve } from 'path';
+import { merge } from 'lodash';
 import fetch, { RequestInit } from 'node-fetch';
 import { createServer } from '../';
 import { ThenArg } from '../types';
@@ -19,17 +20,20 @@ function checkErrorPayloadShape(payload: string) {
   expect(parsedPayload).toHaveProperty('detail');
 }
 
-async function instantiatePrism(specPath: string) {
+async function instantiatePrism(specPath: string, configOverride?: Partial<IHttpConfig>) {
   const operations = await getHttpOperationsFromResource(specPath);
   const server = createServer(operations, {
     components: { logger },
-    config: {
-      checkSecurity: true,
-      validateRequest: true,
-      validateResponse: true,
-      errors: false,
-      mock: { dynamic: false },
-    },
+    config: merge(
+      {
+        checkSecurity: true,
+        validateRequest: true,
+        validateResponse: true,
+        errors: false,
+        mock: { dynamic: false },
+      },
+      configOverride
+    ),
     cors: true,
   });
 
@@ -75,6 +79,36 @@ describe('GET /pet?__server', () => {
   function requestPetGivenServer(serverUrl: string) {
     return fetch(new URL(`/pet?__server=${serverUrl}`, server.address), { method: 'GET' });
   }
+});
+
+describe('dynamic flag preservation', () => {
+  let server: ThenArg<ReturnType<typeof instantiatePrism>>;
+
+  beforeAll(async () => {
+    server = await instantiatePrism(resolve(__dirname, 'fixtures', 'petstore.no-auth.oas3.yaml'), {
+      mock: { dynamic: true },
+    });
+  });
+
+  afterAll(() => server.close());
+
+  describe('when running the server with dynamic to true', () => {
+    describe('and there is no preference header sent', () => {
+      describe('and I hit the same endpoint twice', () => {
+        let payload: unknown;
+        let secondPayload: unknown;
+
+        beforeAll(async () => {
+          payload = await (await fetch(new URL('/no_auth/pets?name=joe', server.address), { method: 'GET' })).json();
+          secondPayload = await (
+            await fetch(new URL('/no_auth/pets?name=joe', server.address), { method: 'GET' })
+          ).json();
+        });
+
+        it('shuold return two different objects', () => expect(payload).not.toStrictEqual(secondPayload));
+      });
+    });
+  });
 });
 
 describe.each([[oas2File], [oas3File]])('server %s', file => {

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -99,10 +99,12 @@ describe('dynamic flag preservation', () => {
         let secondPayload: unknown;
 
         beforeAll(async () => {
-          payload = await (await fetch(new URL('/no_auth/pets?name=joe', server.address), { method: 'GET' })).json();
-          secondPayload = await (
-            await fetch(new URL('/no_auth/pets?name=joe', server.address), { method: 'GET' })
-          ).json();
+          payload = await fetch(new URL('/no_auth/pets?name=joe', server.address), { method: 'GET' }).then(r =>
+            r.json()
+          );
+          secondPayload = await fetch(new URL('/no_auth/pets?name=joe', server.address), { method: 'GET' }).then(r =>
+            r.json()
+          );
         });
 
         it('shuold return two different objects', () => expect(payload).not.toStrictEqual(secondPayload));

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -9,16 +9,17 @@ import {
 import { DiagnosticSeverity, HttpMethod, IHttpOperation, Dictionary } from '@stoplight/types';
 import { IncomingMessage, ServerResponse, IncomingHttpHeaders } from 'http';
 import { AddressInfo } from 'net';
+import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
+import { IPrismDiagnostic } from '@stoplight/prism-core';
+import { MicriHandler } from 'micri';
 import micri, { Router, json, send, text } from 'micri';
 import * as typeIs from 'type-is';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
 import { serialize } from './serialize';
-import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
-import { IPrismDiagnostic } from '@stoplight/prism-core';
+import { merge } from 'lodash';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as TE from 'fp-ts/lib/TaskEither';
 import * as E from 'fp-ts/lib/Either';
-import { MicriHandler } from 'micri';
 
 function searchParamsToNameValues(searchParams: URLSearchParams): IHttpNameValues {
   const params = {};
@@ -83,7 +84,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         ? TE.right(false)
         : pipe(
             getHttpConfigFromRequest(input),
-            E.map(operationSpecificConfig => Object.assign(opts.config.mock, operationSpecificConfig)),
+            E.map(operationSpecificConfig => merge(opts.config.mock, operationSpecificConfig)),
             TE.fromEither
           );
 


### PR DESCRIPTION
Closes #1033 

`Object.assign` will assign and change properties even if they're undefined, merge does not.

```ts
Object.assign({dynamic: true},{dynamic: undefined})
// {dynamic: undefined}

merge({dynamic: true},{dynamic: undefined})
// {dynamic: true}

```