### PR TITLE
Compare content type parameters separately

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @XVincentX @marcelltoth @karol-maciaszek
+*       @XVincentX @karol-maciaszek

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+## Fixed
+
+- Since the media type parameters are not standardised (apart from the quality one), the negotiator will discard them during the matching process or simply treat them as strings/numbers without trying to guess anything more [#1159](https://github.com/stoplightio/prism/pull/1159)
+
 ## Changed
 
 - **BREAKING**: The `getHttpOperationsFromSpec` and `getHttpOperationsFromResource` have been moved from the HTTP Package to the CLI package. If you're using Prism programmatically, this might require some code changes on your side [#1009](https://github.com/stoplightio/prism/pull/1009)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,16 +88,64 @@ The application will wait for a debugger to be attached and break on the first l
 
 #### What is this `fp-ts` all about?
 
-`fp-ts` is the library containing functions and data structures that help Prism lean toward a functional style. It might be annoying to step into its functions; fortunately according to your IDE, you might be able to skip the code. In case you're using Visual Studio Code, you can use the `skipFiles` section of your `launch.json` file:
+`fp-ts` is the library containing functions and data structures that help Prism lean toward a functional style. It might be annoying to step into its functions; fortunately according to your IDE, you might be able to skip the code. In case you're using Visual Studio Code, you can use the `skipFiles` section of your `launch.json` file. Here's what we currently use in development:
 
 ```json
 {
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "inputs": [
+    {
+      "id": "oasFile",
+      "description": "OAS file to mock/proxy",
+      "default": "../../examples/petstore.oas3.yaml",
+      "type": "promptString"
+    },
+    {
+      "id": "origin",
+      "description": "Proxy destination",
+      "default": "https://httpbin.org",
+      "type": "promptString"
+    },
+    {
+      "id": "testFile",
+      "description": "Test file",
+      "type": "promptString"
+    }
+  ],
   "configurations": [
     {
       "type": "node",
-      "request": "attach",
-      "name": "Launch Program",
-      "skipFiles": ["node_modules/fp-ts/*.js"]
+      "request": "launch",
+      "name": "Mock file",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["node_modules/fp-ts/*.js"],
+      "program": "${workspaceRoot}/packages/cli/src/index.ts",
+      "args": ["mock", "${input:oasFile}"],
+      "cwd": "${workspaceRoot}/packages/cli",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Proxy file",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["node_modules/fp-ts/*.js"],
+      "program": "${workspaceRoot}/packages/cli/src/index.ts",
+      "args": ["proxy", "${input:oasFile}", "${input:origin}"],
+      "cwd": "${workspaceRoot}/packages/cli",
+      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run test file",
+      "autoAttachChildProcesses": true,
+      "skipFiles": ["node_modules/fp-ts/*.js"],
+      "program": "${workspaceRoot}/node_modules/.bin/jest",
+      "args": ["${input:testFile}", "--runInBand"]
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,33 +88,10 @@ The application will wait for a debugger to be attached and break on the first l
 
 #### What is this `fp-ts` all about?
 
-`fp-ts` is the library containing functions and data structures that help Prism lean toward a functional style. It might be annoying to step into its functions; fortunately according to your IDE, you might be able to skip the code. In case you're using Visual Studio Code, you can use the `skipFiles` section of your `launch.json` file. Here's what we currently use in development:
+`fp-ts` is the library containing functions and data structures that help Prism lean toward a functional style. It might be annoying to step into its functions; fortunately according to your IDE, you might be able to skip the code. In case you're using Visual Studio Code, you can use the `skipFiles` section of your `launch.json` file. You can cobble something like this:
 
 ```json
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
-  "inputs": [
-    {
-      "id": "oasFile",
-      "description": "OAS file to mock/proxy",
-      "default": "../../examples/petstore.oas3.yaml",
-      "type": "promptString"
-    },
-    {
-      "id": "origin",
-      "description": "Proxy destination",
-      "default": "https://httpbin.org",
-      "type": "promptString"
-    },
-    {
-      "id": "testFile",
-      "description": "Test file",
-      "type": "promptString"
-    }
-  ],
   "configurations": [
     {
       "type": "node",
@@ -126,26 +103,6 @@ The application will wait for a debugger to be attached and break on the first l
       "args": ["mock", "${input:oasFile}"],
       "cwd": "${workspaceRoot}/packages/cli",
       "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Proxy file",
-      "autoAttachChildProcesses": true,
-      "skipFiles": ["node_modules/fp-ts/*.js"],
-      "program": "${workspaceRoot}/packages/cli/src/index.ts",
-      "args": ["proxy", "${input:oasFile}", "${input:origin}"],
-      "cwd": "${workspaceRoot}/packages/cli",
-      "runtimeArgs": ["-r", "ts-node/register/transpile-only", "-r", "tsconfig-paths/register"]
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Run test file",
-      "autoAttachChildProcesses": true,
-      "skipFiles": ["node_modules/fp-ts/*.js"],
-      "program": "${workspaceRoot}/node_modules/.bin/jest",
-      "args": ["${input:testFile}", "--runInBand"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@stoplight/types": "^11.4.1",
     "@types/caseless": "^0.12.2",
     "@types/chance": "^1.0.6",
+    "@types/content-type": "^1.1.3",
     "@types/faker": "^4.1.5",
     "@types/jest": "^25.1.2",
     "@types/json-schema": "^7.0.3",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -25,6 +25,7 @@
     "ajv": "^6.10.2",
     "ajv-oai": "^1.0.0",
     "caseless": "^0.12.0",
+    "content-type": "^1.0.4",
     "faker": "^4.1.0",
     "fp-ts": "^2.5.3",
     "fp-ts-contrib": "^0.1.15",

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -23,7 +23,7 @@ describe('http mocker', () => {
         assertRight(response, result => expect(result).toMatchSnapshot());
       });
 
-      test.only('and that content type does not exist should return a 406 error', () => {
+      test('and that content type does not exist should return a 406 error', () => {
         const mockResult = mock({
           resource: httpOperations[0],
           input: httpRequests[0],

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -23,7 +23,7 @@ describe('http mocker', () => {
         assertRight(response, result => expect(result).toMatchSnapshot());
       });
 
-      test('and that content type does not exist should return a 406 error', () => {
+      test.only('and that content type does not exist should return a 406 error', () => {
         const mockResult = mock({
           resource: httpOperations[0],
           input: httpRequests[0],

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -23,17 +23,17 @@ export function hasContents(v: IHttpOperationResponse): v is PickRequired<IHttpO
 }
 
 export function findBestHttpContentByMediaType(
-  response: PickRequired<IHttpOperationResponse, 'contents'>,
+  contents: IMediaTypeContent[],
   mediaType: string[]
 ): Option<IMediaTypeContent> {
   const bestType = accepts({
     headers: {
       accept: mediaType.join(','),
     },
-  }).type(response.contents.map(c => c.mediaType));
+  }).type(contents.map(c => c.mediaType));
 
   return pipe(
-    response.contents,
+    contents,
     findFirst(content => content.mediaType === bestType)
   );
 }

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -37,6 +37,7 @@ export function findBestHttpContentByMediaType(
     O.fromPredicate((bestType): bestType is string => !!bestType),
     O.chain(bestType => findFirst<IMediaTypeContent>(content => content.mediaType === bestType)(contents)),
     O.alt(() =>
+      // Since media type parameters are not standardised (apart from the quality value), we're going to try again ignoring them all.
       pipe(
         mediaTypes
           .map(mt => contentType.parse(mt))

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -42,7 +42,7 @@ export function findBestHttpContentByMediaType(
       pipe(
         mediaTypes
           .map(mt => contentType.parse(mt))
-          .filter(mt => Object.keys(mt.parameters).filter(k => k !== 'q').length > 0)
+          .filter(({ parameters }) => Object.keys(parameters).some(k => k !== 'q'))
           .map(({ type, parameters }) => ({ type, parameters: pick(parameters, 'q') }))
           .map(mt => contentType.format(mt)),
         fromArray,

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -42,7 +42,7 @@ export function findBestHttpContentByMediaType(
       pipe(
         mediaTypes
           .map(mt => contentType.parse(mt))
-          .filter(mt => Object.keys(mt.parameters).length > 0)
+          .filter(mt => Object.keys(mt.parameters).filter(k => k !== 'q').length > 0)
           .map(({ type, parameters }) => ({ type, parameters: pick(parameters, 'q') }))
           .map(mt => contentType.format(mt)),
         fromArray,

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -1,7 +1,7 @@
 import { IHttpOperation, IHttpOperationResponse, IMediaTypeContent, IHttpHeaderParam } from '@stoplight/types';
 import * as E from 'fp-ts/lib/Either';
 import { NonEmptyArray, fromArray } from 'fp-ts/lib/NonEmptyArray';
-import { isNonEmpty, findIndex } from 'fp-ts/lib/Array';
+import { isNonEmpty } from 'fp-ts/lib/Array';
 import * as O from 'fp-ts/lib/Option';
 import * as R from 'fp-ts/lib/Reader';
 import * as RE from 'fp-ts/lib/ReaderEither';
@@ -26,12 +26,7 @@ import { ProblemJsonError } from '../../types';
 
 const outputNoContentFoundMessage = (contentTypes: string[]) => `Unable to find content for ${contentTypes}`;
 
-const createEmptyResponse = (code: string, headers: IHttpHeaderParam[], mediaTypes: string[]) =>
-  pipe(
-    mediaTypes,
-    findIndex(ct => ct.includes('*/*')),
-    O.map(() => ({ code, headers }))
-  );
+const createEmptyResponse = (code: string, headers: IHttpHeaderParam[]): IHttpNegotiationResult => ({ code, headers });
 
 const helpers = {
   negotiateByPartialOptionsAndHttpContent(
@@ -343,13 +338,7 @@ const helpers = {
                 return pipe(
                   O.fromNullable(response.contents),
                   O.chain(fromArray),
-                  O.chain(contents =>
-                    createEmptyResponse(
-                      response.code,
-                      response.headers || [],
-                      contents.map(c => c.mediaType)
-                    )
-                  ),
+                  O.map(() => createEmptyResponse(response.code, response.headers || [])),
                   E.fromOption(() => {
                     logger.trace(`Unable to find a content with a schema defined for the response ${response.code}`);
 

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -138,7 +138,7 @@ const helpers = {
   },
 
   negotiateOptionsBySpecificResponse(
-    httpOperation: Pick<IHttpOperation, 'method'>,
+    requestMethod: string,
     desiredOptions: NegotiationOptions,
     response: IHttpOperationResponse
   ): RE.ReaderEither<Logger, Error, IHttpNegotiationResult> {
@@ -146,7 +146,7 @@ const helpers = {
     const { mediaTypes, dynamic, exampleKey } = desiredOptions;
 
     return logger => {
-      if (httpOperation.method === 'head') {
+      if (requestMethod === 'head') {
         logger.info(`Responding with an empty body to a HEAD request.`);
 
         return E.right({
@@ -218,7 +218,7 @@ const helpers = {
       findLowest2xx(httpOperation.responses),
       RE.fromOption(() => ProblemJsonError.fromTemplate(NO_SUCCESS_RESPONSE_DEFINED)),
       RE.chain(lowest2xxResponse =>
-        helpers.negotiateOptionsBySpecificResponse(httpOperation, desiredOptions, lowest2xxResponse)
+        helpers.negotiateOptionsBySpecificResponse(httpOperation.method, desiredOptions, lowest2xxResponse)
       )
     );
   },
@@ -247,7 +247,7 @@ const helpers = {
           ),
           RE.chain(response =>
             pipe(
-              helpers.negotiateOptionsBySpecificResponse(httpOperation, desiredOptions, response),
+              helpers.negotiateOptionsBySpecificResponse(httpOperation.method, desiredOptions, response),
               RE.orElse(() =>
                 pipe(
                   helpers.negotiateOptionsForDefaultCode(httpOperation, desiredOptions),

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -98,7 +98,7 @@ const helpers = {
     const findHttpContent = hasContents(response)
       ? pipe(
           findDefaultContentType(response),
-          O.alt(() => findBestHttpContentByMediaType(response, ['application/json', '*/*']))
+          O.alt(() => findBestHttpContentByMediaType(response.contents, ['application/json', '*/*']))
         )
       : O.none;
 
@@ -153,11 +153,9 @@ const helpers = {
       }
 
       if (mediaTypes && isNonEmpty(mediaTypes)) {
-        // a user provided mediaType
-        const httpContent = hasContents(response) ? findBestHttpContentByMediaType(response, mediaTypes) : O.none;
-
         return pipe(
-          httpContent,
+          O.fromNullable(response.contents),
+          O.chain(contents => findBestHttpContentByMediaType(contents, mediaTypes)),
           O.fold(
             () =>
               pipe(

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -160,7 +160,7 @@ const helpers = {
         O.chain(fromArray),
         O.fold(
           () => {
-            logger.trace('No mediaType provided. Fallbacking to the default media type (application/json)');
+            logger.debug('No mediaType provided. Fallbacking to the default media type (application/json)');
             return helpers.negotiateDefaultMediaType(
               {
                 code,
@@ -291,19 +291,19 @@ const helpers = {
             pipe(
               previous,
               O.alt(() => {
-                logger.trace(`Unable to find a ${statusCodes[index]} response definition`);
+                logger.debug(`Unable to find a ${statusCodes[index]} response definition`);
                 return findResponseByStatusCode(httpResponses, current);
               })
             ),
           pipe(findResponseByStatusCode(httpResponses, first))
         ),
         O.alt(() => {
-          logger.trace(`Unable to find a ${tail(statusCodes)} response definition`);
+          logger.debug(`Unable to find a ${tail(statusCodes)} response definition`);
           return pipe(
             createResponseFromDefault(httpResponses, first),
             O.fold(
               () => {
-                logger.trace("Unable to find a 'default' response definition");
+                logger.debug("Unable to find a 'default' response definition");
                 return O.none;
               },
               response => {
@@ -343,7 +343,7 @@ const helpers = {
                 headers: response.headers || [],
               });
             } else {
-              logger.trace(`Unable to find a content with an example defined for the response ${response.code}`);
+              logger.debug(`Unable to find a content with an example defined for the response ${response.code}`);
               // find first response with a schema
               const responseWithSchema = response.contents && response.contents.find(content => !!content.schema);
               if (responseWithSchema) {
@@ -358,7 +358,7 @@ const helpers = {
                 return pipe(
                   createEmptyResponse(response.code, response.headers || [], ['*/*']),
                   E.fromOption(() => {
-                    logger.trace(`Unable to find a content with a schema defined for the response ${response.code}`);
+                    logger.debug(`Unable to find a content with a schema defined for the response ${response.code}`);
 
                     return new Error(`Neither schema nor example defined for ${response.code} response.`);
                   })

--- a/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
+++ b/packages/http/src/mocker/negotiator/NegotiatorHelpers.ts
@@ -133,7 +133,7 @@ const helpers = {
   },
 
   negotiateOptionsBySpecificResponse(
-    httpOperation: IHttpOperation,
+    httpOperation: Pick<IHttpOperation, 'method'>,
     desiredOptions: NegotiationOptions,
     response: IHttpOperationResponse
   ): RE.ReaderEither<Logger, Error, IHttpNegotiationResult> {
@@ -335,16 +335,7 @@ const helpers = {
                   headers: response.headers || [],
                 });
               } else {
-                return pipe(
-                  O.fromNullable(response.contents),
-                  O.chain(fromArray),
-                  O.map(() => createEmptyResponse(response.code, response.headers || [])),
-                  E.fromOption(() => {
-                    logger.trace(`Unable to find a content with a schema defined for the response ${response.code}`);
-
-                    return new Error(`Neither schema nor example defined for ${response.code} response.`);
-                  })
-                );
+                return E.right(createEmptyResponse(response.code, response.headers || []));
               }
             }
           })

--- a/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
@@ -2,7 +2,7 @@ import { assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { findBestHttpContentByMediaType } from '../InternalHelpers';
 
 describe('InternalHelpers', () => {
-  describe('findBestHttpContentByMediaType', () => {
+  describe('findBestHttpContentByMediaType()', () => {
     describe('with multiple content types for a response', () => {
       const availableResponses = {
         code: '200',
@@ -16,6 +16,46 @@ describe('InternalHelpers', () => {
         ]);
 
         assertSome(possibleResponse, response => expect(response).toHaveProperty('mediaType', 'application/xml'));
+      });
+    });
+
+    describe('when available content types has a non standard parameter', () => {
+      it('should return an unparametrised version', () => {
+        assertSome(
+          findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1' }], ['application/json'])
+        );
+      });
+    });
+
+    describe('when available content types has the Q and a non standard parameter', () => {
+      it('should return an unparametrised version', () => {
+        assertSome(
+          findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1; q=0.6' }], ['application/json'])
+        );
+      });
+
+      describe('multiple media types available', () => {
+        it('will still give preference with the q parameter', () => {
+          assertSome(
+            findBestHttpContentByMediaType(
+              [
+                { mediaType: 'application/json; version=1; q=0.6' },
+                { mediaType: 'application/json; version=1; q=1' },
+                { mediaType: 'application/vnd+json; version=1; q=0.5' },
+              ],
+              ['application/json']
+            ),
+            mt => expect(mt).toHaveProperty('mediaType', 'application/json; version=1; q=1')
+          );
+        });
+      });
+    });
+
+    describe('when requested content type has a parameter', () => {
+      it('should return an unparametrised version', () => {
+        assertSome(
+          findBestHttpContentByMediaType([{ mediaType: 'application/json' }], ['application/json; version=1'])
+        );
       });
     });
   });

--- a/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
@@ -39,11 +39,11 @@ describe('InternalHelpers', () => {
           assertSome(
             findBestHttpContentByMediaType(
               [
-                { mediaType: 'application/json; version=1; q=0.6' },
                 { mediaType: 'application/json; version=1; q=1' },
+                { mediaType: 'application/xml; version=1; q=0.6' },
                 { mediaType: 'application/vnd+json; version=1; q=0.5' },
               ],
-              ['application/json']
+              ['application/json', 'application/xml']
             ),
             mt => expect(mt).toHaveProperty('mediaType', 'application/json; version=1; q=1')
           );

--- a/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
@@ -10,7 +10,7 @@ describe('InternalHelpers', () => {
       };
 
       it('should respect the q parameter', () => {
-        const possibleResponse = findBestHttpContentByMediaType(avaiableResponses, [
+        const possibleResponse = findBestHttpContentByMediaType(avaiableResponses.contents, [
           'application/json;q=0.8',
           'application/xml;q=1',
         ]);

--- a/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
@@ -4,13 +4,13 @@ import { findBestHttpContentByMediaType } from '../InternalHelpers';
 describe('InternalHelpers', () => {
   describe('findBestHttpContentByMediaType', () => {
     describe('with multiple content types for a response', () => {
-      const avaiableResponses = {
+      const availableResponses = {
         code: '200',
         contents: [{ mediaType: 'application/xml' }, { mediaType: 'application/json' }],
       };
 
       it('should respect the q parameter', () => {
-        const possibleResponse = findBestHttpContentByMediaType(avaiableResponses.contents, [
+        const possibleResponse = findBestHttpContentByMediaType(availableResponses.contents, [
           'application/json;q=0.8',
           'application/xml;q=1',
         ]);

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -14,7 +14,6 @@ import helpers from '../NegotiatorHelpers';
 import { IHttpNegotiationResult, NegotiationOptions } from '../types';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { findBestHttpContentByMediaType } from '../InternalHelpers';
-import * as contentType from 'content-type';
 
 const chance = new Chance();
 const chanceOptions: Partial<Chance.StringOptions> = { length: 8, casing: 'lower', alpha: true, numeric: false };
@@ -748,48 +747,6 @@ describe('NegotiatorHelpers', () => {
         assertRight(negotiationResult, result => {
           expect(result).toEqual(expectedResponse);
         });
-      });
-    });
-  });
-
-  describe('findBestHttpContentByMediaType()', () => {
-    describe('when available content types has a non standard parameter', () => {
-      it('should return an unparametrised version', () => {
-        assertSome(
-          findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1' }], ['application/json'])
-        );
-      });
-    });
-
-    describe('when available content types has the Q and a non standard parameter', () => {
-      it('should return an unparametrised version', () => {
-        assertSome(
-          findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1; q=0.6' }], ['application/json'])
-        );
-      });
-
-      describe('multiple media types available', () => {
-        it('will still give preference with the q parameter', () => {
-          assertSome(
-            findBestHttpContentByMediaType(
-              [
-                { mediaType: 'application/json; version=1; q=0.6' },
-                { mediaType: 'application/json; version=1; q=1' },
-                { mediaType: 'application/vnd+json; version=1; q=0.5' },
-              ],
-              ['application/json']
-            ),
-            mt => expect(mt).toHaveProperty('mediaType', 'application/json; version=1; q=1')
-          );
-        });
-      });
-    });
-
-    describe('when requested content type has a parameter', () => {
-      it('should return an unparametrised version', () => {
-        assertSome(
-          findBestHttpContentByMediaType([{ mediaType: 'application/json' }], ['application/json; version=1'])
-        );
       });
     });
   });

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -752,11 +752,19 @@ describe('NegotiatorHelpers', () => {
   });
 
   describe('findBestHttpContentByMediaType()', () => {
-    describe('when used in a mixed parameter situation', () => {
-      it('should return an unparametrised version', () =>
+    describe('when avaiable content types have a parameter', () => {
+      it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1' }], ['application/json'])
-        ));
+        );
+      });
+    });
+    describe('when requested content type has a parameter', () => {
+      it('should return an unparametrised version', () => {
+        assertSome(
+          findBestHttpContentByMediaType([{ mediaType: 'application/json' }], ['application/json; version=1'])
+        );
+      });
     });
   });
 

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -15,6 +15,8 @@ import { IHttpNegotiationResult, NegotiationOptions } from '../types';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 
 const chance = new Chance();
+const chanceOptions: Partial<Chance.StringOptions> = { length: 8, casing: 'lower', alpha: true, numeric: false };
+
 const logger = createLogger('TEST', { enabled: false });
 
 const assertPayloadlessResponse = (actualResponse: E.Either<Error, IHttpNegotiationResult>) => {
@@ -61,7 +63,7 @@ describe('NegotiatorHelpers', () => {
   describe('negotiateOptionsForInvalidRequest()', () => {
     describe('and 422 response exists', () => {
       const actualCode = '422';
-      const actualMediaType = `${chance.string()}/${chance.string()}`;
+      const actualMediaType = `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`;
       const actualExampleKey = chance.string();
 
       test('and has static examples defined should return the first static example', () => {
@@ -190,7 +192,7 @@ describe('NegotiatorHelpers', () => {
               headers: [],
               contents: [
                 {
-                  mediaType: `${chance.string()}/${chance.string()}`,
+                  mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
                   examples: [
                     { key: chance.string(), value: '', externalValue: '' },
                     { key: chance.string(), value: '', externalValue: '' },
@@ -214,7 +216,7 @@ describe('NegotiatorHelpers', () => {
               headers: [],
               contents: [
                 {
-                  mediaType: `${chance.string()}/${chance.string()}`,
+                  mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
                   examples: [
                     { key: chance.string(), value: '', externalValue: '' },
                     { key: chance.string(), value: '', externalValue: '' },
@@ -453,7 +455,7 @@ describe('NegotiatorHelpers', () => {
     describe('given forced mediaType', () => {
       it('and httpContent exists should negotiate that contents', () => {
         const desiredOptions = {
-          mediaTypes: [`${chance.string()}/${chance.string()}`],
+          mediaTypes: [`${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`],
           dynamic: chance.bool(),
           exampleKey: chance.string(),
         };
@@ -555,7 +557,7 @@ describe('NegotiatorHelpers', () => {
         });
       });
 
-      describe('the response exists, but there is no httpContent', () => {
+      describe.only('the response exists, but there is no httpContent', () => {
         const httpResponseSchema: IHttpOperationResponse = {
           code: '200',
           contents: [],
@@ -578,7 +580,7 @@ describe('NegotiatorHelpers', () => {
 
         it('should throw an error', () => {
           const desiredOptions: NegotiationOptions = {
-            mediaTypes: [`${chance.string()}/${chance.string()}`],
+            mediaTypes: [`${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`],
             dynamic: chance.bool(),
             exampleKey: chance.string(),
           };
@@ -803,7 +805,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       };
 
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [bodyExample],
         encodings: [],
       };
@@ -829,7 +831,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: chance.bool(),
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [],
         encodings: [],
       };
@@ -848,7 +850,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [],
         schema: { type: 'string' },
         encodings: [],
@@ -871,7 +873,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [],
         encodings: [],
       };
@@ -898,7 +900,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         externalValue: '',
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [
           bodyExample,
           {
@@ -928,7 +930,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         code: '200',
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [],
         schema: { type: 'string' },
         encodings: [],
@@ -952,7 +954,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       };
 
       const httpContent: IMediaTypeContent = {
-        mediaType: `${chance.string()}/${chance.string()}`,
+        mediaType: `${chance.string(chanceOptions)}/${chance.string(chanceOptions)}`,
         examples: [],
         encodings: [],
       };

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -560,7 +560,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualResponse = helpers.negotiateOptionsBySpecificResponse(
-            { ...httpOperation, responses: [{ code: '200', contents: [{ mediaType: 'text/plain ' }] }] },
+            httpOperation,
             desiredOptions,
             httpResponseSchema
           )(logger);
@@ -602,7 +602,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualResponse = helpers.negotiateOptionsBySpecificResponse(
-            { ...httpOperation, responses: [{ code: '200', contents: [{ mediaType: 'text/plain ' }] }] },
+            httpOperation,
             desiredOptions,
             httpResponseSchema
           )(logger);

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -773,8 +773,8 @@ describe('NegotiatorHelpers', () => {
           assertSome(
             findBestHttpContentByMediaType(
               [
-                { mediaType: 'application/json; version=1; q=1' },
                 { mediaType: 'application/json; version=1; q=0.6' },
+                { mediaType: 'application/json; version=1; q=1' },
                 { mediaType: 'application/vnd+json; version=1; q=0.5' },
               ],
               ['application/json']

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -322,7 +322,11 @@ describe('NegotiatorHelpers', () => {
       const actualOperationConfig = helpers.negotiateOptionsBySpecificCode(httpOperation, desiredOptions, code)(logger);
 
       expect(negotiateOptionsBySpecificResponseMock).toHaveBeenCalledTimes(1);
-      expect(negotiateOptionsBySpecificResponseMock).toHaveBeenCalledWith(httpOperation, desiredOptions, fakeResponse);
+      expect(negotiateOptionsBySpecificResponseMock).toHaveBeenCalledWith(
+        httpOperation.method,
+        desiredOptions,
+        fakeResponse
+      );
       expect(negotiateOptionsForDefaultCodeMock).not.toHaveBeenCalled();
       assertRight(actualOperationConfig, operationConfig => {
         expect(operationConfig).toEqual(fakeOperationConfig);
@@ -348,7 +352,11 @@ describe('NegotiatorHelpers', () => {
       const actualOperationConfig = helpers.negotiateOptionsBySpecificCode(httpOperation, desiredOptions, code)(logger);
 
       expect(negotiateOptionsBySpecificResponseMock).toHaveBeenCalledTimes(1);
-      expect(negotiateOptionsBySpecificResponseMock).toHaveBeenCalledWith(httpOperation, desiredOptions, fakeResponse);
+      expect(negotiateOptionsBySpecificResponseMock).toHaveBeenCalledWith(
+        httpOperation.method,
+        desiredOptions,
+        fakeResponse
+      );
       expect(negotiateOptionsForDefaultCodeMock).toHaveBeenCalledTimes(1);
       expect(negotiateOptionsForDefaultCodeMock).toHaveBeenCalledWith(httpOperation, desiredOptions);
       assertRight(actualOperationConfig, operationConfig => {

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -14,6 +14,7 @@ import helpers from '../NegotiatorHelpers';
 import { IHttpNegotiationResult, NegotiationOptions } from '../types';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { findBestHttpContentByMediaType } from '../InternalHelpers';
+import * as contentType from 'content-type';
 
 const chance = new Chance();
 const chanceOptions: Partial<Chance.StringOptions> = { length: 8, casing: 'lower', alpha: true, numeric: false };
@@ -752,11 +753,35 @@ describe('NegotiatorHelpers', () => {
   });
 
   describe('findBestHttpContentByMediaType()', () => {
-    describe('when avaiable content types have a parameter', () => {
+    describe('when avaiable content types has a non standard parameter', () => {
       it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1' }], ['application/json'])
         );
+      });
+    });
+
+    describe('when avaiable content types has the Q and a non standard parameter', () => {
+      it('should return an unparametrised version', () => {
+        assertSome(
+          findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1; q=0.6' }], ['application/json'])
+        );
+      });
+
+      describe('multiple media types avaiable', () => {
+        it('will still give preference with the q parameter', () => {
+          assertSome(
+            findBestHttpContentByMediaType(
+              [
+                { mediaType: 'application/json; version=1; q=1' },
+                { mediaType: 'application/json; version=1; q=0.6' },
+                { mediaType: 'application/vnd+json; version=1; q=0.5' },
+              ],
+              ['application/json']
+            ),
+            mt => expect(mt).toHaveProperty('mediaType', 'application/json; version=1; q=1')
+          );
+        });
       });
     });
 

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -61,7 +61,7 @@ describe('NegotiatorHelpers', () => {
   describe('negotiateOptionsForInvalidRequest()', () => {
     describe('and 422 response exists', () => {
       const actualCode = '422';
-      const actualMediaType = chance.string();
+      const actualMediaType = `${chance.string()}/${chance.string()}`;
       const actualExampleKey = chance.string();
 
       test('and has static examples defined should return the first static example', () => {
@@ -190,7 +190,7 @@ describe('NegotiatorHelpers', () => {
               headers: [],
               contents: [
                 {
-                  mediaType: chance.string(),
+                  mediaType: `${chance.string()}/${chance.string()}`,
                   examples: [
                     { key: chance.string(), value: '', externalValue: '' },
                     { key: chance.string(), value: '', externalValue: '' },
@@ -214,7 +214,7 @@ describe('NegotiatorHelpers', () => {
               headers: [],
               contents: [
                 {
-                  mediaType: chance.string(),
+                  mediaType: `${chance.string()}/${chance.string()}`,
                   examples: [
                     { key: chance.string(), value: '', externalValue: '' },
                     { key: chance.string(), value: '', externalValue: '' },
@@ -578,7 +578,7 @@ describe('NegotiatorHelpers', () => {
 
         it('should throw an error', () => {
           const desiredOptions: NegotiationOptions = {
-            mediaTypes: [chance.string()],
+            mediaTypes: [`${chance.string()}/${chance.string()}`],
             dynamic: chance.bool(),
             exampleKey: chance.string(),
           };
@@ -803,7 +803,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       };
 
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [bodyExample],
         encodings: [],
       };
@@ -829,7 +829,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: chance.bool(),
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [],
         encodings: [],
       };
@@ -848,7 +848,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [],
         schema: { type: 'string' },
         encodings: [],
@@ -871,7 +871,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [],
         encodings: [],
       };
@@ -898,7 +898,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         externalValue: '',
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [
           bodyExample,
           {
@@ -928,7 +928,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         code: '200',
       };
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [],
         schema: { type: 'string' },
         encodings: [],
@@ -952,7 +952,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       };
 
       const httpContent: IMediaTypeContent = {
-        mediaType: chance.string(),
+        mediaType: `${chance.string()}/${chance.string()}`,
         examples: [],
         encodings: [],
       };

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -9,10 +9,11 @@ import {
 import { Chance } from 'chance';
 import * as E from 'fp-ts/lib/Either';
 import { left, right } from 'fp-ts/lib/ReaderEither';
-import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
+import { assertRight, assertLeft, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import helpers from '../NegotiatorHelpers';
 import { IHttpNegotiationResult, NegotiationOptions } from '../types';
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
+import { findBestHttpContentByMediaType } from '../InternalHelpers';
 
 const chance = new Chance();
 const chanceOptions: Partial<Chance.StringOptions> = { length: 8, casing: 'lower', alpha: true, numeric: false };
@@ -747,6 +748,15 @@ describe('NegotiatorHelpers', () => {
           expect(result).toEqual(expectedResponse);
         });
       });
+    });
+  });
+
+  describe('findBestHttpContentByMediaType()', () => {
+    describe('when used in a mixed parameter situation', () => {
+      it('should return an unparametrised version', () =>
+        assertSome(
+          findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1' }], ['application/json'])
+        ));
     });
   });
 

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -471,7 +471,7 @@ describe('NegotiatorHelpers', () => {
         jest.spyOn(helpers, 'negotiateDefaultMediaType');
 
         const actualOperationConfig = helpers.negotiateOptionsBySpecificResponse(
-          httpOperation,
+          httpOperation.method,
           desiredOptions,
           httpResponseSchema
         )(logger);
@@ -511,7 +511,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualOperationConfig = helpers.negotiateOptionsBySpecificResponse(
-            httpOperation,
+            httpOperation.method,
             desiredOptions,
             httpResponseSchema
           )(logger);
@@ -538,7 +538,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualOperationConfig = helpers.negotiateOptionsBySpecificResponse(
-            httpOperation,
+            httpOperation.method,
             desiredOptions,
             httpResponseSchema
           )(logger);
@@ -560,7 +560,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualResponse = helpers.negotiateOptionsBySpecificResponse(
-            httpOperation,
+            httpOperation.method,
             desiredOptions,
             httpResponseSchema
           )(logger);
@@ -576,7 +576,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualResponse = helpers.negotiateOptionsBySpecificResponse(
-            httpOperation,
+            httpOperation.method,
             desiredOptions,
             httpResponseSchema
           )(logger);
@@ -602,7 +602,7 @@ describe('NegotiatorHelpers', () => {
           };
 
           const actualResponse = helpers.negotiateOptionsBySpecificResponse(
-            httpOperation,
+            httpOperation.method,
             desiredOptions,
             httpResponseSchema
           )(logger);
@@ -636,7 +636,7 @@ describe('NegotiatorHelpers', () => {
         jest.spyOn(helpers, 'negotiateDefaultMediaType').mockReturnValue(E.right(fakeOperationConfig));
 
         const actualOperationConfig = helpers.negotiateOptionsBySpecificResponse(
-          httpOperation,
+          httpOperation.method,
           desiredOptions,
           httpResponseSchema
         )(logger);

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -558,7 +558,7 @@ describe('NegotiatorHelpers', () => {
         });
       });
 
-      describe.only('the response exists, but there is no httpContent', () => {
+      describe('the response exists, but there is no httpContent', () => {
         const httpResponseSchema: IHttpOperationResponse = {
           code: '200',
           contents: [],
@@ -759,6 +759,7 @@ describe('NegotiatorHelpers', () => {
         );
       });
     });
+
     describe('when requested content type has a parameter', () => {
       it('should return an unparametrised version', () => {
         assertSome(

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -531,7 +531,7 @@ describe('NegotiatorHelpers', () => {
           assertRight(actualOperationConfig, config => expect(config).toHaveProperty('mediaType', 'application/xml'));
         });
 
-        it('should negotiatiate the only content that is really avaiable', () => {
+        it('should negotiatiate the only content that is really available', () => {
           const desiredOptions: NegotiationOptions = {
             mediaTypes: ['application/idonotexist', 'application/json'],
             dynamic: false,
@@ -677,7 +677,7 @@ describe('NegotiatorHelpers', () => {
         ['*/*', 'application/xml'],
         ['*/*', 'application/json'],
         ['application/json', 'application/xml'],
-      ])('should return %s even when %s is avaiable', (defaultMediaType, alternateMediaType) => {
+      ])('should return %s even when %s is available', (defaultMediaType, alternateMediaType) => {
         const code = chance.string();
         const partialOptions = {
           code,
@@ -753,7 +753,7 @@ describe('NegotiatorHelpers', () => {
   });
 
   describe('findBestHttpContentByMediaType()', () => {
-    describe('when avaiable content types has a non standard parameter', () => {
+    describe('when available content types has a non standard parameter', () => {
       it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1' }], ['application/json'])
@@ -761,14 +761,14 @@ describe('NegotiatorHelpers', () => {
       });
     });
 
-    describe('when avaiable content types has the Q and a non standard parameter', () => {
+    describe('when available content types has the Q and a non standard parameter', () => {
       it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType([{ mediaType: 'application/json; version=1; q=0.6' }], ['application/json'])
         );
       });
 
-      describe('multiple media types avaiable', () => {
+      describe('multiple media types available', () => {
         it('will still give preference with the q parameter', () => {
           assertSome(
             findBestHttpContentByMediaType(

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -285,7 +285,7 @@ describe('HttpValidator', () => {
 });
 
 describe('validateMediaType()', () => {
-  describe('when avaiable content type does not have parameters', () => {
+  describe('when available content type does not have parameters', () => {
     const content: IMediaTypeContent = {
       mediaType: 'application/vnd.archa.api+json',
     };

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -1,5 +1,5 @@
 import { IPrismDiagnostic } from '@stoplight/prism-core';
-import { DiagnosticSeverity, IHttpOperation, HttpParamStyles } from '@stoplight/types';
+import { DiagnosticSeverity, IHttpOperation, HttpParamStyles, IMediaTypeContent } from '@stoplight/types';
 import * as E from 'fp-ts/lib/Either';
 import { IHttpRequest } from '../../types';
 import * as validator from '../index';
@@ -280,6 +280,20 @@ describe('HttpValidator', () => {
           );
         });
       });
+    });
+  });
+});
+
+describe('#validateMediaType', () => {
+  describe('when avaiable content type does not have parameters', () => {
+    const content: IMediaTypeContent = {
+      mediaType: 'application/vnd.archa.api+json',
+    };
+
+    describe('and the requeste media type matches, but has parameter', () => {
+      const result = validator.validateMediaType([content], 'application/vnd.archa.api+json; version=1');
+
+      it('should pass the validation', () => assertRight(result));
     });
   });
 });

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -291,9 +291,10 @@ describe('validateMediaType()', () => {
     };
 
     describe('and the requeste media type matches, but has parameter', () => {
-      const result = validator.validateMediaType([content], 'application/vnd.archa.api+json; version=1');
-
-      it('should pass the validation', () => assertRight(result));
+      it('should pass the validation', () => {
+        const result = validator.validateMediaType([content], 'application/vnd.archa.api+json; version=1');
+        assertRight(result);
+      });
     });
   });
 });

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -284,7 +284,7 @@ describe('HttpValidator', () => {
   });
 });
 
-describe('#validateMediaType', () => {
+describe('validateMediaType()', () => {
   describe('when avaiable content type does not have parameters', () => {
     const content: IMediaTypeContent = {
       mediaType: 'application/vnd.archa.api+json',

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -290,7 +290,7 @@ describe('validateMediaType()', () => {
       mediaType: 'application/vnd.archa.api+json',
     };
 
-    describe('and the requeste media type matches, but has parameter', () => {
+    describe('and the request media type matches, but has parameter', () => {
       it('should pass the validation', () => {
         const result = validator.validateMediaType([content], 'application/vnd.archa.api+json; version=1');
         assertRight(result);

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -96,7 +96,7 @@ const findResponseByStatus = (responses: IHttpOperationResponse[], statusCode: n
     E.mapLeft<IPrismDiagnostic, NonEmptyArray<IPrismDiagnostic>>(error => [error])
   );
 
-const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
+export const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
     DoOption.bind('parsedMediaType', pipe(O.fromNullable(mediaType), O.map(contentType.parse)))
       .doL(({ parsedMediaType }) =>

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -95,16 +95,20 @@ const findResponseByStatus = (responses: IHttpOperationResponse[], statusCode: n
 
 const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
-    contents,
-    findFirst(c => {
-      const parsedMediaType = contentType.parse(mediaType);
-      const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
-
-      return (
-        !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
-        isEqual(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
-      );
-    }),
+    O.fromNullable(mediaType),
+    O.chain(() =>
+      pipe(
+        contents,
+        findFirst(c => {
+          const parsedMediaType = contentType.parse(mediaType);
+          const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
+          return (
+            !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
+            isEqual(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
+          );
+        })
+      )
+    ),
     E.fromOption<IPrismDiagnostic>(() => ({
       message: `The received media type "${mediaType || ''}" does not match the one${
         contents.length > 1 ? 's' : ''

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -13,7 +13,7 @@ import * as O from 'fp-ts/lib/Option';
 import * as E from 'fp-ts/lib/Either';
 import { is as typeIs } from 'type-is';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { inRange, isEqual } from 'lodash';
+import { inRange, isMatch } from 'lodash';
 import { validateSecurity } from './validators/security';
 import { URI } from 'uri-template-lite';
 
@@ -104,7 +104,7 @@ const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType
           const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
           return (
             !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
-            isEqual(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
+            isMatch(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
           );
         })
       )

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -96,7 +96,7 @@ const findResponseByStatus = (responses: IHttpOperationResponse[], statusCode: n
 const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
     O.fromNullable(mediaType),
-    O.map(mediaType => contentType.parse(mediaType)),
+    O.map(contentType.parse),
     O.chain(parsedMediaType =>
       pipe(
         contents,

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -96,11 +96,11 @@ const findResponseByStatus = (responses: IHttpOperationResponse[], statusCode: n
 const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
     O.fromNullable(mediaType),
-    O.chain(() =>
+    O.map(mediaType => contentType.parse(mediaType)),
+    O.chain(parsedMediaType =>
       pipe(
         contents,
         findFirst(c => {
-          const parsedMediaType = contentType.parse(mediaType);
           const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
           return (
             !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -11,6 +11,7 @@ import * as contentType from 'content-type';
 import { findFirst, isNonEmpty } from 'fp-ts/lib/Array';
 import * as O from 'fp-ts/lib/Option';
 import * as E from 'fp-ts/lib/Either';
+import { Do } from 'fp-ts-contrib/lib/Do';
 import { is as typeIs } from 'type-is';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { inRange, isMatch } from 'lodash';
@@ -28,6 +29,8 @@ import { HttpBodyValidator, HttpHeadersValidator, HttpQueryValidator } from './v
 import { NonEmptyArray } from 'fp-ts/lib/NonEmptyArray';
 import { sequenceValidation, sequenceOption } from './validators/utils';
 import { HttpPathValidator } from './validators/path';
+
+const DoOption = Do(O.option);
 
 export const bodyValidator = new HttpBodyValidator('body');
 export const headersValidator = new HttpHeadersValidator(headerDeserializerRegistry, 'header');
@@ -95,20 +98,20 @@ const findResponseByStatus = (responses: IHttpOperationResponse[], statusCode: n
 
 const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
-    O.fromNullable(mediaType),
-    O.map(contentType.parse),
-    O.chain(parsedMediaType =>
-      pipe(
-        contents,
-        findFirst(c => {
-          const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
-          return (
-            !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
-            isMatch(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
-          );
-        })
+    DoOption.bind('parsedMediaType', pipe(O.fromNullable(mediaType), O.map(contentType.parse)))
+      .doL(({ parsedMediaType }) =>
+        pipe(
+          contents,
+          findFirst(c => {
+            const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
+            return (
+              !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
+              isMatch(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
+            );
+          })
+        )
       )
-    ),
+      .done(),
     E.fromOption<IPrismDiagnostic>(() => ({
       message: `The received media type "${mediaType || ''}" does not match the one${
         contents.length > 1 ? 's' : ''

--- a/test-harness/specs/content-negotiation/E2E-Accept-Content-Negotiation-AC-16.oas3.txt
+++ b/test-harness/specs/content-negotiation/E2E-Accept-Content-Negotiation-AC-16.oas3.txt
@@ -1,0 +1,31 @@
+====test====
+When I send a request (with no Accept header) to an operation
+And this operation defines some responses
+Then I should get back the first response defined for that operation
+And this response should have 200 status code
+====spec====
+openapi: 3.0.0
+paths:
+  /get:
+    get:
+      responses:
+        '200':
+          description: Created
+          content:
+            application/vnd.archa.api+json:
+              schema:
+                required:
+                  - value
+                properties:
+                  value:
+                    type: string
+                    example: "hello"
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i http://127.0.0.1:4010/get -H 'Accept: application/vnd.archa.api+json; version=1'
+====expect====
+HTTP/1.1 200 OK
+content-type: application/vnd.archa.api+json
+
+{"value":"hello"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,6 +1535,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/content-type@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/content-type/-/content-type-1.1.3.tgz#3688bd77fc12f935548eef102a4e34c512b03a07"
+  integrity sha512-pv8VcFrZ3fN93L4rTNIbbUzdkzjEyVMp5mPVjsFfOYTDOZMZiZ8P1dhu+kEv3faYyKzZgLlSvnyQNFg+p/v5ug==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2785,7 +2790,7 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-content-type@1.0.4:
+content-type@1.0.4, content-type@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==


### PR DESCRIPTION
This pull request implements a backup strategy to ignore parameters in content type when is possible. Since they're not standard (apart for the `q` value) we won't assume anything about it and drop them in some cases

Closes #1152 