### PR TITLE
install pipenv with pip3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,7 @@ jobs:
       - when:
           condition: <<parameters.install_manually>>
           steps:
-            - run:
-                command: pip3 install pipenv
-                environment:
-                  HOMEBREW_NO_AUTO_UPDATE: 1
+            - run: pip3 install pipenv
             - run: sudo bash -c 'echo "0.0.0.0 httpbin.org" >> /etc/hosts'
             - run: git clone https://github.com/postmanlabs/httpbin httpbin
             - run: cd httpbin && pip3 install --no-cache-dir -r <(pipenv lock -r) && pip3 install --no-cache-dir ./

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           condition: <<parameters.install_manually>>
           steps:
             - run:
-                command: brew install pipenv
+                command: pip3 install pipenv
                 environment:
                   HOMEBREW_NO_AUTO_UPDATE: 1
             - run: sudo bash -c 'echo "0.0.0.0 httpbin.org" >> /etc/hosts'


### PR DESCRIPTION
To avoid python2/python3 issues

Error: Could not symlink Frameworks/Python.framework/Headers
Target /usr/local/Frameworks/Python.framework/Headers
is a symlink belonging to python@3.9. You can unlink it:
  brew unlink python@3.9

Context
[Succeed build ](https://app.circleci.com/pipelines/github/stoplightio/prism/8146/workflows/63cee241-c0de-4a36-a61b-66afc1697baf)
[Failed Build](https://app.circleci.com/pipelines/github/stoplightio/prism/8143/workflows/91e94c6a-1d61-4ef4-a1cb-9a8a02613746/jobs/17049)