### PR TITLE
Remove fp-ts-contrib

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,6 @@
     "chalk": "^4.0.0",
     "chokidar": "^3.4.2",
     "fp-ts": "^2.8.2",
-    "fp-ts-contrib": "^0.1.19",
     "json-schema-ref-parser": "^9.0.1",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",

--- a/packages/cli/src/combinators.ts
+++ b/packages/cli/src/combinators.ts
@@ -1,8 +1,6 @@
 import * as E from 'fp-ts/Either';
 import * as A from 'fp-ts/Array';
-import { Do } from 'fp-ts-contrib/lib/Do';
 import { sequenceS } from 'fp-ts/Apply';
 
 export const traverseEither = A.array.traverse(E.either);
 export const sequenceSEither = sequenceS(E.either);
-export const doEither = Do(E.either);

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -62,18 +62,18 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
     config: Config,
     validations: IPrismDiagnostic[]
   ): TE.TaskEither<Error, ResourceAndValidation & { output: Output }> => {
+    const mockCall = components.mock({
+      resource,
+      input: { data, validations },
+      config: config.mock,
+    });
+
     const produceOutput = isProxyConfig(config)
       ? components.forward(
           { validations: config.errors ? validations : [], data },
           config.upstream.href
         )(components.logger.child({ name: 'PROXY' }))
-      : TE.fromEither(
-          components.mock({
-            resource,
-            input: { data, validations },
-            config: config.mock,
-          })(components.logger.child({ name: 'NEGOTIATOR' }))
-        );
+      : TE.fromEither(mockCall(components.logger.child({ name: 'NEGOTIATOR' })));
 
     return pipe(
       produceOutput,

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -68,11 +68,11 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
       config: config.mock,
     });
 
+    const forwardCall = (config: IPrismProxyConfig) =>
+      components.forward({ validations: config.errors ? validations : [], data }, config.upstream.href);
+
     const produceOutput = isProxyConfig(config)
-      ? components.forward(
-          { validations: config.errors ? validations : [], data },
-          config.upstream.href
-        )(components.logger.child({ name: 'PROXY' }))
+      ? forwardCall(config)(components.logger.child({ name: 'PROXY' }))
       : TE.fromEither(mockCall(components.logger.child({ name: 'NEGOTIATOR' })));
 
     return pipe(

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -28,7 +28,6 @@
     "content-type": "^1.0.4",
     "faker": "^4.1.0",
     "fp-ts": "^2.8.2",
-    "fp-ts-contrib": "^0.1.19",
     "json-schema-faker": "0.5.0-rcv.29",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1",

--- a/packages/http/src/combinators.ts
+++ b/packages/http/src/combinators.ts
@@ -4,9 +4,7 @@ import * as A from 'fp-ts/Array';
 import { sequenceT } from 'fp-ts/Apply';
 import { getSemigroup } from 'fp-ts/NonEmptyArray';
 import { getValidation } from 'fp-ts/Either';
-import { Do } from 'fp-ts-contrib/lib/Do';
 
 export const traverseOption = A.array.traverse(O.option);
-export const doOption = Do(O.option);
 export const sequenceOption = sequenceT(O.option);
 export const sequenceValidation = sequenceT(getValidation(getSemigroup<IPrismDiagnostic>()));

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -32,7 +32,7 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
         : createUnprocessableEntityResponse(failedValidations);
     }),
     TE.swap,
