### PR TITLE
Feature/support colons in paths

### DIFF
--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -13,41 +13,92 @@ describe('matchPath()', () => {
   test('any concrete path should match an equal concrete path', () => {
     // e.g. /a/b/c should match /a/b/c
     const path = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 6 }),
       includeTemplates: false,
     });
 
     assertRight(matchPath(path, path), e => expect(e).toEqual(MatchType.CONCRETE));
   });
 
+  test('any concrete path with colon should match an equal concrete path', () => {
+    // e.g. /a/b:c should match /a/b:c
+    const path = randomPath({
+      pathFragments: faker.datatype.number({ min: 2, max: 6 }),
+      includeTemplates: false,
+      includeColon: true,
+    });
+    assertRight(matchPath(path, path), e => expect(e).toEqual(MatchType.CONCRETE));
+  });
+
+  // This test will likely never fail because strings are always different
   test('none request path should match path with less fragments', () => {
     // e.g. /a/b/c should not match /a/b
     // e.g. /a/b/c should not match /{a}/b
-    const trailingSlash = faker.random.boolean();
+    const trailingSlash = faker.datatype.boolean();
     const requestPath = randomPath({
-      pathFragments: faker.random.number({ min: 4, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
       includeTemplates: false,
       trailingSlash,
     });
     const operationPath = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 3 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
       trailingSlash,
     });
 
     assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
   });
 
+  test('none request path with colons should match path with less fragments', () => {
+    // e.g. /a/b:c should not match /a/b
+    // e.g. /a/b:c should not match /{a}/b
+    const requestPath = randomPath({
+      pathFragments: faker.datatype.number({ min: 5, max: 7 }),
+      includeTemplates: false,
+      includeColon: true,
+    });
+    const operationPath = requestPath.split(':').shift() + '';
+    assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
+  });
+
+  test('none request path with a colon should not match equivalent slash path', () => {
+    // e.g. /a/b:c should not match /a/b/c
+    const requestPath = randomPath({
+      pathFragments: faker.datatype.number({ min: 5, max: 7 }),
+      includeTemplates: false,
+      includeColon: true,
+    });
+    const operationPath = requestPath.replace(':', '/');
+    console.log(requestPath, operationPath);
+    assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
+  });
+
+  // This test will likely never fail because strings are always different
   test('none request path should match concrete path with more fragments', () => {
     // e.g. /a/b should not match /a/b/c
     // e.g. /a/b/ should not match /a/b/c
     const requestPath = randomPath({
-      pathFragments: faker.random.number({ min: 4, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
       includeTemplates: false,
     });
     const operationPath = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 3 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
       includeTemplates: false,
     });
+
+    assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
+  });
+
+  test('none request path with colons should match path with more fragments', () => {
+    // e.g. /a/b:c should not match /a/b/c:d
+    // e.g. /a/b:c should not match /{a}/b/c:d
+    const requestPath = randomPath({
+      pathFragments: faker.datatype.number({ min: 5, max: 7 }),
+      includeTemplates: false,
+      includeColon: true,
+    });
+    const newPath = requestPath.split(':').shift();
+    const lastWord = requestPath.split(':').pop();
+    const operationPath = [newPath, '/', lastWord, ':', faker.random.word()].join('');
 
     assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
   });
