### PR TITLE
Reduce function requirements and ProblemJson function name

### DIFF
--- a/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
+++ b/packages/http-server/src/__tests__/getHttpConfigFromRequest.spec.ts
@@ -7,7 +7,6 @@ describe('getHttpConfigFromRequest()', () => {
       test('and no query should return my own default', () => {
         return assertRight(
           getHttpConfigFromRequest({
-            method: 'get',
             url: { path: '/' },
           }),
           parsed => expect(parsed).toEqual({})
@@ -15,76 +14,47 @@ describe('getHttpConfigFromRequest()', () => {
       });
 
       test('and no matching query should return my own default', () => {
-        return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/', query: {} },
-          }),
-          parsed => expect(parsed).toEqual({})
+        return assertRight(getHttpConfigFromRequest({ url: { path: '/', query: {} } }), parsed =>
+          expect(parsed).toEqual({})
         );
       });
 
       test('extracts code', () => {
-        return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/', query: { __code: '202' } },
-          }),
-          parsed => expect(parsed).toHaveProperty('code', '202')
+        return assertRight(getHttpConfigFromRequest({ url: { path: '/', query: { __code: '202' } } }), parsed =>
+          expect(parsed).toHaveProperty('code', '202')
         );
       });
 
       test('extracts example', () => {
-        return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/', query: { __example: 'bear' } },
-          }),
-          parsed => expect(parsed).toHaveProperty('exampleKey', 'bear')
+        return assertRight(getHttpConfigFromRequest({ url: { path: '/', query: { __example: 'bear' } } }), parsed =>
+          expect(parsed).toHaveProperty('exampleKey', 'bear')
         );
       });
 
       test('extracts dynamic', () => {
-        return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/', query: { __dynamic: 'true' } },
-          }),
-          parsed => expect(parsed).toHaveProperty('dynamic', true)
+        return assertRight(getHttpConfigFromRequest({ url: { path: '/', query: { __dynamic: 'true' } } }), parsed =>
+          expect(parsed).toHaveProperty('dynamic', true)
         );
       });
     });
 
     describe('headers', () => {
       test('extracts code', () => {
-        return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/' },
-            headers: { prefer: 'code=202' },
-          }),
-          parsed => expect(parsed).toHaveProperty('code', '202')
+        return assertRight(getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'code=202' } }), parsed =>
+          expect(parsed).toHaveProperty('code', '202')
         );
       });
 
       test('extracts example', () => {
         return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/' },
-            headers: { prefer: 'example=bear' },
-          }),
+          getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'example=bear' } }),
           parsed => expect(parsed).toHaveProperty('exampleKey', 'bear')
         );
       });
 
       test('extracts dynamic', () => {
         return assertRight(
-          getHttpConfigFromRequest({
-            method: 'get',
-            url: { path: '/' },
-            headers: { prefer: 'dynamic=true' },
-          }),
+          getHttpConfigFromRequest({ url: { path: '/' }, headers: { prefer: 'dynamic=true' } }),
           parsed => expect(parsed).toHaveProperty('dynamic', true)
         );
       });
@@ -92,7 +62,6 @@ describe('getHttpConfigFromRequest()', () => {
       test('prefers header over query', () => {
         return assertRight(
           getHttpConfigFromRequest({
-            method: 'get',
             url: { path: '/', query: { __dynamic: 'false' } },
             headers: { prefer: 'dynamic=true' },
           }),

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -19,7 +19,7 @@ type RequestPreferences = Partial<Omit<IHttpOperationConfig, 'mediaType'>>;
 
 export const getHttpConfigFromRequest = (
   req: Pick<IHttpRequest, 'headers' | 'url'>
-): E.Either<Error, RequestPreferences> => {
+): E.Either<ProblemJsonError, RequestPreferences> => {
   const preferences: unknown =
     req.headers && req.headers['prefer']
       ? parsePreferHeader(req.headers['prefer'])

--- a/packages/http-server/src/getHttpConfigFromRequest.ts
+++ b/packages/http-server/src/getHttpConfigFromRequest.ts
@@ -17,7 +17,9 @@ const PreferencesDecoder = D.partial({
 
 type RequestPreferences = Partial<Omit<IHttpOperationConfig, 'mediaType'>>;
 
-export const getHttpConfigFromRequest = (req: IHttpRequest): E.Either<Error, RequestPreferences> => {
+export const getHttpConfigFromRequest = (
+  req: Pick<IHttpRequest, 'headers' | 'url'>
+): E.Either<Error, RequestPreferences> => {
   const preferences: unknown =
     req.headers && req.headers['prefer']
       ? parsePreferHeader(req.headers['prefer'])

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -140,13 +140,13 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         );
       }),
       TE.mapLeft((e: Error & { status?: number; additional?: { headers?: Dictionary<string> } }) => {
-        if (!reply.finished) {
+        if (!reply.writableEnded) {
           reply.setHeader('content-type', 'application/problem+json');
 
           if (e.additional && e.additional.headers)
             Object.entries(e.additional.headers).forEach(([name, value]) => reply.setHeader(name, value));
 
-          send(reply, e.status || 500, JSON.stringify(ProblemJsonError.fromPlainError(e)));
+          send(reply, e.status || 500, JSON.stringify(ProblemJsonError.toProblemJson(e)));
         } else {
           reply.end();
         }

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -55,27 +55,19 @@ export class ProblemJsonError extends Error {
     detail?: string,
     additional?: Dictionary<unknown>
   ): ProblemJsonError {
-    const error = new ProblemJsonError(
+    return new ProblemJsonError(
       `https://stoplight.io/prism/errors#${template.type}`,
       template.title,
       template.status,
       detail || '',
       additional
     );
-
-    return error;
   }
 
   public static fromPlainError(
     error: Error & { detail?: string; status?: number; additional?: Dictionary<unknown> }
-  ): ProblemJson {
-    return {
-      type: error.name && error.name !== 'Error' ? error.name : 'https://stoplight.io/prism/errors#UNKNOWN',
-      title: error.message,
-      status: error.status || 500,
-      detail: error.detail || '',
-      ...error.additional,
-    };
+  ): ProblemJsonError {
+    return new ProblemJsonError(error.name, error.message, error.status || 500, error.detail || '', error.additional);
   }
 
   constructor(

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -68,10 +68,11 @@ export class ProblemJsonError extends Error {
     error: Error & { detail?: string; status?: number; additional?: Dictionary<unknown> }
   ): ProblemJson {
     return {
-      type: error.name,
+      type: error.name && error.name !== 'Error' ? error.name : 'https://stoplight.io/prism/errors#UNKNOWN',
       title: error.message,
       status: error.status || 500,
       detail: error.detail || '',
+      ...error.additional,
     };
   }
 

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -64,10 +64,15 @@ export class ProblemJsonError extends Error {
     );
   }
 
-  public static fromPlainError(
+  public static toProblemJson(
     error: Error & { detail?: string; status?: number; additional?: Dictionary<unknown> }
-  ): ProblemJsonError {
-    return new ProblemJsonError(error.name, error.message, error.status || 500, error.detail || '', error.additional);
+  ): ProblemJson {
+    return {
+      type: error.name,
+      title: error.message,
+      status: error.status || 500,
+      detail: error.detail || '',
+    };
   }
 
   constructor(


### PR DESCRIPTION
This PR reduces the arguments the HTTP Request parameter extraction requires to do its job as well as renaming the function in ProblemJson to be more communicative.

This is feedback I gathered while doing some upgrades of Prism in Stoplight's platform.

P.S: This PR has been created exclusively from an iPad Air 4 using GitHub CodeSpaces and their native iOS app. :trollface: 