### PR TITLE
Standardized Docker commands

### DIFF
--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -25,13 +25,13 @@ curl -L https://raw.githack.com/stoplightio/prism/master/install | sh
 Prism is available as a Docker image. We recommend specifying the major version you'd like to use as a tag:
 
 ```bash
-docker run --init -P stoplight/prism:4 mock -h 0.0.0.0 api.oas2.yml
+docker run --init -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 api.oas2.yml
 ```
 
 If the document you want to mock is on your computer, you'll need to mount the directory where the file resides as a volume:
 
 ```bash
-docker run --init --rm -it -v $(pwd):/tmp -P stoplight/prism:4 mock -h 0.0.0.0 "/tmp/file.yaml"
+docker run --init --rm -it -v $(pwd):/tmp -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 "/tmp/file.yaml"
 ```
 
 If you want to start the proxy server, you can run a command like this:

--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -37,7 +37,7 @@ docker run --init --rm -v $(pwd):/tmp -p 4010:4010 stoplight/prism:4 mock -h 0.0
 If you want to start the proxy server, you can run a command like this:
 
 ```bash
-docker run --init --rm -d --name myprism -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:4 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
+docker run --init --rm -d -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:4 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
 ```
 
 Now everything is installed, let's look at some of the [concepts](./02-concepts.md).

--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -31,13 +31,13 @@ docker run --init -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 api.oas2.yml
 If the document you want to mock is on your computer, you'll need to mount the directory where the file resides as a volume:
 
 ```bash
-docker run --init --rm -it -v $(pwd):/tmp -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 "/tmp/file.yaml"
+docker run --init --rm -v $(pwd):/tmp -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 "/tmp/file.yaml"
 ```
 
 If you want to start the proxy server, you can run a command like this:
 
 ```bash
-docker run --init --rm -it -d --name myprism -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:4 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
+docker run --init --rm -d --name myprism -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:4 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
 ```
 
 Now everything is installed, let's look at some of the [concepts](./02-concepts.md).


### PR DESCRIPTION
From the Docker documentation https://docs.docker.com/engine/reference/commandline/run/

> - P : Publish all exposed ports to random port

much better to specify the port to expose using `-p` as in the last example.