@@ -55,9 +106,15 @@ describe('matchPath()', () => {
   test('request path should match a templated path and resolve variables', () => {
     assertRight(matchPath('/a', '/{a}'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
+    assertRight(matchPath('/a:b', '/{a}:b'), e => expect(e).toEqual(MatchType.TEMPLATED));
+
     assertRight(matchPath('/a/b', '/{a}/{b}'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
+    assertRight(matchPath('/a/b:c', '/{a}/{b}:{c}'), e => expect(e).toEqual(MatchType.TEMPLATED));
+
     assertRight(matchPath('/a/b', '/a/{b}'), e => expect(e).toEqual(MatchType.TEMPLATED));
+
+    assertRight(matchPath('/a/b:c', '/a/b:{c}'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
     assertRight(matchPath('/test.json', '/test.{format}'), e => expect(e).toEqual(MatchType.TEMPLATED));
   });
@@ -65,27 +122,32 @@ describe('matchPath()', () => {
   test('request path should match a template path and resolve undefined variables', () => {
     assertRight(matchPath('/', '/{a}'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
+    assertRight(matchPath('/:', '/{a}:{b}'), e => expect(e).toEqual(MatchType.TEMPLATED));
+
     assertRight(matchPath('//', '/{a}/'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
     assertRight(matchPath('//b', '/{a}/{b}'), e => expect(e).toEqual(MatchType.TEMPLATED));
+
+    assertRight(matchPath('//b:c', '/{a}/{b}:{c}'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
     assertRight(matchPath('/a/', '/{a}/{b}'), e => expect(e).toEqual(MatchType.TEMPLATED));
 
     assertRight(matchPath('//', '/{a}/{b}'), e => expect(e).toEqual(MatchType.TEMPLATED));
   });
 
+  // This test will likely never fail because strings are always different
   test('none path should match templated operation with more path fragments', () => {
     // e.g. `/a/b` should not match /{x}/{y}/{z}
     // e.g. `/a` should not match /{x}/{y}/{z}
     const requestPath = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 3 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
       includeTemplates: false,
       trailingSlash: false,
     });
 
     const operationPath = randomPath({
-      pathFragments: faker.random.number({ min: 4, max: 6 }),
-      includeTemplates: false,
+      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
+      includeTemplates: true,
       trailingSlash: false,
     });
 

--- a/packages/http/src/router/matchPath.ts
+++ b/packages/http/src/router/matchPath.ts
@@ -27,7 +27,7 @@ export function matchPath(requestPath: string, operationPath: string): E.Either<
     return E.right(MatchType.NOMATCH);
   }
 
-  // a/b:c
+  // a/b:c = a/b:c
   const operationPathColonFragments = fragmentarizeWithColon(operationPath);
   const requestPathColonFragments = fragmentarizeWithColon(requestPath);
   if (

--- a/test-harness/specs/routing/prefer-colon-path.oas3.txt
+++ b/test-harness/specs/routing/prefer-colon-path.oas3.txt
@@ -1,0 +1,39 @@
+====test====
+When a path has a colon in it, it is selected first
+====spec====
+openapi: 3.0.0
+paths:
+  /test:{rpc}:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: number
+  /test/yes:
+    get:
+      responses:
+        '200':
+          content:
+            text/plain:
+              schema:
+                type: string
+  /test:
+    get:
+      responses:
+        '200':
+          content:
+            text/plain:
+              schema:
+                type: string
+
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -X GET http://localhost:4010/test:yes
+====expect====
+HTTP/1.1 200 OK
+content-type: application/json
+
+0

--- a/test-harness/specs/validate-path-params/path-param-with-colon-simple.oas3.txt
+++ b/test-harness/specs/validate-path-params/path-param-with-colon-simple.oas3.txt
@@ -1,0 +1,33 @@
+====test====
+When I send a request to an operation
+And the operation has a RPC verb and colon in it
+And in the request I sent that segment is present
+I should get a 200 response back
+And the payload of the response should be in application/json content-type
+====spec====
+openapi: 3.0.2
+paths:
+  /pet/a:{b}:
+    get:
+      parameters:
+        - in: path
+          name: b
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          content:
+            description: ok
+            application/json:
+              example: "ok"
+          
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -X GET http://127.0.0.1:4010/pet/a:run
+====expect====
+HTTP/1.1 200 OK
+content-type: application/json
+
+"ok"


### PR DESCRIPTION
Addresses #1785 

**Summary**

First attempt at resolving the "custom method" standard that Google advises around REST endpoints (meeting the need for composable RPC calls within a REST framework).  This typically looks like this:

```
POST /users/{username}:activate
POST /users/{username}:block
```
This PR modifies the http/router/matchPath function to split fragments based on either a slash or a colon but does make some presumptions around trailingSlashes not being compatible.

It also allows for parameterized verbs such as:
```
POST /users/{username}:{action}
```
**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [X] Added & updated in .spec files
    - any concrete path with colon should match an equal concrete path
    - none request path should match path with less fragments
    - none request path with colons should match path with less fragments
    - none request path with a colon should not match equivalent slash path
    - none request path should match concrete path with more fragments
    - none request path with colons should match path with more fragments
    - request path should match a templated path and resolve variables
    - request path should match a template path and resolve undefined variables
    - none path should match templated operation with more path fragments
  - [X] Added in test-harness files
    - When a path has a colon in it, it is selected first
    - When I send a request to an operation with a colon in it, return 200
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [X] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [X] N/A

**Additional context**

I updated the faker references to use the non-deprecated `faker.datatype` instead of the deprecated `faker.random` call, but only in the files I touched.

I also noted a few tests that I suspect aren't actually testing what they're supposed to be... comparing random string vs random string instead of two similar structures.  `x/y/z` will never equal `a/b/c` or `a/b`.  I did not copy that test structure in my tests, but I'm open to modifications.  

Also thanks to @bziggz for assisting. 