### PR TITLE
chore(deps): bump @stoplight/json-schema-sampler from 0.1.0 to 0.2.0

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@stoplight/json": "^3.11.2",
-    "@stoplight/json-schema-sampler": "0.1.0",
+    "@stoplight/json-schema-sampler": "0.2.0",
     "@stoplight/prism-core": "^4.1.3",
     "@stoplight/types": "^12.0.0",
     "@stoplight/yaml": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,10 +1319,10 @@
     type-is "^1.6.18"
     urijs "~1.19.2"
 
-"@stoplight/json-schema-sampler@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-sampler/-/json-schema-sampler-0.1.0.tgz#e0b9be21e454a1002e906dcc750bf3dfa96ed967"
-  integrity sha512-hpn/jnrSs2Tf4/49+2yram81jvy52SDuqzUQWUIzmHzmLCyHDMS7kWqK/PuIu/eAaA28K15W/+0vuTQJcEBZPQ==
+"@stoplight/json-schema-sampler@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-sampler/-/json-schema-sampler-0.2.0.tgz#31215818ad0c571852fd201955a21a25bc0b77c2"
+  integrity sha512-FKMyGU8beAQCtNmuMNOxbMWDPJGVqSQqv5ESnId2O9Arzo7jPd3QUB6E95MnEcuKVaIQd2mk+d0+Isi7gJOJcA==
   dependencies:
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"


### PR DESCRIPTION
Here's the list of changes introduced between the two releases

https://github.com/stoplightio/json-schema-sampler/compare/bdd5ae5a6e57289ef2508f8abb3065231d2d88a1~1...e096188662e08bd16e9f4982e69cd27f36b1df25

The meaningful change for Prism is basic support of `if` compound keyword.

https://github.com/stoplightio/json-schema-sampler/commit/e096188662e08bd16e9f4982e69cd27f36b1df25 is relatively important for platform, as otherwise we're forced to set a resolution.
It's not an issue with the code itself, but rather with the old version of Webpack we use in platform-internal.

I'm planning to trigger a minor release after this PR is merged.