### PR TITLE
feat: readOnly and writeOnly support

### DIFF
--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -6,7 +6,7 @@ import * as sampler from 'openapi-sampler';
 import { Either, tryCatch, toError, right } from 'fp-ts/Either';
 import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/pipeable';
-import { stripWriteOnly } from 'http/src/utils/jsonSchema';
+import { stripWriteOnly } from '../../utils/jsonSchema';
 
 jsf.extend('faker', () => faker);
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,10 +1,12 @@
 import * as faker from 'faker/locale/en_US';
-import { cloneDeep } from 'lodash';
 import { JSONSchema } from '../../types';
 
 import * as jsf from 'json-schema-faker';
 import * as sampler from 'openapi-sampler';
-import { Either, tryCatch, toError } from 'fp-ts/Either';
+import { Either, tryCatch, toError, right } from 'fp-ts/Either';
+import * as O from 'fp-ts/lib/Option';
+import { pipe } from 'fp-ts/pipeable';
+import { stripWriteOnly } from 'http/src/utils/jsonSchema';
 
 jsf.extend('faker', () => faker);
 
@@ -20,7 +22,13 @@ jsf.option({
 });
 
 export function generate(source: JSONSchema): Either<Error, unknown> {
-  return tryCatch(() => jsf.generate(cloneDeep(source)), toError);
+  return pipe(
+    stripWriteOnly(source),
+    O.fold(
+      () => right(undefined),
+      schema => tryCatch(() => jsf.generate(schema), toError)
+    )
+  );
 }
 
 export function generateStatic(resource: unknown, source: JSONSchema): Either<Error, unknown> {

--- a/packages/http/src/utils/jsonSchema.ts
+++ b/packages/http/src/utils/jsonSchema.ts
@@ -1,10 +1,11 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
 import * as O from 'fp-ts/lib/Option';
 import { pipe } from 'fp-ts/pipeable';
-import { mapValues, intersection } from 'lodash/fp';
+import { mapValues, intersection, pickBy } from 'lodash/fp';
 
 type RequiredSchemaSubset = {
   readOnly?: boolean;
+  writeOnly?: boolean;
   properties?: Record<string, JSONSchema6 | JSONSchema7 | JSONSchema4 | boolean>;
   required?: string[] | false;
 };
@@ -27,7 +28,8 @@ const buildSchemaFilter = (predicate: (schema: RequiredSchemaSubset) => boolean)
             O.toUndefined
           );
         })
-      )
+      ),
+      O.map(pickBy(val => val !== undefined))
     );
 
     const strippedPropertyKeys = pipe(
@@ -53,3 +55,4 @@ const buildSchemaFilter = (predicate: (schema: RequiredSchemaSubset) => boolean)
 };
 
 export const stripReadOnly = buildSchemaFilter(schema => schema.readOnly !== true);
+export const stripWriteOnly = buildSchemaFilter(schema => schema.writeOnly !== true);

--- a/packages/http/src/utils/jsonSchema.ts
+++ b/packages/http/src/utils/jsonSchema.ts
@@ -1,0 +1,47 @@
+import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
+import * as O from 'fp-ts/lib/Option';
+import { pipe } from 'fp-ts/pipeable';
+import { mapValues, intersection } from 'lodash/fp';
+
+type RequiredSchemaSubset = {
+  readOnly?: boolean;
+  properties?: Record<string, JSONSchema6 | JSONSchema7 | JSONSchema4 | boolean>;
+  required?: string[] | false;
+};
+
+export function stripReadOnly<S extends RequiredSchemaSubset>(inputSchema: S): O.Option<S> {
+  if (inputSchema.readOnly) {
+    return O.none;
+  }
+
+  const strippedProperties = pipe(
+    O.fromNullable(inputSchema.properties),
+    O.map(
+      mapValues(val => {
+        return pipe(
+          O.some(val),
+          O.chain(val => (typeof val === 'boolean' ? O.none : stripReadOnly(val))),
+          O.toUndefined
+        );
+      })
+    )
+  );
+
+  const strippedPropertyKeys = pipe(
+    strippedProperties,
+    O.map(Object.keys),
+    O.getOrElse(() => [] as string[])
+  );
+
+  const requiredPropertyKeys = pipe(
+    O.fromNullable(inputSchema.required || null),
+    O.map(intersection(strippedPropertyKeys)),
+    O.toUndefined
+  );
+
+  return O.some({
+    ...inputSchema,
+    properties: O.toUndefined(strippedProperties),
+    required: requiredPropertyKeys,
+  });
+}

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -193,7 +193,7 @@ describe('HttpValidator', () => {
             error => expect(error).toHaveLength(2)
           );
 
-          expect(validators.validateBody).toHaveBeenCalledWith(undefined, [], undefined);
+          expect(validators.validateBody).toHaveBeenCalledWith(undefined, [], undefined, 'output');
           expect(validators.validateHeaders).toHaveBeenCalled();
         });
       });

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -11,6 +11,7 @@ import { JSONSchema } from '../../types';
 import { body } from '../deserializers';
 import { validateAgainstSchema } from './utils';
 import { validateFn } from './types';
+import { stripReadOnly } from 'http/src/utils/jsonSchema';
 
 export function deserializeFormBody(
   schema: JSONSchema,
@@ -88,7 +89,7 @@ export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, 
     O.bind('mediaType', () => O.fromNullable(mediaType)),
     O.bind('contentResult', ({ mediaType }) => findContentByMediaTypeOrFirst(specs, mediaType)),
     O.alt(() => O.some({ contentResult: { content: specs[0] || {}, mediaType: 'random' } })),
-    O.bind('schema', ({ contentResult }) => O.fromNullable(contentResult.content.schema))
+    O.bind('schema', ({ contentResult }) => pipe(O.fromNullable(contentResult.content.schema), O.chain(stripReadOnly)))
   );
 
   return pipe(

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -11,7 +11,7 @@ import { JSONSchema } from '../../types';
 import { body } from '../deserializers';
 import { validateAgainstSchema } from './utils';
 import { Context, validateFn } from './types';
-import { stripReadOnly, stripWriteOnly } from 'http/src/utils/jsonSchema';
+import { stripReadOnly, stripWriteOnly } from '../../utils/jsonSchema';
 
 export function deserializeFormBody(
   schema: JSONSchema,

--- a/packages/http/src/validator/validators/types.ts
+++ b/packages/http/src/validator/validators/types.ts
@@ -2,8 +2,11 @@ import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { Either } from 'fp-ts/Either';
 import { NonEmptyArray } from 'fp-ts/NonEmptyArray';
 
+export type Context = 'input' | 'output' | 'none';
+
 export type validateFn<Target, Specs> = (
   target: Target,
   specs: Specs[],
-  mediaType?: string
+  mediaType?: string,
+  context?: Context
 ) => Either<NonEmptyArray<IPrismDiagnostic>, Target>;


### PR DESCRIPTION
Resolves #1142 

I'm not familiar with prism and FP much so code style, placement and naming might be off. Yet I think it fixes both the issue above, both the related `writeOnly` support. Hope it's not that terrible. 😄 

Also how would you go about testing this? I was messing with `http/src/validator/__tests__/index.spec.ts` but the actual validator return value is always mocked out, so doesn't verify much. Is there a test suite that tests the actual schema validation logic?