### PR TITLE
Use new Decoders

### DIFF
--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -24,7 +24,7 @@
     "@stoplight/types": "^11.6.0",
     "fast-xml-parser": "^3.12.20",
     "fp-ts": "^2.8.6",
-    "io-ts": "^2.2.12",
+    "io-ts": "^2.2.13",
     "lodash": "^4.17.20",
     "micri": "^4.2.1",
     "node-fetch": "^2.6.1",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -25,7 +25,6 @@
     "fast-xml-parser": "^3.12.20",
     "fp-ts": "^2.8.6",
     "io-ts": "^2.2.12",
-    "io-ts-types": "^0.5.12",
     "lodash": "^4.17.20",
     "micri": "^4.2.1",
     "node-fetch": "^2.6.1",

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -18,7 +18,7 @@ const PreferencesDecoder = D.partial({
 type RequestPreferences = Partial<Omit<IHttpOperationConfig, 'mediaType'>>;
 
 export const getHttpConfigFromRequest = (req: IHttpRequest): E.Either<Error, RequestPreferences> => {
-  const preferences =
+  const preferences: unknown =
     req.headers && req.headers['prefer']
       ? parsePreferHeader(req.headers['prefer'])
       : { code: req.url.query?.__code, dynamic: req.url.query?.__dynamic, example: req.url.query?.__example };

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -1,7 +1,7 @@
 import { IHttpOperationConfig, IHttpRequest, ProblemJsonError, UNPROCESSABLE_ENTITY } from '@stoplight/prism-http';
 import { pipe } from 'fp-ts/pipeable';
 import * as E from 'fp-ts/Either';
-import * as D from 'io-ts/Decoder';
+import * as D from 'io-ts/lib/Decoder';
 //@ts-ignore
 import * as parsePreferHeader from 'parse-prefer-header';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4625,10 +4625,10 @@ inquirer@^6.2.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-io-ts@^2.2.12:
-  version "2.2.12"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.12.tgz#b840f2da4c2a6c8a4d8ab48122914672bfb22bab"
-  integrity sha512-pZh43E3xs1RUmv3voC58Mbb6Ihjo3UdDU6WWi578Zpe2BxVue1SlSQCioSymZxk9HoXa370nSfFzp5LrLA2F8g==
+io-ts@^2.2.13:
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.13.tgz#e04016685e863dd5cffb2b5262c5c9c74432dfda"
+  integrity sha512-BYJgE/BanovJKDvCnAkrr7f3gTucSyk+Sr5VtpouBO1/YfBKUyIn2z1ODG8LEF+1D4sjKZ3Bd/A5/v8JrJe5UQ==
 
 ip-regex@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4625,11 +4625,6 @@ inquirer@^6.2.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
-io-ts-types@^0.5.12:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/io-ts-types/-/io-ts-types-0.5.12.tgz#270487f6e0adfe0a597ca14e50fbab287e4bb266"
-  integrity sha512-8IC96BJBTMeHFIikM3Mh5poyl2NA6pgF1ncWBktrpS1xfCdoRZQeSWPDcUaiR8T8jYWfAYOt/KEcIsw2e1fufw==
-
 io-ts@^2.2.12:
   version "2.2.12"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.12.tgz#b840f2da4c2a6c8a4d8ab48122914672bfb22bab"


### PR DESCRIPTION
Use the new io-ts decoding system and remove the types, since we can use the `parse` method.