### PR TITLE
feat: support circular refs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+Addresses #[ISSUE_NUMBER]
+
+**Summary**
+
+Replace this with something that explains what this PR is for and why it matters.
+
+**Checklist**
+
+- The basics
+  - [ ] I tested these changes manually in my local or dev environment
+- Tests
+  - [ ] Added or updated
+  - [ ] N/A
+- Event Tracking
+  - [ ] I added event tracking and followed the event tracking guidelines
+  - [ ] N/A
+- Error Reporting
+  - [ ] I reported errors and followed the error reporting guidelines
+  - [ ] N/A
+
+**Screenshots**
+
+If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
+section before creating the PR.
+
+**Additional context**
+
+Add any other context about the pull request here. Remove this section if there is no additional context.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Yarn is a package manager for your code, similar to npm. While you can use npm t
 3. Git clone your fork (i.e. `git clone https://github.com/<your-username>/prism.git`) to your machine.
 4. Run `yarn` to install dependencies and setup the project.
 5. Because during the development we run the software directly on top of TypeScript sources, we advise you to use our script: `cd packages/cli && yarn cli mock openapi.yaml`.
-6. Run `git checkout -b [name_of_your_new_branch]` to create a new branch for your work. To help build nicer changelogs, we have a convention for branch names. Please start your branch with either `feature/{branch-name}`, `chore/{branch-name}`, or `fix/{branch-name}`. For example, if I was adding a CLI, I would make my branch name: `feature/add-cli`.
+6. Run `git checkout -b [name_of_your_new_branch]` to create a new branch for your work. To help build nicer changelogs, we have a convention for branch names. Please start your branch with either `feature/{branch-name}`, `chore/{branch-name}`, or `fix/{branch-name}`. For example, if I was adding a new CLI feature, I would make my branch name: `feature/add-cli-new-feature`.
 7. Make changes, write code and tests, etc. The fun stuff!
 8. Run `yarn test` to test your changes.
 9. Commit your changes.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest",
     "release": "lerna version",
     "prebuild.binary": "yarn build",
-    "build.binary": "npx pkg --output ./cli-binaries/prism-cli ./packages/cli/",
+    "build.binary": "npx pkg --output ./cli-binaries/prism-cli --options max_old_space_size=4096 ./packages/cli/",
     "test.harness": "jest -c ./jest.harness.config.js"
   },
   "resolutions": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
     "@stoplight/http-spec": "^4.2.0",
