### PR TITLE
Remove path start error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Changed
 
 - Prism is now able to take in consideration all the responses defined for a request (typical in Postman Collection) and respond in a more appropriate way [#1310](https://github.com/stoplightio/prism/pull/1310)
+- Prism is now stop to claim error for paths declared in the document that are not starting with a `/` [#1340](https://github.com/stoplightio/prism/pull/1340)
 
-- **BREAKING**: The `getHttpOperationsFromSpec` has been moved from the HTTP Package to the CLI package. If you're using Prism programmatically, this might require some code changes on your side. `getHttpOperationsFromResource` has been removed. [#1009](https://github.com/stoplightio/prism/pull/1009), [#1192](https://github.com/stoplightio/prism/pull/1192)
-- **BREAKING**: The `createClientFromOperations` is now exported as `export function` instead of exporting an object. If you're using Prism programmatically, this might require some code changes on your side [#1009](https://github.com/stoplightio/prism/pull/1009)
+* **BREAKING**: The `getHttpOperationsFromSpec` has been moved from the HTTP Package to the CLI package. If you're using Prism programmatically, this might require some code changes on your side. `getHttpOperationsFromResource` has been removed. [#1009](https://github.com/stoplightio/prism/pull/1009), [#1192](https://github.com/stoplightio/prism/pull/1192)
+* **BREAKING**: The `createClientFromOperations` is now exported as `export function` instead of exporting an object. If you're using Prism programmatically, this might require some code changes on your side [#1009](https://github.com/stoplightio/prism/pull/1009)
 
 # 3.3.6 (2020-07-08)
 

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -7,26 +7,6 @@ import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/uti
 const chance = new Chance();
 
 describe('matchPath()', () => {
-  test('request path must start with a slash or throw error', () => {
-    const requestPath = randomPath({ leadingSlash: true });
-    const operationPath = randomPath({ leadingSlash: false });
-    assertLeft(matchPath(requestPath, operationPath), e =>
-      expect(e.message).toBe(
-        `Given request path '${requestPath}' the operation path '${operationPath}' must start with a slash.`
-      )
-    );
-  });
-
-  test('operation path must start with a slash or throw error', () => {
-    const requestPath = randomPath({ leadingSlash: true });
-    const operationPath = randomPath({ leadingSlash: false });
-    assertLeft(matchPath(requestPath, operationPath), e =>
-      expect(e.message).toBe(
-        `Given request path '${requestPath}' the operation path '${operationPath}' must start with a slash.`
-      )
-    );
-  });
-
   test('root path should match another root path', () => {
     const path = '/';
     assertRight(matchPath(path, path), e => expect(e).toEqual(MatchType.CONCRETE));

--- a/packages/http/src/router/matchPath.ts
+++ b/packages/http/src/router/matchPath.ts
@@ -11,11 +11,6 @@ function getTemplateParamName(pathFragment: string) {
 }
 
 export function matchPath(requestPath: string, operationPath: string): E.Either<Error, MatchType> {
-  if (!operationPath.startsWith('/')) {
-    return E.left(
-      new Error(`Given request path '${requestPath}' the operation path '${operationPath}' must start with a slash.`)
-    );
-  }
   const operationPathFragments = fragmentarize(operationPath);
   const requestPathFragments = fragmentarize(requestPath);
 


### PR DESCRIPTION
Remove path start error, since there is nothing we can do from the Prism side and it's only harming our Sentry logs.