### PR TITLE
Prism doesn't seem to honor 'nullable: true' while validating

### DIFF
--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -36,6 +36,21 @@ describe('validate()', () => {
         error => expect(error).toContainEqual(expect.objectContaining({ code: 'type', message: 'should be number' }))
       );
     });
+
+    it('supports nullables', () => {
+      const mockSchema: JSONSchema = {
+        type: 'object',
+        properties: { id: { type: 'integer', nullable: true } },
+        required: ['id'],
+      };
+      assertRight(
+        validate(
+          { id: null },
+          [{ mediaType: 'application/json', schema: mockSchema, examples: [], encodings: [] }],
+          'application/json'
+        )
+      );
+    });
   });
 
   describe('body is form-urlencoded with deep object style', () => {


### PR DESCRIPTION
:wave: It's possible Prism may not properly support OAS 3.0.x `nullable`.

Provided I have properly expressed the problem in the attached repro case, I believe this unit test should pass, not fail.

Thoughts?