### PR TITLE
Remove Map Statement

### DIFF
--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -88,15 +88,14 @@ export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, 
     O.bind('mediaType', () => O.fromNullable(mediaType)),
     O.bind('contentResult', ({ mediaType }) => findContentByMediaTypeOrFirst(specs, mediaType)),
     O.alt(() => O.some({ contentResult: { content: specs[0] || {}, mediaType: 'random' } })),
-    O.bind('schema', ({ contentResult }) => O.fromNullable(contentResult.content.schema)),
-    O.map(({ schema, contentResult: { content, mediaType } }) => ({ schema, mediaType, content }))
+    O.bind('schema', ({ contentResult }) => O.fromNullable(contentResult.content.schema))
   );
 
   return pipe(
     findContentByMediaType,
     O.fold(
       () => E.right(target),
-      ({ content, mediaType: mt, schema }) =>
+      ({ contentResult: { content, mediaType: mt }, schema }) =>
         pipe(
           mt,
           O.fromPredicate(mediaType => !!typeIs(mediaType, ['application/x-www-form-urlencoded'])),


### PR DESCRIPTION
There is no reason to map, we can reconstruct the context in the required function directly.