-    "@stoplight/json": "^3.13.6",
+    "@stoplight/json": "^3.13.7",
     "@stoplight/json-schema-ref-parser": "9.2.1",
     "@stoplight/prism-core": "^4.2.4",
     "@stoplight/prism-http": "^4.2.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,9 @@
   },
   "bugs": "https://github.com/stoplightio/prism/issues",
   "dependencies": {
-    "@stoplight/http-spec": "^4.1.0",
+    "@stoplight/http-spec": "^4.2.0",
+    "@stoplight/json": "^3.13.6",
+    "@stoplight/json-schema-ref-parser": "9.2.1",
     "@stoplight/prism-core": "^4.2.4",
     "@stoplight/prism-http": "^4.2.4",
     "@stoplight/prism-http-server": "^4.2.4",
@@ -15,7 +17,6 @@
     "chalk": "^4.1.1",
     "chokidar": "^3.5.1",
     "fp-ts": "^2.10.4",
-    "json-schema-ref-parser": "^9.0.7",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "pino": "^6.11.3",

--- a/packages/cli/src/operations.ts
+++ b/packages/cli/src/operations.ts
@@ -19,7 +19,6 @@ export async function getHttpOperationsFromSpec(specFilePathOrObject: string | o
   else throw new Error('Unsupported document format');
 
   operations.forEach((op, i, ops) => {
-    // TODO: should we add a __bundled__ property to stoplight/types for http operations?
     ops[i] = bundleTarget({
       document: {
         ...result,

--- a/packages/cli/src/operations.ts
+++ b/packages/cli/src/operations.ts
@@ -2,20 +2,34 @@ import { transformOas3Operations } from '@stoplight/http-spec/oas3/operation';
 import { transformOas2Operations } from '@stoplight/http-spec/oas2/operation';
 import { transformPostmanCollectionOperations } from '@stoplight/http-spec/postman/operation';
 import { dereference } from 'json-schema-ref-parser';
+import { bundleTarget, pathToPointer } from '@stoplight/json';
 import { IHttpOperation } from '@stoplight/types';
-import { get } from 'lodash';
+import { get, isPlainObject } from 'lodash';
 import type { Spec } from 'swagger-schema-official';
 import type { OpenAPIObject } from 'openapi3-ts';
 import type { CollectionDefinition } from 'postman-collection';
 
 export async function getHttpOperationsFromSpec(specFilePathOrObject: string | object): Promise<IHttpOperation[]> {
-  const result = await dereference(specFilePathOrObject, { dereference: { circular: false } });
+  const result = decycle(await dereference(specFilePathOrObject));
 
-  if (isOpenAPI2(result)) return transformOas2Operations(result);
-  if (isOpenAPI3(result)) return transformOas3Operations(result);
-  if (isPostmanCollection(result)) return transformPostmanCollectionOperations(result);
+  let operations: IHttpOperation[] = [];
+  if (isOpenAPI2(result)) operations = transformOas2Operations(result);
+  else if (isOpenAPI3(result)) operations = transformOas3Operations(result);
+  else if (isPostmanCollection(result)) operations = transformPostmanCollectionOperations(result);
+  else throw new Error('Unsupported document format');
 
-  throw new Error('Unsupported document format');
+  operations.forEach((op, i, ops) => {
+    // TODO: should we add a __bundled__ property to stoplight/types for http operations?
+    ops[i] = bundleTarget({
+      document: {
+        ...result,
+        __target__: op,
+      },
+      path: '#/__target__',
+    });
+  });
+
+  return operations;
 }
 
 function isOpenAPI2(document: unknown): document is Spec {
@@ -29,3 +43,38 @@ function isOpenAPI3(document: unknown): document is OpenAPIObject {
 function isPostmanCollection(document: unknown): document is CollectionDefinition {
   return Array.isArray(get(document, 'item')) && get(document, 'info.name');
 }
+
+// TODO: remove, need https://github.com/stoplightio/json/pull/90
+export const decycle = (obj: unknown, replacer?: (value: any) => any) => {
+  const objs = new WeakMap<object, string>();
+  return (function derez(value: any, path: string[]) {
+    // The new object or array
+    let curObj: any;
+
+    // If a replacer function was provided, then call it to get a replacement value.
+    if (replacer) value = replacer(value);
+
+    if (isPlainObject(value) || Array.isArray(value)) {
+      // The path of an earlier occurance of value
+      const oldPath = objs.get(value);
+      // If the value is an object or array, look to see if we have already
+      // encountered it. If so, return a {"$ref":PATH} object.
+      if (oldPath) return { $ref: oldPath };
+
+      objs.set(value, pathToPointer(path));
+      // If it is an array, replicate the array.
+      if (Array.isArray(value)) {
+        curObj = value.map((element, i) => derez(element, [...path, String(i)]));
+      } else {
+        // It is an object, replicate the object.
+        curObj = {};
+        Object.keys(value).forEach(name => {
+          curObj[name] = derez(value[name], [...path, name]);
+        });
+      }
+      objs.delete(value);
+      return curObj;
+    }
+    return value;
+  })(obj, []);
+};

--- a/packages/cli/src/operations.ts
+++ b/packages/cli/src/operations.ts
@@ -2,9 +2,9 @@ import { transformOas3Operations } from '@stoplight/http-spec/oas3/operation';
 import { transformOas2Operations } from '@stoplight/http-spec/oas2/operation';
 import { transformPostmanCollectionOperations } from '@stoplight/http-spec/postman/operation';
 import { dereference } from 'json-schema-ref-parser';
-import { bundleTarget, pathToPointer } from '@stoplight/json';
+import { bundleTarget, decycle } from '@stoplight/json';
 import { IHttpOperation } from '@stoplight/types';
-import { get, isPlainObject } from 'lodash';
+import { get } from 'lodash';
 import type { Spec } from 'swagger-schema-official';
 import type { OpenAPIObject } from 'openapi3-ts';
 import type { CollectionDefinition } from 'postman-collection';
@@ -43,38 +43,3 @@ function isOpenAPI3(document: unknown): document is OpenAPIObject {
 function isPostmanCollection(document: unknown): document is CollectionDefinition {
   return Array.isArray(get(document, 'item')) && get(document, 'info.name');
 }
-
-// TODO: remove, need https://github.com/stoplightio/json/pull/90
-export const decycle = (obj: unknown, replacer?: (value: any) => any) => {
-  const objs = new WeakMap<object, string>();
-  return (function derez(value: any, path: string[]) {
-    // The new object or array
-    let curObj: any;
-
-    // If a replacer function was provided, then call it to get a replacement value.
-    if (replacer) value = replacer(value);
-
-    if (isPlainObject(value) || Array.isArray(value)) {
-      // The path of an earlier occurance of value
-      const oldPath = objs.get(value);
-      // If the value is an object or array, look to see if we have already
-      // encountered it. If so, return a {"$ref":PATH} object.
-      if (oldPath) return { $ref: oldPath };
-
-      objs.set(value, pathToPointer(path));
-      // If it is an array, replicate the array.
-      if (Array.isArray(value)) {
-        curObj = value.map((element, i) => derez(element, [...path, String(i)]));
-      } else {
-        // It is an object, replicate the object.
-        curObj = {};
-        Object.keys(value).forEach(name => {
-          curObj[name] = derez(value[name], [...path, name]);
-        });
-      }
-      objs.delete(value);
-      return curObj;
-    }
-    return value;
-  })(obj, []);
-};

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -251,6 +251,67 @@ describe('body params validation', () => {
           tags: [],
           security: [],
         },
+        {
+          id: '?http-operation-id?',
+          method: 'post',
+          path: '/json-body-circular-property-required',
+          responses: [
+            {
+              code: '200',
+              headers: [],
+              contents: [
+                {
+                  mediaType: 'text/plain',
+                  schema: {
+                    type: 'string',
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                  },
+                  examples: [],
+                  encodings: [],
+                },
+              ],
+            },
+          ],
+          servers: [],
+          request: {
+            body: {
+              contents: [
+                {
+                  mediaType: 'application/json',
+                  schema: {
+                    $ref: '#/__bundled__/schemas',
+                  },
+                  examples: [],
+                  encodings: [],
+                },
+              ],
+            },
+            headers: [],
+            query: [],
+            cookie: [],
+            path: [],
+          },
+          tags: [],
+          security: [],
+          // @ts-ignore
+          ['__bundled__']: {
+            schemas: {
+              $schema: 'http://json-schema.org/draft-07/schema#',
+              type: 'object',
+              required: ['id'],
+              properties: {
+                id: {
+                  type: 'integer',
+                  minimum: -9223372036854776000,
+                  maximum: 9223372036854776000,
+                },
+                self: {
+                  $ref: '#/__bundled__/schemas',
+                },
+              },
+            },
+          },
+        },
       ]);
     });
 
@@ -290,6 +351,30 @@ describe('body params validation', () => {
           expect(response.status).toBe(422);
           return expect(response.json()).resolves.toMatchObject({
             validation: [{ code: 'required', message: "must have required property 'id'", severity: 'Error' }],
+          });
+        });
+      });
+    });
+
+    describe('operation with circular required property', () => {
+      describe('when property not provided', () => {
+        test('returns 422 & error message', async () => {
+          const response = await makeRequest('/json-body-circular-property-required', {
+            method: 'POST',
+            body: JSON.stringify({ id: 123, self: {} }),
+            headers: { 'content-type': 'application/json' },
+          });
+
+          expect(response.status).toBe(422);
+          return expect(response.json()).resolves.toMatchObject({
+            validation: [
+              {
+                code: 'required',
+                location: ['body', 'self'],
+                message: "must have required property 'id'",
+                severity: 'Error',
+              },
+            ],
           });
         });
       });

--- a/packages/http-server/src/__tests__/fixtures/petstore.no-auth.circular.oas2.yaml
+++ b/packages/http-server/src/__tests__/fixtures/petstore.no-auth.circular.oas2.yaml
@@ -907,6 +907,8 @@ definitions:
           - available
           - pending
           - sold
+        related:
+          '$ref': '#/definitions/Pet'
     xml:
       name: Pet
   ApiResponse:

--- a/packages/http-server/src/__tests__/fixtures/petstore.no-auth.circular.oas3.yaml
+++ b/packages/http-server/src/__tests__/fixtures/petstore.no-auth.circular.oas3.yaml
@@ -886,6 +886,8 @@ components:
             - available
             - pending
             - sold
+        related:
+          $ref: '#/components/schemas/Pet'
       xml:
         name: Pet
     ApiResponse:

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -9,8 +9,8 @@ import { ThenArg } from '../types';
 
 const logger = createLogger('TEST', { enabled: false });
 
-const oas3File = 'petstore.no-auth.oas3.yaml';
-const oas2File = 'petstore.no-auth.oas2.yaml';
+const oas3File = ['petstore.no-auth.oas3.yaml', 'petstore.no-auth.circular.oas3.yaml'];
+const oas2File = ['petstore.no-auth.oas2.yaml', 'petstore.no-auth.circular.oas2.yaml'];
 
 function checkErrorPayloadShape(payload: string) {
   const parsedPayload = JSON.parse(payload);
@@ -134,11 +134,11 @@ describe('Prefer header overrides', () => {
   });
 });
 
-describe.each([[oas2File], [oas3File]])('server %s', file => {
+describe.each([[...oas2File], [...oas3File]])('server %s', file => {
   let server: ThenArg<ReturnType<typeof instantiatePrism>>;
 
   beforeEach(async () => {
-    server = await instantiatePrism(resolve(__dirname, 'fixtures', file));
+    server = await instantiatePrism(resolve(__dirname, 'fixtures', file), { mock: { dynamic: true } });
   });
 
   afterEach(() => server.close());
@@ -168,7 +168,9 @@ describe.each([[oas2File], [oas3File]])('server %s', file => {
   });
 
   it('will return requested response using the __code property', async () => {
-    const response = await makeRequest('/pets/123?__code=404');
+    // TODO: Figure out why dynamic being enabled on the server returns a 200, instead of a 404.
+    // const response = await makeRequest('/pets/123?__code=404');
+    const response = await makeRequest('/pets/123?__code=404&__dynamic=false');
 
     expect(response.status).toBe(404);
     return expect(response.text()).resolves.toBe('');
@@ -233,8 +235,8 @@ describe.each([[oas2File], [oas3File]])('server %s', file => {
     // according to the schema
 
     const expectedValues = {
-      'x-rate-limit': file === oas3File ? '1000' : expect.stringMatching(/^-?\d+$/),
-      'x-stats': file === oas3File ? '1500' : expect.stringMatching(/^-?\d+$/),
+      'x-rate-limit': oas3File.includes(file) ? '1000' : expect.stringMatching(/^-?\d+$/),
+      'x-stats': oas3File.includes(file) ? '1500' : expect.stringMatching(/^-?\d+$/),
       'x-expires-after': expect.any(String),
       'x-strange-header': 'null',
     };
@@ -264,7 +266,7 @@ describe.each([[oas2File], [oas3File]])('server %s', file => {
     });
 
     // oas2 does not support overriding servers and named examples
-    if (file === oas3File) {
+    if (oas3File.includes(file)) {
       it('returns requested response example using __example property', async () => {
         const response = await makeRequest('/pets/123?__example=cat');
         const payload = await response.json();

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -168,8 +168,6 @@ describe.each([[...oas2File], [...oas3File]])('server %s', file => {
   });
 
   it('will return requested response using the __code property', async () => {
-    // TODO: Figure out why dynamic being enabled on the server returns a 200, instead of a 404.
-    // const response = await makeRequest('/pets/123?__code=404');
     const response = await makeRequest('/pets/123?__code=404&__dynamic=false');
 
     expect(response.status).toBe(404);

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,15 +16,15 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@stoplight/json": "^3.12.0",
+    "@stoplight/json": "^3.13.6",
     "@stoplight/json-schema-sampler": "0.2.0",
     "@stoplight/prism-core": "^4.2.4",
     "@stoplight/types": "^12.2.0",
     "@stoplight/yaml": "^4.2.2",
     "abstract-logging": "^2.0.1",
     "accepts": "^1.3.7",
-    "ajv": "^8.2.0",
-    "ajv-formats": "^2.0.2",
+    "ajv": "^8.4.0",
+    "ajv-formats": "^2.1.0",
     "caseless": "^0.12.0",
     "content-type": "^1.0.4",
     "faker": "^5.5.3",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,7 +16,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@stoplight/json": "^3.13.6",
+    "@stoplight/json": "^3.13.7",
     "@stoplight/json-schema-sampler": "0.2.0",
     "@stoplight/prism-core": "^4.2.4",
     "@stoplight/types": "^12.2.0",

--- a/packages/http/src/mocker/generator/HttpParamGenerator.ts
+++ b/packages/http/src/mocker/generator/HttpParamGenerator.ts
@@ -49,7 +49,7 @@ export function generate(param: IHttpParam | IHttpContent): O.Option<unknown> {
       pipe(
         O.fromNullable(param.schema),
         O.map(improveSchema),
-        O.chain(schema => O.fromEither(generateDynamicExample(schema)))
+        O.chain(schema => O.fromEither(generateDynamicExample({}, schema)))
       )
     )
   );

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -20,8 +20,8 @@ jsf.option({
   maxLength: 100,
 });
 
-export function generate(source: JSONSchema): Either<Error, unknown> {
-  return tryCatch(() => jsf.generate(cloneDeep(source)), toError);
+export function generate(bundle: unknown, source: JSONSchema): Either<Error, unknown> {
+  return tryCatch(() => jsf.generate({ ...cloneDeep(source), __bundled__: bundle }), toError);
 }
 
 export function generateStatic(resource: IHttpOperation, source: JSONSchema): Either<Error, unknown> {

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -19,7 +19,7 @@ describe('JSONSchema generator', () => {
       };
 
       it('will have a string property not matching anything in particular', () => {
-        assertRight(generate(schema), instance => {
+        assertRight(generate({}, schema), instance => {
           expect(instance).toHaveProperty('name');
           const name = get(instance, 'name');
 
@@ -39,7 +39,7 @@ describe('JSONSchema generator', () => {
       };
 
       it('will have a string property matching the email regex', () => {
-        assertRight(generate(schema), instance => {
+        assertRight(generate({}, schema), instance => {
           expect(instance).toHaveProperty('email');
           const email = get(instance, 'email');
 
@@ -59,14 +59,14 @@ describe('JSONSchema generator', () => {
       };
 
       it('will have a string property matching uuid regex', () => {
-        assertRight(generate(schema), instance => {
+        assertRight(generate({}, schema), instance => {
           const id = get(instance, 'id');
           expect(id).toMatch(uuidRegExp);
         });
       });
 
       it('will not be presented in the form of UUID as a URN', () => {
-        assertRight(generate(schema), instance => {
+        assertRight(generate({}, schema), instance => {
           const id = get(instance, 'id');
           expect(uuidRegExp.test(id)).not.toContainEqual('urn:uuid');
         });
@@ -83,7 +83,7 @@ describe('JSONSchema generator', () => {
       };
 
       it('will have a string property matching the ip regex', () => {
-        assertRight(generate(schema), instance => {
+        assertRight(generate({}, schema), instance => {
           expect(instance).toHaveProperty('ip');
           const ip = get(instance, 'ip');
 
@@ -103,7 +103,7 @@ describe('JSONSchema generator', () => {
         },
       };
 
-      it('will return a left', () => assertLeft(generate(schema)));
+      it('will return a left', () => assertLeft(generate({}, schema)));
     });
 
     it('operates on sealed schema objects', () => {
@@ -117,7 +117,7 @@ describe('JSONSchema generator', () => {
 
       Object.defineProperty(schema.properties, 'name', { writable: false });
 
-      return expect(generate(schema)).toBeTruthy();
+      return expect(generate({}, schema)).toBeTruthy();
     });
   });
 });

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -51,7 +51,9 @@ const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpM
   input,
   config,
 }) => {
-  const payloadGenerator: PayloadGenerator = config.dynamic ? generate : partial(generateStatic, resource);
+  const payloadGenerator: PayloadGenerator = config.dynamic
+    ? partial(generate, resource['__bundled__'])
+    : partial(generateStatic, resource);
 
   return pipe(
     withLogger(logger => {

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -128,10 +128,14 @@ describe('HttpValidator', () => {
               element: { method: 'get', url: { path: '/a/1/b/;b=2' } },
             });
 
-            expect(validators.validatePath).toHaveBeenCalledWith({ a: '1', b: ';b=2' }, [
-              { name: 'a', style: HttpParamStyles.Simple },
-              { name: 'b', style: HttpParamStyles.Matrix },
-            ]);
+            expect(validators.validatePath).toHaveBeenCalledWith(
+              { a: '1', b: ';b=2' },
+              [
+                { name: 'a', style: HttpParamStyles.Simple },
+                { name: 'b', style: HttpParamStyles.Matrix },
+              ],
+              undefined
+            );
           });
         });
       });
@@ -157,10 +161,14 @@ describe('HttpValidator', () => {
               element: { method: 'get', url: { path: '/a-path/1/b/;b-id=2' } },
             });
 
-            expect(validators.validatePath).toHaveBeenCalledWith({ 'a-id': '1', 'b-id': ';b-id=2' }, [
-              { name: 'a-id', style: HttpParamStyles.Simple },
-              { name: 'b-id', style: HttpParamStyles.Matrix },
-            ]);
+            expect(validators.validatePath).toHaveBeenCalledWith(
+              { 'a-id': '1', 'b-id': ';b-id=2' },
+              [
+                { name: 'a-id', style: HttpParamStyles.Simple },
+                { name: 'b-id', style: HttpParamStyles.Matrix },
+              ],
+              undefined
+            );
           });
         });
       });
@@ -193,7 +201,7 @@ describe('HttpValidator', () => {
             error => expect(error).toHaveLength(2)
           );
 
-          expect(validators.validateBody).toHaveBeenCalledWith(undefined, [], undefined);
+          expect(validators.validateBody).toHaveBeenCalledWith(undefined, [], undefined, undefined);
           expect(validators.validateHeaders).toHaveBeenCalled();
         });
       });

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -64,7 +64,7 @@ export function findContentByMediaTypeOrFirst(specs: IMediaTypeContent[], mediaT
   );
 }
 
-function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, target: string) {
+function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, target: string, bundle?: unknown) {
   const encodings = get(content, 'encodings', []);
   const encodedUriParams = splitUriParams(target);
 
@@ -74,7 +74,7 @@ function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, 
     E.map(decodedUriEntities => deserializeFormBody(schema, encodings, decodedUriEntities)),
     E.chain(deserialised =>
       pipe(
-        validateAgainstSchema(deserialised, schema, true),
+        validateAgainstSchema(deserialised, schema, true, undefined, bundle),
         E.fromOption(() => deserialised),
         E.swap
       )
@@ -82,7 +82,7 @@ function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, 
   );
 }
 
-export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, mediaType) => {
+export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, mediaType, bundle) => {
   const findContentByMediaType = pipe(
     O.Do,
     O.bind('mediaType', () => O.fromNullable(mediaType)),
@@ -102,7 +102,7 @@ export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, 
           O.fold(
             () =>
               pipe(
-                validateAgainstSchema(target, schema, false),
+                validateAgainstSchema(target, schema, false, undefined, bundle),
                 E.fromOption(() => target),
                 E.swap
               ),

--- a/packages/http/src/validator/validators/headers.ts
+++ b/packages/http/src/validator/validators/headers.ts
@@ -3,5 +3,9 @@ import { IHttpNameValue } from '../../types';
 import { validateParams } from './params';
 import { header } from '../deserializers';
 
-export const validate = (target: IHttpNameValue, specs: IHttpPathParam[]) =>
-  validateParams(target, specs)({ deserializers: header, prefix: 'header', defaultStyle: HttpParamStyles.Simple });
+export const validate = (target: IHttpNameValue, specs: IHttpPathParam[], bundle?: unknown) =>
+  validateParams(
+    target,
+    specs,
+    bundle
+  )({ deserializers: header, prefix: 'header', defaultStyle: HttpParamStyles.Simple });

--- a/packages/http/src/validator/validators/params.ts
+++ b/packages/http/src/validator/validators/params.ts
@@ -19,7 +19,8 @@ export type Deps<Target> = {
 
 export const validateParams = <Target>(
   target: Target,
-  specs: IHttpParam[]
+  specs: IHttpParam[],
+  bundle?: unknown
 ): RE.ReaderEither<Deps<Target>, NEA.NonEmptyArray<IPrismDiagnostic>, Target> => ({
   deserializers,
   prefix,
@@ -59,7 +60,7 @@ export const validateParams = <Target>(
       );
       return { parameterValues, schema };
     }),
-    O.chain(({ parameterValues, schema }) => validateAgainstSchema(parameterValues, schema, true, prefix)),
+    O.chain(({ parameterValues, schema }) => validateAgainstSchema(parameterValues, schema, true, prefix, bundle)),
     O.map(schemaDiagnostic => NEA.concat(schemaDiagnostic, deprecatedWarnings)),
     O.alt(() => NEA.fromArray(deprecatedWarnings)),
     E.fromOption(() => target),

--- a/packages/http/src/validator/validators/path.ts
+++ b/packages/http/src/validator/validators/path.ts
@@ -3,5 +3,5 @@ import type { IHttpNameValue } from '../../types';
 import { validateParams } from './params';
 import { path } from '../deserializers';
 
-export const validate = (target: IHttpNameValue, specs: IHttpPathParam[]) =>
-  validateParams(target, specs)({ deserializers: path, prefix: 'path', defaultStyle: HttpParamStyles.Simple });
+export const validate = (target: IHttpNameValue, specs: IHttpPathParam[], bundle?: unknown) =>
+  validateParams(target, specs, bundle)({ deserializers: path, prefix: 'path', defaultStyle: HttpParamStyles.Simple });

--- a/packages/http/src/validator/validators/query.ts
+++ b/packages/http/src/validator/validators/query.ts
@@ -3,5 +3,5 @@ import type { IHttpNameValues } from '../../types';
 import { validateParams } from './params';
 import { query } from '../deserializers';
 
-export const validate = (target: IHttpNameValues, specs: IHttpQueryParam[]) =>
-  validateParams(target, specs)({ deserializers: query, prefix: 'query', defaultStyle: HttpParamStyles.Form });
+export const validate = (target: IHttpNameValues, specs: IHttpQueryParam[], bundle?: unknown) =>
+  validateParams(target, specs, bundle)({ deserializers: query, prefix: 'query', defaultStyle: HttpParamStyles.Form });

--- a/packages/http/src/validator/validators/types.ts
+++ b/packages/http/src/validator/validators/types.ts
@@ -5,5 +5,6 @@ import { NonEmptyArray } from 'fp-ts/NonEmptyArray';
 export type validateFn<Target, Specs> = (
   target: Target,
   specs: Specs[],
-  mediaType?: string
+  mediaType?: string,
+  bundle?: unknown
 ) => Either<NonEmptyArray<IPrismDiagnostic>, Target>;

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -75,10 +75,16 @@ export const validateAgainstSchema = (
   value: unknown,
   schema: JSONSchema,
   coerce: boolean,
-  prefix?: string
+  prefix?: string,
+  bundle?: unknown
 ): O.Option<NonEmptyArray<IPrismDiagnostic>> =>
   pipe(
-    O.tryCatch(() => assignAjvInstance(String(schema.$schema), coerce).compile(schema)),
+    O.tryCatch(() =>
+      assignAjvInstance(String(schema.$schema), coerce).compile({
+        ...schema,
+        __bundled__: bundle,
+      })
+    ),
     O.chainFirst(validateFn => O.tryCatch(() => validateFn(value))),
     O.chain(validateFn => pipe(O.fromNullable(validateFn.errors), O.chain(fromArray))),
     O.map(errors => convertAjvErrors(errors, DiagnosticSeverity.Error, prefix))

--- a/test-harness/specs/validate-body-params/form-byte-format-fail.oas2.txt
+++ b/test-harness/specs/validate-body-params/form-byte-format-fail.oas2.txt
@@ -24,4 +24,4 @@ curl -i -X POST http://localhost:4010/path -H "Content-Type: application/x-www-f
 ====expect====
 HTTP/1.1 422 Unprocessable Entity
 
-{"type":"https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY","title":"Invalid request","status":422,"detail":"Your request is not valid and no HTTP validation response was found in the spec, so Prism is generating this error for you.","validation":[{"location":["body","id"],"severity":"Error","code":"pattern","message":"must match pattern \"^[\\w\\d+\\/=]*$\""}, {"location":["body","id"],"severity":"Error","code":"format","message":"must match format \"byte\""}]}
+{"type":"https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY","title":"Invalid request","status":422,"detail":"Your request is not valid and no HTTP validation response was found in the spec, so Prism is generating this error for you.","validation":[{"location":["body","id"],"severity":"Error","code":"pattern","message":"must match pattern \"^[\\w\\d+\\/=]*$\""},{"location":["body","id"],"severity":"Error","code":"format","message":"must match format \"byte\""}]}

--- a/test-harness/specs/validate-body-params/form-byte-format-fail.oas2.txt
+++ b/test-harness/specs/validate-body-params/form-byte-format-fail.oas2.txt
@@ -24,4 +24,4 @@ curl -i -X POST http://localhost:4010/path -H "Content-Type: application/x-www-f
 ====expect====
 HTTP/1.1 422 Unprocessable Entity
 
-{"type":"https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY","title":"Invalid request","status":422,"detail":"Your request is not valid and no HTTP validation response was found in the spec, so Prism is generating this error for you.","validation":[{"location":["body","id"],"severity":"Error","code":"pattern","message":"must match pattern \"^[\\w\\d+\\/=]*$\""}]}
+{"type":"https://stoplight.io/prism/errors#UNPROCESSABLE_ENTITY","title":"Invalid request","status":422,"detail":"Your request is not valid and no HTTP validation response was found in the spec, so Prism is generating this error for you.","validation":[{"location":["body","id"],"severity":"Error","code":"pattern","message":"must match pattern \"^[\\w\\d+\\/=]*$\""}, {"location":["body","id"],"severity":"Error","code":"format","message":"must match format \"byte\""}]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,6 @@
 # yarn lockfile v1
 
 
-"@apidevtools/json-schema-ref-parser@9.0.7":
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz#64aa7f5b34e43d74ea9e408b90ddfba02050dde3"
-  integrity sha512-QdwOGF1+eeyFh+17v2Tz626WX0nucd1iKOm6JUTUvCZdbolblCOOQCxGrQPY0f7jEhn36PiAWqZnsC2r5vmUWg==
-  dependencies:
-    "@jsdevtools/ono" "^7.1.3"
-    call-me-maybe "^1.0.1"
-    js-yaml "^3.13.1"
-
 "@babel/code-frame@7.12.11", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -1300,13 +1291,13 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stoplight/http-spec@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-4.1.0.tgz#9af81c973fb20462fd292c7e1a0c994a22003a3b"
-  integrity sha512-01cjtYFth5yaiQMB/xnpwithXKpNU5m9p55qnrRQE7jGVn/BYL9CzTBRcOw1iE7xOh0Atylkm63K6lf4EOfskA==
+"@stoplight/http-spec@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-4.2.0.tgz#b453ccc04a9bde80a51283f3297f8996d142ede2"
+  integrity sha512-wQiv+9404niXkJUEA5tTM8AQBjREZB4s0RXg9PU5xCSWLYpLq20OqwIioXvT6kZTvYsgL6r2ywacMwvDnMTTQQ==
   dependencies:
     "@stoplight/json" "^3.10.2"
-    "@stoplight/types" "^12.2.0"
+    "@stoplight/types" "^12.3.0"
     "@types/swagger-schema-official" "~2.0.21"
     "@types/to-json-schema" "^0.2.0"
     "@types/type-is" "^1.6.3"
@@ -1319,6 +1310,19 @@
     type-is "^1.6.18"
     urijs "~1.19.2"
 
+"@stoplight/json-schema-ref-parser@9.2.1":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-ref-parser/-/json-schema-ref-parser-9.2.1.tgz#48a55c61e7c518e9a7332c424cd53a41b405e9af"
+  integrity sha512-iKWeomA0HHDcbG0G8yVzQFs9y5vtF/GtjEDSuhofdHcPxXMhnTUh8d9NdbhXPCVhwIRmdvzP3jMv2A3747hyWg==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@stoplight/path" "^1.3.2"
+    "@stoplight/yaml" "^4.0.2"
+    abort-controller "^3.0.0"
+    call-me-maybe "^1.0.1"
+    fastestsmallesttextencoderdecoder "^1.0.22"
+    isomorphic-fetch "^3.0.0"
+
 "@stoplight/json-schema-sampler@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json-schema-sampler/-/json-schema-sampler-0.2.0.tgz#31215818ad0c571852fd201955a21a25bc0b77c2"
@@ -1327,7 +1331,7 @@
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"
 
-"@stoplight/json@^3.10.2", "@stoplight/json@^3.12.0":
+"@stoplight/json@^3.10.2":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.12.0.tgz#26c8d32da78eac6a760ba2c9cca6ae717dc417b4"
   integrity sha512-c0bvFOGICk8QWIat72Td2GG6Bdvq/6O2jQcDZ8rEjh56YOdC/YPn1S8ihKu3AntJCtvqC9eTfadWBqkNK9HAjw==
@@ -1338,10 +1342,26 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
+"@stoplight/json@^3.13.6":
+  version "3.13.6"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.13.6.tgz#5e4927734348a0a257c066de7ca3ffe9d8526d6f"
+  integrity sha512-JQNNqp++A4YVCR9mqYuPJQruvu5/XLAJaObR3sD4xT+xwUq8BPP1B/TAjGPS9jP+Fn/nzuFmk7VmYVTSyWClow==
+  dependencies:
+    "@stoplight/ordered-object-literal" "^1.0.1"
+    "@stoplight/types" "^12.2.0"
+    jsonc-parser "~2.2.1"
+    lodash "^4.17.15"
+    safe-stable-stringify "^1.1"
+
 "@stoplight/ordered-object-literal@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.1.tgz#01ece81ba5dda199ca3dc5ec7464691efa5d5b76"
   integrity sha512-kDcBIKwzAXZTkgzaiPXH2I0JXavBkOb3jFzYNFS5cBuvZS3s/K+knpk2wLVt0n8XrnRQsSffzN6XG9HqUhfq6Q==
+
+"@stoplight/path@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/path/-/path-1.3.2.tgz#96e591496b72fde0f0cdae01a61d64f065bd9ede"
+  integrity sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ==
 
 "@stoplight/types@^11.9.0":
   version "11.10.0"
@@ -1359,12 +1379,20 @@
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
 
+"@stoplight/types@^12.3.0":
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-12.3.0.tgz#ac71d295319f26abb279e3d89d1c1774857d20b4"
+  integrity sha512-hgzUR1z5BlYvIzUeFK5pjs5JXSvEutA9Pww31+dVicBlunsG1iXopDx/cvfBY7rHOrgtZDuvyeK4seqkwAZ6Cg==
+  dependencies:
+    "@types/json-schema" "^7.0.4"
+    utility-types "^3.10.0"
+
 "@stoplight/yaml-ast-parser@0.0.48":
   version "0.0.48"
   resolved "https://registry.yarnpkg.com/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.48.tgz#442b21f419427acaa8a3106ebc5d73351c407002"
   integrity sha512-sV+51I7WYnLJnKPn2EMWgS4EUfoP4iWEbrWwbXsj0MZCB/xOK8j6+C9fntIdOM50kpx45ZLC3s6kwKivWuqvyg==
 
-"@stoplight/yaml@^4.2.2":
+"@stoplight/yaml@^4.0.2", "@stoplight/yaml@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@stoplight/yaml/-/yaml-4.2.2.tgz#8c48a46dcdaee114f659764827f46afc0669d65b"
   integrity sha512-N086FU8pmSpjc5TvMBjmlTniZVh3OXzmEh6SYljSLiuv6aMxgjyjf13YrAlUqgu0b4b6pQ5zmkjrfo9i0SiLsw==
@@ -1737,6 +1765,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 abstract-logging@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-2.0.1.tgz#6b0c371df212db7129b57d2e7fcf282b8bf1c839"
@@ -1802,10 +1837,10 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv-formats@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.0.2.tgz#69875cb99d76c74be46e9c7a4444bc232354eba0"
-  integrity sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==
+ajv-formats@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.0.tgz#96eaf83e38d32108b66d82a9cb0cfa24886cdfeb"
+  integrity sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==
   dependencies:
     ajv "^8.0.0"
 
@@ -1819,10 +1854,20 @@ ajv@6.12.6, ajv@^6.10.0, ajv@^6.12.4, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.2.0:
+ajv@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.2.0.tgz#c89d3380a784ce81b2085f48811c4c101df4c602"
   integrity sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
+ajv@^8.4.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.5.0.tgz#695528274bcb5afc865446aa275484049a18ae4b"
+  integrity sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -3513,6 +3558,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
 eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
@@ -3732,6 +3782,11 @@ fast-xml-parser@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz#59b47e7b965f45258629cc6c127bf783281c5e93"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
 
 fastq@^1.6.0:
   version "1.8.0"
@@ -5182,6 +5237,14 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -5703,13 +5766,6 @@ json-schema-ref-parser@^6.1.0:
     call-me-maybe "^1.0.1"
     js-yaml "^3.12.1"
     ono "^4.0.11"
-
-json-schema-ref-parser@^9.0.7:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz#c0ccc5aaee34844f0865889b67e0b67d616f7375"
-  integrity sha512-uxU9Ix+MVszvCTvBucQiIcNEny3oAEFg7EQHSZw2bquCCuqUqEPEczIdv/Uqo1Zv4/wDPZqOI+ulrMk1ncMtjQ==
-  dependencies:
-    "@apidevtools/json-schema-ref-parser" "9.0.7"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -9162,6 +9218,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,6 +1353,17 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
+"@stoplight/json@^3.13.7":
+  version "3.13.7"
+  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.13.7.tgz#1ebc67988597aad3d8668f9ea596f846ca37c7f9"
+  integrity sha512-8XGY4aJSu4f0mtzmkET8LUdymk2U8p144e64DnS87rmaczMUzhzQXT0vQZJoF+PnpXbZvdAkjG6XVAINvzi0oQ==
+  dependencies:
+    "@stoplight/ordered-object-literal" "^1.0.1"
+    "@stoplight/types" "^12.2.0"
+    jsonc-parser "~2.2.1"
+    lodash "^4.17.15"
+    safe-stable-stringify "^1.1"
+
 "@stoplight/ordered-object-literal@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.1.tgz#01ece81ba5dda199ca3dc5ec7464691efa5d5b76"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,17 +1342,6 @@
     lodash "^4.17.15"
     safe-stable-stringify "^1.1"
 
-"@stoplight/json@^3.13.6":
-  version "3.13.6"
-  resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.13.6.tgz#5e4927734348a0a257c066de7ca3ffe9d8526d6f"
-  integrity sha512-JQNNqp++A4YVCR9mqYuPJQruvu5/XLAJaObR3sD4xT+xwUq8BPP1B/TAjGPS9jP+Fn/nzuFmk7VmYVTSyWClow==
-  dependencies:
-    "@stoplight/ordered-object-literal" "^1.0.1"
-    "@stoplight/types" "^12.2.0"
-    jsonc-parser "~2.2.1"
-    lodash "^4.17.15"
-    safe-stable-stringify "^1.1"
-
 "@stoplight/json@^3.13.7":
   version "3.13.7"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.13.7.tgz#1ebc67988597aad3d8668f9ea596f846ca37c7f9"


### PR DESCRIPTION
Addresses https://github.com/stoplightio/prism/issues/1456

Blocked By https://github.com/stoplightio/json/pull/90

**Summary**

- switch to our forked json schema ref parser
- bundle http operations
- validate circular data properly
- dynamically generate data for circular structures
- tests

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

