### PR TITLE
Use encodeURI param names to avoid performance issues on start up.

### DIFF
--- a/packages/cli/src/util/__tests__/paths.spec.ts
+++ b/packages/cli/src/util/__tests__/paths.spec.ts
@@ -274,7 +274,7 @@ describe('createExamplePath()', () => {
       );
     });
 
-    it('generates when params have special characters', () => {
+    it('encodes params with special characters', () => {
       assertRight(
         createExamplePath({
           id: '123',

--- a/packages/cli/src/util/__tests__/paths.spec.ts
+++ b/packages/cli/src/util/__tests__/paths.spec.ts
@@ -273,6 +273,27 @@ describe('createExamplePath()', () => {
         e => expect(e.message).toEqual('Space delimited style is only applicable to array parameter')
       );
     });
+
+    it('generates when params have special characters', () => {
+      assertRight(
+        createExamplePath({
+          id: '123',
+          path: '/path',
+          method: 'get',
+          request: {
+            query: [
+              {
+                name: 'StartTime>',
+                style: HttpParamStyles.Form,
+                examples: [{ key: 'foo', value: '1985-10-25T03:33:00.613Z' }],
+              },
+            ],
+          },
+          responses: [{ code: '200' }],
+        }),
+        r => expect(r).toEqual('/path?StartTime%3E=1985-10-25T03%3A33%3A00.613Z')
+      );
+    });
   });
 
   describe('mixed parameters', () => {

--- a/packages/cli/src/util/paths.ts
+++ b/packages/cli/src/util/paths.ts
@@ -28,7 +28,7 @@ export function createExamplePath(
     E.bind('pathData', () => generateTemplateAndValuesForPathParams(operation)),
     E.bind('queryData', ({ pathData }) => generateTemplateAndValuesForQueryParams(pathData.template, operation)),
     E.map(({ pathData, queryData }) =>
-      decodeURI(URI.expand(queryData.template, transformValues({ ...pathData.values, ...queryData.values })))
+      URI.expand(queryData.template, transformValues({ ...pathData.values, ...queryData.values }))
     )
   );
 }


### PR DESCRIPTION
Addresses [#1743]

Use encodeURI param names to avoid performance issues on startup.

See more details in the  https://github.com/stoplightio/prism/issues/1743#issuecomment-830021600 thread