### PR TITLE
explicit accept encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - Prism will now refuse to start in case it will detect circular references. [#1270](https://github.com/stoplightio/prism/pull/1270)
-- Prism's Proxy feature will stop proactively requesting Compressed responses, following what is really in the OAS document [#1309](https://github.com/stoplightio/prism/pull/1309)
+- Prism's Proxy feature will stop proactively requesting Compressed responses, following what is really in the OAS document [#1309](https://github.com/stoplightio/prism/pull/1309),[#1319](https://github.com/stoplightio/prism/pull/1319)
 
 ## Changed
 

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -45,10 +45,10 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
         logger.info(`Forwarding "${input.method}" request to ${url}...`);
 
         return fetch(url, {
-          compress: false,
           body,
           method: input.method,
           headers: defaults(omit(input.headers, ['host']), {
+            'accept-encoding': '*',
             accept: 'application/json, text/plain, */*',
             'user-agent': `Prism/${prismVersion}`,
           }),


### PR DESCRIPTION
Removing the compress flag will not only disable requesting compressed content but also disable the unzipping in case somebody is requesting it.

The correct solution Is to provide a default `accept-encoding` header so that `node-fetch` won't try to override it.