-    TE.chain(() => TE.fromEither(serializeBody(input.body))),
+    TE.chainEitherK(() => serializeBody(input.body)),
     TE.chain(body =>
       TE.tryCatch(async () => {
         const partialUrl = parse(baseUrl);

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -7,7 +7,7 @@ import * as O from 'fp-ts/Option';
 import * as A from 'fp-ts/Array';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
-import { doOption, traverseOption } from '../../combinators';
+import { traverseOption } from '../../combinators';
 import { head } from 'fp-ts/Array';
 import { pipe } from 'fp-ts/pipeable';
 import { generate as generateHttpParam } from '../generator/HttpParamGenerator';
@@ -39,7 +39,6 @@ export function runCallback({
       ),
       TE.chainEitherK(element => {
         logger.info({ name: 'CALLBACK' }, `${callback.callbackName}: Request finished`);
-
         return pipe(
           validateOutput({ resource: callback, element }),
           E.mapLeft(violations => {
@@ -64,8 +63,8 @@ function assembleRequest({
   return {
     url: resolveRuntimeExpressions(resource.path, request, response),
     requestData: {
-      headers: O.toUndefined(assembleHeaders(resource.request, bodyAndMediaType && bodyAndMediaType.mediaType)),
-      body: bodyAndMediaType && bodyAndMediaType.body,
+      headers: O.toUndefined(assembleHeaders(resource.request, bodyAndMediaType?.mediaType)),
+      body: bodyAndMediaType?.body,
       method: resource.method,
     },
   };
@@ -73,15 +72,9 @@ function assembleRequest({
 
 function assembleBody(request?: IHttpOperationRequest): O.Option<{ body: string; mediaType: string }> {
   return pipe(
-    O.fromNullable(request),
-    O.mapNullable(request => request.body),
-    O.mapNullable(body => body.contents),
-    O.chain(contents =>
-      doOption
-        .bind('content', head(contents))
-        .bindL('body', ({ content }) => generateHttpParam(content))
-        .done()
-    ),
+    O.fromNullable(request?.body?.contents),
+    O.bind('content', contents => head(contents)),
+    O.bind('body', ({ content }) => generateHttpParam(content)),
     O.chain(({ body, content: { mediaType } }) =>
       pipe(
         E.stringifyJSON(body, () => undefined),
@@ -92,21 +85,25 @@ function assembleBody(request?: IHttpOperationRequest): O.Option<{ body: string;
   );
 }
 
-function assembleHeaders(request?: IHttpOperationRequest, bodyMediaType?: string): O.Option<Dictionary<string>> {
-  return pipe(
-    O.fromNullable(request),
-    O.mapNullable(request => request.headers),
+const assembleHeaders = (request?: IHttpOperationRequest, bodyMediaType?: string): O.Option<Dictionary<string>> =>
+  pipe(
+    O.fromNullable(request?.headers),
     O.chain(params =>
-      traverseOption(params, param =>
-        doOption.bind('value', generateHttpParam(param)).return(({ value }) => [param.name, value])
-      )
-    ),
-    O.reduce(
       pipe(
-        O.fromNullable(bodyMediaType),
-        O.map(mediaType => ({ 'content-type': mediaType }))
-      ),
-      (mediaTypeHeader, headers) => ({ ...headers, ...mediaTypeHeader })
+        traverseOption(params, param =>
+          pipe(
+            generateHttpParam(param),
+            O.bindTo('value'),
+            O.map(({ value }) => [param.name, value])
+          )
+        ),
+        O.reduce(
+          pipe(
+            O.fromNullable(bodyMediaType),
+            O.map(mediaType => ({ 'content-type': mediaType }))
+          ),
+          (mediaTypeHeader, headers) => ({ ...headers, ...mediaTypeHeader })
+        )
+      )
     )
   );
-}

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -89,20 +89,18 @@ const assembleHeaders = (request?: IHttpOperationRequest, bodyMediaType?: string
   pipe(
     O.fromNullable(request?.headers),
     O.chain(params =>
-      pipe(
-        traverseOption(params, param =>
-          pipe(
-            generateHttpParam(param),
-            O.map(value => [param.name, value])
-          )
-        ),
-        O.reduce(
-          pipe(
-            O.fromNullable(bodyMediaType),
-            O.map(mediaType => ({ 'content-type': mediaType }))
-          ),
-          (mediaTypeHeader, headers) => ({ ...headers, ...mediaTypeHeader })
+      traverseOption(params, param =>
+        pipe(
+          generateHttpParam(param),
+          O.map(value => [param.name, value])
         )
       )
+    ),
+    O.reduce(
+      pipe(
+        O.fromNullable(bodyMediaType),
+        O.map(mediaType => ({ 'content-type': mediaType }))
+      ),
+      (mediaTypeHeader, headers) => ({ ...headers, ...mediaTypeHeader })
     )
   );

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -37,15 +37,14 @@ export function runCallback({
       TE.mapLeft(error =>
         logger.error({ name: 'CALLBACK' }, `${callback.callbackName}: Request failed: ${error.message}`)
       ),
-      TE.chain(element => {
+      TE.chainEitherK(element => {
         logger.info({ name: 'CALLBACK' }, `${callback.callbackName}: Request finished`);
 
         return pipe(
           validateOutput({ resource: callback, element }),
           E.mapLeft(violations => {
             pipe(violations, A.map(logViolation));
-          }),
-          TE.fromEither
+          })
         );
       })
     );

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -93,8 +93,7 @@ const assembleHeaders = (request?: IHttpOperationRequest, bodyMediaType?: string
         traverseOption(params, param =>
           pipe(
             generateHttpParam(param),
-            O.bindTo('value'),
-            O.map(({ value }) => [param.name, value])
+            O.map(value => [param.name, value])
           )
         ),
         O.reduce(

--- a/packages/http/src/utils/runtimeExpression.ts
+++ b/packages/http/src/utils/runtimeExpression.ts
@@ -110,7 +110,7 @@ export function resolveRuntimeExpression(
     return pipe(
       O.fromNullable(body),
       O.bindTo('body'),
-      O.bind('path', _ =>
+      O.bind('path', () =>
         pipe(
           lookup(2, parts),
           O.chain(part => O.tryCatch(() => pointerToPath('#' + part)))

--- a/packages/http/src/utils/runtimeExpression.ts
+++ b/packages/http/src/utils/runtimeExpression.ts
@@ -1,6 +1,5 @@
 import { IHttpRequest, IHttpResponse } from '../types';
 import * as O from 'fp-ts/Option';
-import { doOption } from '../combinators';
 import { lookup } from 'fp-ts/Array';
 import { pipe } from 'fp-ts/pipeable';
 import { get as _get } from 'lodash';
@@ -73,11 +72,9 @@ export function resolveRuntimeExpression(
 
   function tryRequestQuery() {
     return pipe(
-      doOption
-        .do(isPart(1, 'query'))
-        .bind('query', O.fromNullable(request.url.query))
-        .bind('part', lookup(2, parts))
-        .done(),
+      isPart(1, 'query'),
+      O.bind('query', _ => O.fromNullable(request.url.query)),
+      O.bind('part', _ => lookup(2, parts)),
       O.chain(({ part, query }) => O.fromNullable(query[part]))
     );
   }
@@ -111,16 +108,14 @@ export function resolveRuntimeExpression(
 
   function readBody(body: unknown) {
     return pipe(
-      doOption
-        .bind('body', O.fromNullable(body))
-        .bind(
-          'path',
-          pipe(
-            lookup(2, parts),
-            O.chain(part => O.tryCatch(() => pointerToPath('#' + part)))
-          )
+      O.fromNullable(body),
+      O.bindTo('body'),
+      O.bind('path', _ =>
+        pipe(
+          lookup(2, parts),
+          O.chain(part => O.tryCatch(() => pointerToPath('#' + part)))
         )
-        .done(),
+      ),
       O.chain(({ body, path }) => O.fromNullable(_get(body, path)))
     );
   }

--- a/packages/http/src/utils/runtimeExpression.ts
+++ b/packages/http/src/utils/runtimeExpression.ts
@@ -73,8 +73,8 @@ export function resolveRuntimeExpression(
   function tryRequestQuery() {
     return pipe(
       isPart(1, 'query'),
-      O.bind('query', _ => O.fromNullable(request.url.query)),
-      O.bind('part', _ => lookup(2, parts)),
+      O.bind('query', () => O.fromNullable(request.url.query)),
+      O.bind('part', () => lookup(2, parts)),
       O.chain(({ part, query }) => O.fromNullable(query[part]))
     );
   }

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -12,7 +12,7 @@ import * as contentType from 'content-type';
 import { findFirst, isNonEmpty } from 'fp-ts/Array';
 import * as O from 'fp-ts/Option';
 import * as E from 'fp-ts/Either';
-import { doOption, sequenceValidation, sequenceOption } from '../combinators';
+import { sequenceValidation, sequenceOption } from '../combinators';
 import { is as typeIs } from 'type-is';
 import { pipe } from 'fp-ts/pipeable';
 import { inRange, isMatch } from 'lodash';
@@ -96,21 +96,20 @@ const findResponseByStatus = (responses: IHttpOperationResponse[], statusCode: n
 
 export const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, mediaType: string) =>
   pipe(
-    doOption
-      .bind('parsedMediaType', pipe(O.fromNullable(mediaType), O.map(contentType.parse)))
-      .doL(({ parsedMediaType }) =>
-        pipe(
-          contents,
-          findFirst(c => {
-            const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
-            return (
-              !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
-              isMatch(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
-            );
-          })
-        )
+    O.fromNullable(mediaType),
+    O.map(contentType.parse),
+    O.chain(parsedMediaType =>
+      pipe(
+        contents,
+        findFirst(c => {
+          const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
+          return (
+            !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
+            isMatch(parsedMediaType.parameters, parsedSelectedContentMediaType.parameters)
+          );
+        })
       )
-      .done(),
+    ),
     E.fromOption<IPrismDiagnostic>(() => ({
       message: `The received media type "${mediaType || ''}" does not match the one${
         contents.length > 1 ? 's' : ''

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@stoplight/types';
 import * as caseless from 'caseless';
 import * as contentType from 'content-type';
-import { findFirst, isNonEmpty } from 'fp-ts/Array';
+import * as A from 'fp-ts/Array';
 import * as O from 'fp-ts/Option';
 import * as E from 'fp-ts/Either';
 import { sequenceValidation, sequenceOption } from '../combinators';
@@ -101,7 +101,7 @@ export const validateMediaType = (contents: NonEmptyArray<IMediaTypeContent>, me
     O.chain(parsedMediaType =>
       pipe(
         contents,
-        findFirst(c => {
+        A.findFirst(c => {
           const parsedSelectedContentMediaType = contentType.parse(c.mediaType);
           return (
             !!typeIs(parsedMediaType.type, [parsedSelectedContentMediaType.type]) &&
@@ -127,7 +127,7 @@ const validateOutput: ValidatorFn<IHttpOperation, IHttpResponse> = ({ resource, 
       sequenceValidation(
         pipe(
           O.fromNullable(response.contents),
-          O.chain(contents => pipe(contents, O.fromPredicate(isNonEmpty))),
+          O.chain(contents => pipe(contents, O.fromPredicate(A.isNonEmpty))),
           O.fold(
             () => E.right<NonEmptyArray<IPrismDiagnostic>, unknown>(undefined),
             contents => validateMediaType(contents, mediaType)

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -32,13 +32,10 @@ export const validateAgainstSchema = (
   schema: JSONSchema,
   coerce: boolean,
   prefix?: string
-): O.Option<NonEmptyArray<IPrismDiagnostic>> => {
-  const ajvInstance = coerce ? ajv : ajvNoCoerce;
-
-  return pipe(
-    O.tryCatch(() => ajvInstance.compile(schema)),
+): O.Option<NonEmptyArray<IPrismDiagnostic>> =>
+  pipe(
+    O.tryCatch(() => (coerce ? ajv : ajvNoCoerce).compile(schema)),
     O.chainFirst(validateFn => O.tryCatch(() => validateFn(value))),
     O.chain(validateFn => pipe(O.fromNullable(validateFn.errors), O.chain(fromArray))),
     O.map(errors => convertAjvErrors(errors, DiagnosticSeverity.Error, prefix))
   );
-};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3897,11 +3897,6 @@ format-util@^1.0.3:
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.3.tgz#032dca4a116262a12c43f4c3ec8566416c5b2d95"
   integrity sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=
 
-fp-ts-contrib@^0.1.19:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/fp-ts-contrib/-/fp-ts-contrib-0.1.19.tgz#5154f2f277373d54e5b4da6d7ca6751aaa8cfc74"
-  integrity sha512-u0dZbkh0gLrtiIV/spcwU7D8uoVAUCD7+Z5xSmDGHVKrw6G7jOQh6MlC0IrHXqiu1+J51ui/oFrKOEj9jA99LQ==
-
 fp-ts@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.8.2.tgz#7948dea1ceef32e487d7f7f47bd2d3c4fcccfc0d"


### PR DESCRIPTION
fp-ts 2.4 has built-in support for `bind` notation — allowing us to remove `fp-ts-contrib` and refactor some code.