### PR TITLE
Correctly lookup the properties in lowercase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,9 @@ jobs:
           command: yarn build
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
+          name: Publish on the beta tag
+          command: yarn lerna publish $(npx semver --preid beta -i prerelease $(npm show @stoplight/prism-cli@beta version)) --no-push --no-git-tag-version --dist-tag beta -y
+      - run:
           name: Publish
           command: yarn lerna publish from-git --create-release=github --yes
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixed
 
-- Prism is not returning an error anymore when trying to construct a schema for HTTP headers and querystring with mixed cases property names [#1268](https://github.com/stoplightio/prism/pull/1268)
+- Prism is not returning an error anymore when trying to construct a schema for HTTP headers and query string with mixed cases property names [#1268](https://github.com/stoplightio/prism/pull/1268)
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+## Fixed
+
+- Prism is not returning an error anymore when trying to construct a schema for HTTP headers and querystring with mixed cases property names [#1268](https://github.com/stoplightio/prism/pull/1268)
+
 ## Changed
 
 - **BREAKING**: The `getHttpOperationsFromSpec` has been moved from the HTTP Package to the CLI package. If you're using Prism programmatically, this might require some code changes on your side. `getHttpOperationsFromResource` has been removed. [#1009](https://github.com/stoplightio/prism/pull/1009), [#1192](https://github.com/stoplightio/prism/pull/1192)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "release": "lerna version",
     "prerelease:beta": "yarn build",
-    "release:beta": "lerna publish --preid beta --force-publish=* --no-push --no-git-tag-version --dist-tag beta",
+    "release:beta": "lerna publish $(npx semver --preid beta -i prerelease $(npm show @stoplight/prism-cli@beta version)) --force-publish=* --no-push --no-git-tag-version --dist-tag beta",
     "prebuild.binary": "yarn build",
     "build.binary": "npx pkg --output ./cli-binaries/prism-cli ./packages/cli/",
     "test.harness": "jest -c ./jest.harness.config.js"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "posttest": "yarn lint",
     "test": "jest",
     "release": "lerna version",
-    "prerelease:beta": "yarn build",
-    "release:beta": "lerna publish $(npx semver --preid beta -i prerelease $(npm show @stoplight/prism-cli@beta version)) --force-publish=* --no-push --no-git-tag-version --dist-tag beta",
     "prebuild.binary": "yarn build",
     "build.binary": "npx pkg --output ./cli-binaries/prism-cli ./packages/cli/",
     "test.harness": "jest -c ./jest.harness.config.js"

--- a/packages/http/src/validator/validators/params.ts
+++ b/packages/http/src/validator/validators/params.ts
@@ -74,11 +74,11 @@ function createJsonSchemaFromParams(params: IHttpParam[]): O.Option<JSONSchema> 
       type: 'object',
       properties: pickBy(
         mapValues(
-          keyBy(params, p => p.name.toLowerCase()),
+          keyBy(params, p => p.name),
           'schema'
         )
       ) as JSONSchema4,
-      required: compact(params.map(m => (m.required ? m.name.toLowerCase() : undefined))),
+      required: compact(params.map(m => (m.required ? m.name : undefined))),
     }))
   );
 }

--- a/packages/http/src/validator/validators/params.ts
+++ b/packages/http/src/validator/validators/params.ts
@@ -32,8 +32,8 @@ export class HttpParamsValidator<Target> implements IHttpValidator<Target, IHttp
 
     return pipe(
       NEA.fromArray(specs),
-      O.map(spec => {
-        const schema = createJsonSchemaFromParams(spec);
+      O.map(specs => {
+        const schema = createJsonSchemaFromParams(specs);
         const parameterValues = pickBy(
           mapValues(
             keyBy(specs, s => s.name.toLowerCase()),

--- a/packages/http/src/validator/validators/params.ts
+++ b/packages/http/src/validator/validators/params.ts
@@ -48,7 +48,7 @@ export class HttpParamsValidator<Target> implements IHttpValidator<Target, IHttp
                   // the validators a bit
                   // @ts-ignore
                   mapKeys(target, (_value, key) => key.toLowerCase()),
-                  schema.properties && (schema.properties[el.name] as JSONSchema4),
+                  schema.properties && (schema.properties[el.name.toLowerCase()] as JSONSchema4),
                   el.explode || false
                 );
 
@@ -73,10 +73,10 @@ function createJsonSchemaFromParams(params: NEA.NonEmptyArray<IHttpParam>): JSON
     type: 'object',
     properties: pickBy(
       mapValues(
-        keyBy(params, p => p.name),
+        keyBy(params, p => p.name.toLocaleLowerCase()),
         'schema'
       )
     ) as JSONSchema4,
-    required: compact(params.map(m => (m.required ? m.name : undefined))),
+    required: compact(params.map(m => (m.required ? m.name.toLowerCase() : undefined))),
   };
 }

--- a/test-harness/specs/validate-query-params/query-param-upper-case.oas2.txt
+++ b/test-harness/specs/validate-query-params/query-param-upper-case.oas2.txt
@@ -1,0 +1,32 @@
+====test====
+When I send a request to an operation
+And the operation has a query param specified in mixed between lowercase and uppercase
+And in the request I sent that param is present in a different casing
+It should still pass the validation
+====spec====
+swagger: '2.0'
+produces:
+  - application/json
+paths:
+  "/v1/test":
+    get:
+      parameters:
+      - collectionFormat: csv
+        in: query
+        items:
+          format: uuid
+          type: string
+        name: filter[somethingId]
+        required: false
+        type: array
+      responses:
+        '200':
+          description: OK
+          examples:
+            error: false
+====server====
+mock -p 4010 ${document}
+====command====
+curl -sIXGET http://127.0.0.1:4010/v1/test?somethingid=04fc0172-1943-4c38-8e0f-36935e05b8dd
+====expect====
+HTTP/1.1 200 OK


### PR DESCRIPTION
Closes #1267 

- Correctly lookup properties in lower case (this happens because query string and headers are case insensitive)
- Make the `createJsonSchema` function pure
- Auto publishes the master branch under the `beta` tag automagically