### PR TITLE
Fix: Support nullable

### DIFF
--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -36,6 +36,21 @@ describe('validate()', () => {
         error => expect(error).toContainEqual(expect.objectContaining({ code: 'type', message: 'should be number' }))
       );
     });
+
+    it('supports nullables', () => {
+      const mockSchema: JSONSchema = {
+        type: 'object',
+        properties: { id: { type: 'integer', nullable: true } },
+        required: ['id'],
+      };
+      assertRight(
+        validate(
+          { id: null },
+          [{ mediaType: 'application/json', schema: mockSchema, examples: [], encodings: [] }],
+          'application/json'
+        )
+      );
+    });
   });
 
   describe('body is form-urlencoded with deep object style', () => {

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -7,8 +7,14 @@ import type { ErrorObject } from 'ajv';
 import { JSONSchema } from '../../';
 import * as AjvOAI from 'ajv-oai';
 
-const ajv = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto' });
-const ajvNoCoerce = new AjvOAI({ allErrors: true, messages: true, schemaId: 'auto', coerceTypes: false });
+const ajv = new AjvOAI({ allErrors: true, nullable: true, messages: true, schemaId: 'auto' });
+const ajvNoCoerce = new AjvOAI({
+  allErrors: true,
+  nullable: true,
+  messages: true,
+  schemaId: 'auto',
+  coerceTypes: false,
+});
 
 export const convertAjvErrors = (errors: NonEmptyArray<ErrorObject>, severity: DiagnosticSeverity, prefix?: string) =>
   pipe(


### PR DESCRIPTION
I've been receiving validation errors when using `nullable: true` in my OpenAPI schema.
This extends @nulltoken 's work here https://github.com/stoplightio/prism/pull/1734 -- with the option described [here](https://github.com/ajv-validator/ajv/issues/983#issuecomment-479151797).

Manually testing this locally appears to work as previously failing validations now pass 🥳 -- This unblocks us from using Prism in our E2E test suite.