### PR TITLE
Update Http-server doc with new location of getHttpOperationsFromSpec

### DIFF
--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -6,7 +6,7 @@ Usage:
 
 ```javascript
 const { createServer } = require('@stoplight/prism-http-server');
-const { getHttpOperationsFromSpec } = require("@stoplight/prism-cli/dist/operations");
+const { getHttpOperationsFromSpec } = require('@stoplight/prism-cli/dist/operations');
 const { createLogger } = require('@stoplight/prism-core');
 
 async function createPrismServer() {

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -6,7 +6,7 @@ Usage:
 
 ```javascript
 const { createServer } = require('@stoplight/prism-http-server');
-const { getHttpOperationsFromSpec } = require('@stoplight/prism-http');
+const { getHttpOperationsFromSpec } = require("@stoplight/prism-cli/dist/operations");
 const { createLogger } = require('@stoplight/prism-core');
 
 async function createPrismServer() {


### PR DESCRIPTION
In #1009 the getHttpOperationsFromSpec moved to the prism-cli package. The documentation needs to be updated accordingly