### PR TITLE
fix(http): dynamic generation don't follow constraints

### DIFF
--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -15,8 +15,6 @@ jsf.option({
   optionalsProbability: 1,
   fixedProbabilities: true,
   ignoreMissingRefs: true,
-  maxItems: 20,
-  maxLength: 100,
 });
 
 export function generate(source: JSONSchema): Either<Error, unknown> {


### PR DESCRIPTION
This fixes #1549.

Dynamic generations wouldn't follow `maxItems` and `maxLength` JSON
schema constraints due to the configured `json-schema-faker` options:

> maxItems — Override maxItems if it's greater than this value
> maxLength — Override maxLength if it's greater than this value