### PR TITLE
Teach convertAjvErrors to honor root array based paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Fixed
 
 - Multiple HTTP Headers coming from a proxied response are now [correctly aggreagated using a `,`](https://tools.ietf.org/html/rfc2616#section-4.2) instead of a space. [#1489](https://github.com/stoplightio/prism/pull/1489)
+- Improved the returned path for Problem JSON payloads [#1530](https://github.com/stoplightio/prism/pull/1530)
 
 # 4.1.0 (2020-09-25)
 

--- a/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
+++ b/packages/http/src/validator/__tests__/__snapshots__/functional.spec.ts.snap
@@ -18,6 +18,7 @@ Object {
       "message": "should match format \\"date-time\\"",
       "path": Array [
         "header",
+        "['x-todos-publish']",
       ],
       "severity": 0,
     },
@@ -56,6 +57,7 @@ Object {
       "message": "should match format \\"date-time\\"",
       "path": Array [
         "header",
+        "['x-todos-publish']",
       ],
       "severity": 0,
     },

--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -3,7 +3,7 @@ import * as convertAjvErrorsModule from '../utils';
 import { convertAjvErrors, validateAgainstSchema } from '../utils';
 import { ErrorObject } from 'ajv';
 import { assertSome, assertNone } from '@stoplight/prism-core/src/__tests__/utils';
-import { JSONSchema } from 'http/src/types';
+import { JSONSchema } from '@stoplight/prism-http';
 
 describe('convertAjvErrors()', () => {
   const errorObjectFixture: ErrorObject = {

--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import * as convertAjvErrorsModule from '../utils';
 import { convertAjvErrors, validateAgainstSchema } from '../utils';
 import { ErrorObject } from 'ajv';
 import { assertSome, assertNone } from '@stoplight/prism-core/src/__tests__/utils';
+import { JSONSchema } from 'http/src/types';
 
 describe('convertAjvErrors()', () => {
   const errorObjectFixture: ErrorObject = {
@@ -77,6 +78,50 @@ describe('validateAgainstSchema()', () => {
         DiagnosticSeverity.Error,
         'pfx'
       );
+    });
+
+    it('properly returns array based paths when meaningful', () => {
+      const numberSchema = {
+        type: 'number',
+      };
+
+      const rootArraySchema = {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: numberSchema,
+            status: {
+              type: 'string',
+              enum: ['TODO', 'IN_PROGRESS', 'CANCELLED', 'DONE'],
+            },
+          },
+        },
+      };
+
+      const nestedArraySchema = {
+        type: 'object',
+        properties: {
+          data: rootArraySchema,
+        },
+      };
+
+      assertSome(validateAgainstSchema('test', numberSchema as JSONSchema, true, 'pfx'), error => {
+        expect(error).toEqual([expect.objectContaining({ path: ['pfx'] })]);
+      });
+
+      const arr = [{ id: 11 }, { nope: false }];
+
+      assertSome(validateAgainstSchema(arr, rootArraySchema as JSONSchema, true, 'pfx'), error => {
+        expect(error).toEqual([expect.objectContaining({ path: ['pfx', '[1]'] })]);
+      });
+
+      const obj = { data: arr };
+
+      assertSome(validateAgainstSchema(obj, nestedArraySchema as JSONSchema, true, 'pfx'), error => {
+        expect(error).toEqual([expect.objectContaining({ path: ['pfx', 'data[1]'] })]);
+      });
     });
   });
 

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -15,7 +15,11 @@ export const convertAjvErrors = (errors: NonEmptyArray<ErrorObject>, severity: D
     errors,
     map<ErrorObject, IPrismDiagnostic>(error => {
       const allowedParameters = 'allowedValues' in error.params ? `: ${error.params.allowedValues.join(', ')}` : '';
-      const errorPath = error.dataPath.split('.').slice(1);
+      const errorPath = error.dataPath.includes('.')
+        ? error.dataPath.split('.').slice(1)
+        : error.dataPath.length > 0
+        ? [error.dataPath]
+        : [];
       const path = prefix ? [prefix, ...errorPath] : errorPath;
 
       return {


### PR DESCRIPTION
When analyzing a payload being an array of something, and that one of the entries doesn't match the schema, the position isn't returned as part of the path. 
When the array is quite big, this makes it quite difficult to figure out which entry is malformed.


Given the second array element is wrong:
- `{ data: [{ id: 11 }, { nope: false }] }` => path currently returned: `data[1]`
- `[{ id: 11 }, { nope: false }]` => path currently returned: `(nothing)` (This PR attempts at making this better and returning `[1]`)