### PR TITLE
Docs: document mock options

### DIFF
--- a/docs/guides/http-client.md
+++ b/docs/guides/http-client.md
@@ -81,7 +81,8 @@ The response object has all the information you need, including the used configu
 2. You can override the configuration object on the request level if you prefer
 
 ```ts
-client.request('https://google.it', { method: 'get' }, { validateResponse: false }).then(console.log);
+const config = { validateResponse: false };
+client.request('https://google.it', { method: 'get' }, config).then(console.log);
 ```
 
 This disables response validation _only for the current request_

--- a/docs/guides/http-client.md
+++ b/docs/guides/http-client.md
@@ -73,7 +73,7 @@ Once you've got a client instance:
 1. You can perform the request using the generic method:
 
 ```ts
-client.request('https://google.it', { method: 'get' }).then(response => console.log(response));
+client.request('https://google.it', { method: 'get' }).then(console.log);
 ```
 
 The response object has all the information you need, including the used configuration object.
@@ -81,9 +81,7 @@ The response object has all the information you need, including the used configu
 2. You can override the configuration object on the request level if you prefer
 
 ```ts
-client
-  .request('https://google.it', { method: 'get' }, { validateResponse: false })
-  .then(response => console.log(response));
+client.request('https://google.it', { method: 'get' }, { validateResponse: false }).then(console.log);
 ```
 
 This disables response validation _only for the current request_
@@ -91,30 +89,30 @@ This disables response validation _only for the current request_
 3. You can do the same thing using the shortcut methods
 
 ```ts
-client.get('https://google.it', { mock: false }).then(response => console.log(response));
+client.get('https://google.it', { mock: false }).then(console.log);
 ```
 
 For the shortcut methods (since the only mandatory option is intrinsic in the function name) the option parameter can be omitted
 
 ```ts
-client.get('https://google.it', { validateRequest: false }).then(response => console.log(response));
+client.get('https://google.it', { validateRequest: false }).then(console.log);
 ```
 
 You can also use relative links when doing requests. In such case you won't be able to use the proxy and the server validation will be disabled:
 
 ```ts
-client.get('/users/10', { validateRequest: false }).then(response => console.log(response));
+client.get('/users/10', { validateRequest: false }).then(console.log);
 ```
 
 …or you can also set the base path in the options object:
 
 ```ts
-client.get('/users/10', { baseUrl: 'https://api.stoplight.io/' }).then(response => console.log(response));
+client.get('/users/10', { baseUrl: 'https://api.stoplight.io/' }).then(console.log);
 ```
 
 4. You can also change the mock options for the current request, or set the flag to false to indicate that you want to proxy to an uptream server:
 
 ```ts
-client.request('https://google.it', { method: 'get' }, { mock: { dynamic: true } }).then(response => console.log(response));
-client.request('https://google.it', { method: 'get' }, { mock: false, upstream: new URL('https://api.example.com') ).then(response => console.log(response));
+client.request('https://google.it', { method: 'get' }, { mock: { dynamic: true } }).then(console.log);
+client.request('https://google.it', { method: 'get' }, { mock: false, upstream: new URL('https://api.example.com') ).then(console.log);
 ```

--- a/docs/guides/http-client.md
+++ b/docs/guides/http-client.md
@@ -2,7 +2,7 @@
 
 Prism includes a HTTP Client that you can use to request data to both a real server or a mocked document. The client is modeled after Axios so it may feel familiar.
 
-### Create Client from File
+## Create Client from File
 
 Use the `getHttpOperationsFromSpec` method defined in the `@stoplight/prism-cli` package to create the required operations array from an OpenAPI spec:
 
@@ -40,7 +40,7 @@ const operations = await getHttpOperationsFromSpec(descriptionDoc);
 ...
 ```
 
-### Create Client from Manual HTTP Operations
+## Create Client from Manual HTTP Operations
 
 ```ts
 const { createClientFromOperations } = require('@stoplight/prism-http/dist/client');
@@ -68,9 +68,11 @@ const client = createClientFromOperations(
 
 ---
 
+## Example usages
+
 Once you've got a client instance:
 
-1. You can perform the request using the generic method:
+### Request using the generic method:
 
 ```ts
 client.request('https://google.it', { method: 'get' }).then(console.log);
@@ -78,7 +80,7 @@ client.request('https://google.it', { method: 'get' }).then(console.log);
 
 The response object has all the information you need, including the used configuration object.
 
-2. You can override the configuration object on the request level if you prefer
+### Override the configuration object on the request level
 
 ```ts
 const config = { validateResponse: false };
@@ -87,7 +89,7 @@ client.request('https://google.it', { method: 'get' }, config).then(console.log)
 
 This disables response validation _only for the current request_
 
-3. You can do the same thing using the shortcut methods
+You can do the same thing using the shortcut methods
 
 ```ts
 client.get('https://google.it', { mock: false }).then(console.log);
@@ -111,7 +113,7 @@ client.get('/users/10', { validateRequest: false }).then(console.log);
 client.get('/users/10', { baseUrl: 'https://api.stoplight.io/' }).then(console.log);
 ```
 
-4. You can also change the mock options for the current request, or set the flag to false to indicate that you want to proxy to an uptream server:
+### Set mocking options
 
 ```ts
 client.request('https://google.it', { method: 'get' }, { mock: { dynamic: true } }).then(console.log);

--- a/docs/guides/http-client.md
+++ b/docs/guides/http-client.md
@@ -1,6 +1,6 @@
 # Prism Client
 
-Prism includes a fully-featured HTTP Client that you can use to seamlessly perform requests to both a real server and a mocked document. The client is modeled after Axios so it may feel familiar.
+Prism includes a HTTP Client that you can use to request data to both a real server or a mocked document. The client is modeled after Axios so it may feel familiar.
 
 ### Create Client from File
 
@@ -110,4 +110,11 @@ client.get('/users/10', { validateRequest: false }).then(response => console.log
 
 ```ts
 client.get('/users/10', { baseUrl: 'https://api.stoplight.io/' }).then(response => console.log(response));
+```
+
+4. You can also change the mock options for the current request, or set the flag to false to indicate that you want to proxy to an uptream server:
+
+```ts
+client.request('https://google.it', { method: 'get' }, { mock: { dynamic: true } }).then(response => console.log(response));
+client.request('https://google.it', { method: 'get' }, { mock: false, upstream: new URL('https://api.example.com') ).then(response => console.log(response));
 ```


### PR DESCRIPTION
Let the user know that they can use the `mock` flag