### PR TITLE
Increase max request size to 10mb by default

### DIFF
--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -444,6 +444,24 @@ describe('body params validation', () => {
             });
           });
         });
+
+        describe('and size bigger than 10MB', () => {
+          test('returns 422', async () => {
+            const response = await makeRequest('/json-body-required', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: 'A'.repeat(1024 * 1024 * 10 + 1),
+            });
+
+            expect(response.status).toBe(413);
+            return expect(response.json()).resolves.toMatchObject({
+              error: {
+                code: 'request_entity_too_large',
+                message: 'Body exceeded 10mb limit',
+              },
+            });
+          });
+        });
       });
     });
   });

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -48,9 +48,9 @@ function parseRequestBody(request: IncomingMessage) {
   }
 
   if (typeIs(request, ['application/json', 'application/*+json'])) {
-    return json(request);
+    return json(request, { limit: '10mb' });
   } else {
-    return text(request);
+    return text(request, { limit: '10mb' });
   }
 }
 


### PR DESCRIPTION
Addresses #1814

**Summary**

Configure `micri` to accept requests of up to 10MB instead of just 1MB so that users can send larger requests without any additional effort.
Why 10MB? Because [_10MB ought to be enough for anybody_](https://en.wikiquote.org/wiki/Talk:Bill_Gates). ;p

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [X] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [X] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [X] N/A

**Additional context**

In order to mock a service that accepts images in the request body, I need to increase the maximum request size limit.
10MB is enough for my use case and was suggested by @philsturgeon, this could be a configuration option in the future if different use cases come up.