### PR TITLE
Forward request to server without altering accept header

### DIFF
--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -35,7 +35,7 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
         return fetch(url, {
           body,
           method: input.method,
-          headers: defaults(omit(input.headers, ['host', 'accept']), {
+          headers: defaults(omit(input.headers, ['host']), {
             accept: 'application/json, text/plain, */*',
             'user-agent': `Prism/${prismVersion}`,
           }),


### PR DESCRIPTION
Hi everyone,

This PR is to fix the issue #1075. 

The issue is in the `forwarder` because the request created override the `Accept` header by `application/json, text/plain, */*`.

That PR fix that issue preserving the header if it has been set and add to `application/json, text/plain, */*` if wasn't set.

Nicolas
