### PR TITLE
feat: add custom error for 2**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+# 3.3.1 (2020-03-13)
+
 ## Fixed
 
 - Prism is now able to correctly differentiate between a preflight request and a regular `OPTIONS` request [#1031](https://github.com/stoplightio/prism/pull/1031)
 - Fixed a condition where Prism would ignore CLI flags in case the nor `Prefer` or Query String preferences were passed [#1034](https://github.com/stoplightio/prism/pull/1034)
-- Created a specific error when a 2\*\* response cannot be found for a successful request [#1035](https://github.com/stoplightio/prism/pull/1035)
+- Created a specific error when a 200-299 response cannot be found for a successful request [#1035](https://github.com/stoplightio/prism/pull/1035)
 
 # 3.3.0 (2020-03-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Prism is now able to correctly differentiate between a preflight request and a regular `OPTIONS` request [#1031](https://github.com/stoplightio/prism/pull/1031)
 - Fixed a condition where Prism would ignore CLI flags in case the nor `Prefer` or Query String preferences were passed [#1034](https://github.com/stoplightio/prism/pull/1034)
+- Created a specific error when a 2\*\* response cannot be found for a successful request [#1035](https://github.com/stoplightio/prism/pull/1035)
 
 # 3.3.0 (2020-03-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - Prism is now able to correctly differentiate between a preflight request and a regular `OPTIONS` request [#1031](https://github.com/stoplightio/prism/pull/1031)
+- Fixed a condition where Prism would ignore CLI flags in case the nor `Prefer` or Query String preferences were passed [#1034](https://github.com/stoplightio/prism/pull/1034)
 
 # 3.3.0 (2020-03-10)
 

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -239,17 +239,7 @@ paths:
     get:
       responses:
         300:
-          content:
-            text/plain:
-              schema:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    example: Clark
-                  surname:
-                    type: string
-                    example: Kent
+          description: 'Desc'
 ```
 
 `curl -X POST http://localhost:4010/ -A 'Accept: text/plain'`

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -226,7 +226,7 @@ paths:
 
 ### NO_SUCCESS_RESPONSE_DEFINED
 
-**Message: No 2** response defined, cannot mock\*\*
+**Message: No response in the range 200-299 defined**
 **Returned Status Code: `500`**
 **Explanation:** This error occurs when the current request has matched a corresponding HTTP Operation and has passed all the validations, but there's no successful response (200-299) that could be returned.
 

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -224,6 +224,36 @@ paths:
 
 `curl -X POST http://localhost:4010/ -A 'Accept: text/plain'`
 
+### NO_RESPONSE_DEFINED
+
+**Message: No 2** response defined, cannot mock\*\*
+**Returned Status Code: `500`**
+**Explanation:** This error occurs when the current request has matched a corresponding HTTP Operation and has passed all the validations, but there's no successful response (200-299) that could be returned.
+
+##### Example
+
+```yaml
+openapi: '3.0.1'
+paths:
+  /:
+    get:
+      responses:
+        300:
+          content:
+            text/plain:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    example: Clark
+                  surname:
+                    type: string
+                    example: Kent
+```
+
+`curl -X POST http://localhost:4010/ -A 'Accept: text/plain'`
+
 ## Unknown error
 
 In case you get an `UNKNOWN` error, it likely means we **screwed it up** and we haven't handled this particular edge case. If you encounter one of these, opening an [issue](https://github.com/stoplightio/prism/issues/new?labels=bug&template=bug_report.md) might be a good idea.

--- a/docs/guides/errors.md
+++ b/docs/guides/errors.md
@@ -224,7 +224,7 @@ paths:
 
 `curl -X POST http://localhost:4010/ -A 'Accept: text/plain'`
 
-### NO_RESPONSE_DEFINED
+### NO_SUCCESS_RESPONSE_DEFINED
 
 **Message: No 2** response defined, cannot mock\*\*
 **Returned Status Code: `500`**

--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": ["packages/*"],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "independent": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/prism-core": "^3.3.0",
-    "@stoplight/prism-http-server": "^3.3.0",
+    "@stoplight/prism-core": "^3.3.1",
+    "@stoplight/prism-http-server": "^3.3.1",
     "chalk": "^3.0.0",
     "chokidar": "^3.2.1",
     "fp-ts": "^2.1.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^3.3.0",
-    "@stoplight/prism-http": "^3.3.0",
+    "@stoplight/prism-core": "^3.3.1",
+    "@stoplight/prism-http": "^3.3.1",
     "fast-xml-parser": "^3.12.20",
     "fp-ts": "^2.1.1",
     "io-ts": "^2.1.0",

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -9,16 +9,17 @@ import {
 import { DiagnosticSeverity, HttpMethod, IHttpOperation, Dictionary } from '@stoplight/types';
 import { IncomingMessage, ServerResponse, IncomingHttpHeaders } from 'http';
 import { AddressInfo } from 'net';
+import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
+import { IPrismDiagnostic } from '@stoplight/prism-core';
+import { MicriHandler } from 'micri';
 import micri, { Router, json, send, text } from 'micri';
 import * as typeIs from 'type-is';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
 import { serialize } from './serialize';
-import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
-import { IPrismDiagnostic } from '@stoplight/prism-core';
+import { merge } from 'lodash';
 import { pipe } from 'fp-ts/lib/pipeable';
 import * as TE from 'fp-ts/lib/TaskEither';
 import * as E from 'fp-ts/lib/Either';
-import { MicriHandler } from 'micri';
 
 function searchParamsToNameValues(searchParams: URLSearchParams): IHttpNameValues {
   const params = {};
@@ -83,7 +84,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         ? TE.right(false)
         : pipe(
             getHttpConfigFromRequest(input),
-            E.map(operationSpecificConfig => Object.assign(opts.config.mock, operationSpecificConfig)),
+            E.map(operationSpecificConfig => merge(opts.config.mock, operationSpecificConfig)),
             TE.fromEither
           );
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.1.2",
     "@stoplight/json-ref-readers": "^1.1.1",
     "@stoplight/json-ref-resolver": "^3.0.1",
-    "@stoplight/prism-core": "^3.3.0",
+    "@stoplight/prism-core": "^3.3.1",
     "@stoplight/yaml": "^3.0.2",
     "abstract-logging": "^2.0.0",
     "accepts": "^1.3.7",

--- a/packages/http/src/mocker/errors.ts
+++ b/packages/http/src/mocker/errors.ts
@@ -20,7 +20,7 @@ export const NOT_FOUND: Omit<ProblemJson, 'detail'> = {
 
 export const NO_SUCCESS_RESPONSE_DEFINED: Omit<ProblemJson, 'detail'> = {
   type: 'NO_SUCCESS_RESPONSE_DEFINED',
-  title: 'No 2** response defined, cannot mock',
+  title: 'No response in the range 200-299 defined',
   status: 500,
 };
 

--- a/packages/http/src/mocker/errors.ts
+++ b/packages/http/src/mocker/errors.ts
@@ -18,6 +18,12 @@ export const NOT_FOUND: Omit<ProblemJson, 'detail'> = {
   status: 404,
 };
 
+export const NO_RESPONSE_DEFINED: Omit<ProblemJson, 'detail'> = {
+  type: 'NO_RESPONSE_DEFINED',
+  title: 'No 2** response defined, cannot mock',
+  status: 500,
+};
+
 export const UNAUTHORIZED: Omit<ProblemJson, 'detail'> = {
   type: 'UNAUTHORIZED',
   title: 'Invalid security scheme used',

--- a/packages/http/src/mocker/errors.ts
+++ b/packages/http/src/mocker/errors.ts
@@ -18,8 +18,8 @@ export const NOT_FOUND: Omit<ProblemJson, 'detail'> = {
   status: 404,
 };
 
-export const NO_RESPONSE_DEFINED: Omit<ProblemJson, 'detail'> = {
-  type: 'NO_RESPONSE_DEFINED',
+export const NO_SUCCESS_RESPONSE_DEFINED: Omit<ProblemJson, 'detail'> = {
+  type: 'NO_SUCCESS_RESPONSE_DEFINED',
   title: 'No 2** response defined, cannot mock',
   status: 500,
 };

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -9,7 +9,7 @@ import * as RE from 'fp-ts/lib/ReaderEither';
 import { get, tail } from 'lodash';
 import { Logger } from 'pino';
 import withLogger from '../../withLogger';
-import { NOT_ACCEPTABLE, NOT_FOUND } from '../errors';
+import { NOT_ACCEPTABLE, NOT_FOUND, NO_RESPONSE_DEFINED } from '../errors';
 import {
   contentHasExamples,
   createResponseFromDefault,
@@ -220,7 +220,7 @@ const helpers = {
   ): RE.ReaderEither<Logger, Error, IHttpNegotiationResult> {
     return pipe(
       findLowest2xx(httpOperation.responses),
-      RE.fromOption(() => new Error('No 2** response defined, cannot mock')),
+      RE.fromOption(() => ProblemJsonError.fromTemplate(NO_RESPONSE_DEFINED)),
       RE.chain(lowest2xxResponse =>
         helpers.negotiateOptionsBySpecificResponse(httpOperation, desiredOptions, lowest2xxResponse)
       )

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -9,7 +9,7 @@ import * as RE from 'fp-ts/lib/ReaderEither';
 import { get, tail } from 'lodash';
 import { Logger } from 'pino';
 import withLogger from '../../withLogger';
-import { NOT_ACCEPTABLE, NOT_FOUND, NO_RESPONSE_DEFINED } from '../errors';
+import { NOT_ACCEPTABLE, NOT_FOUND, NO_SUCCESS_RESPONSE_DEFINED } from '../errors';
 import {
   contentHasExamples,
   createResponseFromDefault,
@@ -220,7 +220,7 @@ const helpers = {
   ): RE.ReaderEither<Logger, Error, IHttpNegotiationResult> {
     return pipe(
       findLowest2xx(httpOperation.responses),
-      RE.fromOption(() => ProblemJsonError.fromTemplate(NO_RESPONSE_DEFINED)),
+      RE.fromOption(() => ProblemJsonError.fromTemplate(NO_SUCCESS_RESPONSE_DEFINED)),
       RE.chain(lowest2xxResponse =>
         helpers.negotiateOptionsBySpecificResponse(httpOperation, desiredOptions, lowest2xxResponse)
       )

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -442,7 +442,7 @@ describe('NegotiatorHelpers', () => {
 
       const negotiationResult = helpers.negotiateOptionsForDefaultCode(httpOperation, desiredOptions)(logger);
       assertLeft(negotiationResult, e => {
-        expect(e.message).toBe('No 2** response defined, cannot mock');
+        expect(e.name).toBe('https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED');
       });
     });
   });

--- a/test-harness/specs/default-responses/default_responses-AC-4.oas2.txt
+++ b/test-harness/specs/default-responses/default_responses-AC-4.oas2.txt
@@ -20,4 +20,4 @@ curl -i http://localhost:4010/todos
 HTTP/1.1 500 Internal Server Error
 content-type: application/problem+json
 
-{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No 2** response defined, cannot mock","status":500,"detail":""}
+{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No response in the range 200-299 defined","status":500,"detail":""}

--- a/test-harness/specs/default-responses/default_responses-AC-4.oas2.txt
+++ b/test-harness/specs/default-responses/default_responses-AC-4.oas2.txt
@@ -20,4 +20,4 @@ curl -i http://localhost:4010/todos
 HTTP/1.1 500 Internal Server Error
 content-type: application/problem+json
 
-{"type":"https://stoplight.io/prism/errors#UNKNOWN","title":"No 2** response defined, cannot mock","status":500,"detail":""}
+{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No 2** response defined, cannot mock","status":500,"detail":""}

--- a/test-harness/specs/default-responses/default_responses-AC-4.oas3.txt
+++ b/test-harness/specs/default-responses/default_responses-AC-4.oas3.txt
@@ -20,4 +20,4 @@ curl -i http://localhost:4010/todos
 HTTP/1.1 500 Internal Server Error
 content-type: application/problem+json
 
-{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No 2** response defined, cannot mock","status":500,"detail":""}
+{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No response in the range 200-299 defined","status":500,"detail":""}

--- a/test-harness/specs/default-responses/default_responses-AC-4.oas3.txt
+++ b/test-harness/specs/default-responses/default_responses-AC-4.oas3.txt
@@ -20,4 +20,4 @@ curl -i http://localhost:4010/todos
 HTTP/1.1 500 Internal Server Error
 content-type: application/problem+json
 
-{"type":"https://stoplight.io/prism/errors#UNKNOWN","title":"No 2** response defined, cannot mock","status":500,"detail":""}
+{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No 2** response defined, cannot mock","status":500,"detail":""}

--- a/test-harness/specs/default-responses/default_responses-AC-4.pc.txt
+++ b/test-harness/specs/default-responses/default_responses-AC-4.pc.txt
@@ -35,4 +35,4 @@ curl -i http://localhost:4010/todos
 HTTP/1.1 500 Internal Server Error
 content-type: application/problem+json
 
-{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No 2** response defined, cannot mock","status":500,"detail":""}
+{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No response in the range 200-299 defined","status":500,"detail":""}

--- a/test-harness/specs/default-responses/default_responses-AC-4.pc.txt
+++ b/test-harness/specs/default-responses/default_responses-AC-4.pc.txt
@@ -35,4 +35,4 @@ curl -i http://localhost:4010/todos
 HTTP/1.1 500 Internal Server Error
 content-type: application/problem+json
 
-{"type":"https://stoplight.io/prism/errors#UNKNOWN","title":"No 2** response defined, cannot mock","status":500,"detail":""}
+{"type":"https://stoplight.io/prism/errors#NO_SUCCESS_RESPONSE_DEFINED","title":"No 2** response defined, cannot mock","status":500,"detail":""}


### PR DESCRIPTION
Create a specific error for Prism when it cannot find a suitable 2XX response so we can differentiate with something that's not under our control