### PR TITLE
Fix/remove deprecation

### DIFF
--- a/packages/cli/src/combinators.ts
+++ b/packages/cli/src/combinators.ts
@@ -2,5 +2,5 @@ import * as E from 'fp-ts/Either';
 import * as A from 'fp-ts/Array';
 import { sequenceS } from 'fp-ts/Apply';
 
-export const traverseEither = A.array.traverse(E.either);
-export const sequenceSEither = sequenceS(E.either);
+export const traverseEither = A.traverse(E.Applicative);
+export const sequenceSEither = sequenceS(E.Apply);

--- a/packages/cli/src/util/paths.ts
+++ b/packages/cli/src/util/paths.ts
@@ -79,7 +79,8 @@ function generateParamValue(spec: IHttpParam): E.Either<Error, unknown> {
 
 function generateParamValues(specs: IHttpParam[]): E.Either<Error, Dictionary<unknown>> {
   return pipe(
-    traverseEither(specs, spec =>
+    specs,
+    traverseEither(spec =>
       pipe(
         generateParamValue(spec),
         E.map(value => [encodeURI(spec.name), value])
@@ -110,13 +111,12 @@ function generateTemplateAndValuesForQueryParams(template: string, operation: IH
 function createPathUriTemplate(inputPath: string, specs: IHttpPathParam[]): E.Either<Error, string> {
   // defaults for query: style=Simple exploded=false
   return pipe(
-    traverseEither(
-      specs.filter(spec => spec.required !== false),
-      spec =>
-        pipe(
-          createParamUriTemplate(spec.name, spec.style || HttpParamStyles.Simple, spec.explode || false),
-          E.map(param => ({ param, name: spec.name }))
-        )
+    specs.filter(spec => spec.required !== false),
+    traverseEither(spec =>
+      pipe(
+        createParamUriTemplate(spec.name, spec.style || HttpParamStyles.Simple, spec.explode || false),
+        E.map(param => ({ param, name: spec.name }))
+      )
     ),
     E.map(values => values.reduce((acc, current) => acc.replace(`{${current.name}}`, current.param), inputPath))
   );

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -9,7 +9,7 @@ import { getSemigroup, NonEmptyArray } from 'fp-ts/NonEmptyArray';
 import { DiagnosticSeverity } from '@stoplight/types';
 import { identity } from 'fp-ts/function';
 
-const eitherSequence = A.sequence(E.getValidation(getSemigroup<IPrismDiagnostic>()));
+const eitherSequence = A.sequence(E.getApplicativeValidation(getSemigroup<IPrismDiagnostic>()));
 
 function isProxyConfig(p: IPrismConfig): p is IPrismProxyConfig {
   return !p.mock;

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -9,7 +9,7 @@ import { getSemigroup, NonEmptyArray } from 'fp-ts/NonEmptyArray';
 import { DiagnosticSeverity } from '@stoplight/types';
 import { identity } from 'fp-ts/function';
 
-const eitherSequence = A.array.sequence(E.getValidation(getSemigroup<IPrismDiagnostic>()));
+const eitherSequence = A.sequence(E.getValidation(getSemigroup<IPrismDiagnostic>()));
 
 function isProxyConfig(p: IPrismConfig): p is IPrismProxyConfig {
   return !p.mock;

--- a/packages/http/src/combinators.ts
+++ b/packages/http/src/combinators.ts
@@ -5,6 +5,6 @@ import { sequenceT } from 'fp-ts/Apply';
 import { getSemigroup } from 'fp-ts/NonEmptyArray';
 import { getValidation } from 'fp-ts/Either';
 
-export const traverseOption = A.array.traverse(O.option);
+export const traverseOption = A.traverse(O.option);
 export const sequenceOption = sequenceT(O.option);
 export const sequenceValidation = sequenceT(getValidation(getSemigroup<IPrismDiagnostic>()));

--- a/packages/http/src/combinators.ts
+++ b/packages/http/src/combinators.ts
@@ -5,6 +5,6 @@ import { sequenceT } from 'fp-ts/Apply';
 import { getSemigroup } from 'fp-ts/NonEmptyArray';
 import { getValidation } from 'fp-ts/Either';
 
-export const traverseOption = A.traverse(O.option);
-export const sequenceOption = sequenceT(O.option);
+export const traverseOption = A.traverse(O.Applicative);
+export const sequenceOption = sequenceT(O.Apply);
 export const sequenceValidation = sequenceT(getValidation(getSemigroup<IPrismDiagnostic>()));

--- a/packages/http/src/combinators.ts
+++ b/packages/http/src/combinators.ts
@@ -3,8 +3,8 @@ import * as O from 'fp-ts/Option';
 import * as A from 'fp-ts/Array';
 import { sequenceT } from 'fp-ts/Apply';
 import { getSemigroup } from 'fp-ts/NonEmptyArray';
-import { getValidation } from 'fp-ts/Either';
+import { getApplicativeValidation } from 'fp-ts/Either';
 
 export const traverseOption = A.traverse(O.Applicative);
 export const sequenceOption = sequenceT(O.Apply);
-export const sequenceValidation = sequenceT(getValidation(getSemigroup<IPrismDiagnostic>()));
+export const sequenceValidation = sequenceT(getApplicativeValidation(getSemigroup<IPrismDiagnostic>()));

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -6,7 +6,7 @@ import * as NEA from 'fp-ts/NonEmptyArray';
 import * as E from 'fp-ts/Either';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
-import * as JSON from 'fp-ts/json';
+import * as J from 'fp-ts/Json';
 import { defaults, omit } from 'lodash';
 import { format, parse } from 'url';
 import { posix } from 'path';
@@ -78,7 +78,7 @@ function serializeBody(body: unknown): E.Either<Error, string | undefined> {
     return E.right(body);
   }
 
-  if (body) return pipe(JSON.stringify(body), E.mapLeft(E.toError));
+  if (body) return pipe(J.stringify(body), E.mapLeft(E.toError));
 
   return E.right(undefined);
 }

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -6,6 +6,7 @@ import * as NEA from 'fp-ts/NonEmptyArray';
 import * as E from 'fp-ts/Either';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
+import * as JSON from 'fp-ts/json';
 import { defaults, omit } from 'lodash';
 import { format, parse } from 'url';
 import { posix } from 'path';
@@ -77,7 +78,7 @@ function serializeBody(body: unknown): E.Either<Error, string | undefined> {
     return E.right(body);
   }
 
-  if (body) return E.stringifyJSON(body, E.toError);
+  if (body) return pipe(JSON.stringify(body), E.mapLeft(E.toError));
 
   return E.right(undefined);
 }

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -88,8 +88,8 @@ function assembleBody(request?: IHttpOperationRequest): O.Option<{ body: string;
 const assembleHeaders = (request?: IHttpOperationRequest, bodyMediaType?: string): O.Option<Dictionary<string>> =>
   pipe(
     O.fromNullable(request?.headers),
-    O.chain(params =>
-      traverseOption(params, param =>
+    O.chain(
+      traverseOption(param =>
         pipe(
           generateHttpParam(param),
           O.map(value => [param.name, value])

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -7,6 +7,7 @@ import * as O from 'fp-ts/Option';
 import * as A from 'fp-ts/Array';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
+import * as JSON from 'fp-ts/json';
 import { traverseOption } from '../../combinators';
 import { head } from 'fp-ts/Array';
 import { pipe } from 'fp-ts/function';
@@ -77,7 +78,7 @@ function assembleBody(request?: IHttpOperationRequest): O.Option<{ body: string;
     O.bind('body', ({ content }) => generateHttpParam(content)),
     O.chain(({ body, content: { mediaType } }) =>
       pipe(
-        E.stringifyJSON(body, () => undefined),
+        JSON.stringify(body),
         E.map(body => ({ body, mediaType })),
         O.fromEither
       )

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -7,7 +7,7 @@ import * as O from 'fp-ts/Option';
 import * as A from 'fp-ts/Array';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
-import * as JSON from 'fp-ts/json';
+import * as J from 'fp-ts/Json';
 import { traverseOption } from '../../combinators';
 import { head } from 'fp-ts/Array';
 import { pipe } from 'fp-ts/function';
@@ -78,7 +78,7 @@ function assembleBody(request?: IHttpOperationRequest): O.Option<{ body: string;
     O.bind('body', ({ content }) => generateHttpParam(content)),
     O.chain(({ body, content: { mediaType } }) =>
       pipe(
-        JSON.stringify(body),
+        J.stringify(body),
         E.map(body => ({ body, mediaType })),
         O.fromEither
       )

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -43,8 +43,8 @@ import {
 } from '../validator/validators/body';
 import { NonEmptyArray } from 'fp-ts/NonEmptyArray';
 
-const eitherRecordSequence = Record.sequence(E.either);
-const eitherSequence = sequenceT(E.either);
+const eitherRecordSequence = Record.sequence(E.Applicative);
+const eitherSequence = sequenceT(E.Apply);
 
 const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpMockConfig>['mock'] = ({
   resource,

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -336,7 +336,7 @@ describe('NegotiatorHelpers', () => {
     });
 
     it('given response defined should try to negotiate by that response', () => {
-      const code = faker.random.number();
+      const code = faker.datatype.number();
       const fakeResponse = {
         code: code.toString(),
         contents: [],
@@ -367,7 +367,7 @@ describe('NegotiatorHelpers', () => {
     });
 
     it('given response defined should fallback to default code on error', () => {
-      const code = faker.random.number();
+      const code = faker.datatype.number();
       const fakeResponse = {
         code: code.toString(),
       };
@@ -398,7 +398,7 @@ describe('NegotiatorHelpers', () => {
     });
 
     it('given response not defined should fallback to default code', () => {
-      const code = faker.random.number();
+      const code = faker.datatype.number();
       const desiredOptions = { dynamic: false };
       httpOperation = anHttpOperation(httpOperation).instance();
 
@@ -485,7 +485,7 @@ describe('NegotiatorHelpers', () => {
       it('and httpContent exists should negotiate that contents', () => {
         const desiredOptions = {
           mediaTypes: [faker.system.mimeType()],
-          dynamic: faker.random.boolean(),
+          dynamic: faker.datatype.boolean(),
           exampleKey: faker.random.word(),
         };
 
@@ -610,7 +610,7 @@ describe('NegotiatorHelpers', () => {
         it('should throw an error', () => {
           const desiredOptions: NegotiationOptions = {
             mediaTypes: [faker.system.mimeType()],
-            dynamic: faker.random.boolean(),
+            dynamic: faker.datatype.boolean(),
             exampleKey: faker.random.word(),
           };
 
@@ -656,7 +656,7 @@ describe('NegotiatorHelpers', () => {
     describe('given no mediaType', () => {
       it('should negotiate default media type', () => {
         const desiredOptions: NegotiationOptions = {
-          dynamic: faker.random.boolean(),
+          dynamic: faker.datatype.boolean(),
           exampleKey: faker.random.word(),
         };
 
@@ -708,7 +708,7 @@ describe('NegotiatorHelpers', () => {
         const code = faker.random.word();
         const partialOptions = {
           code,
-          dynamic: faker.random.boolean(),
+          dynamic: faker.datatype.boolean(),
           exampleKey: faker.random.word(),
         };
 
@@ -826,7 +826,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       const partialOptions = {
         code: '200',
         exampleKey,
-        dynamic: faker.random.boolean(),
+        dynamic: faker.datatype.boolean(),
       };
       const bodyExample: INodeExample = {
         key: exampleKey,
@@ -857,7 +857,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       const partialOptions = {
         code: '200',
         exampleKey,
-        dynamic: faker.random.boolean(),
+        dynamic: faker.datatype.boolean(),
       };
       const httpContent: IMediaTypeContent = {
         mediaType: faker.system.mimeType(),

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -15,7 +15,7 @@ import { pickSetOfHttpMethods, pickOneHttpMethod, randomPath } from './utils';
 
 function createResource(method: string, path: string, servers: IServer[]): IHttpOperation {
   return {
-    id: faker.random.uuid(),
+    id: faker.datatype.uuid(),
     method,
     path,
     responses: [{ code: '200' }],

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -13,7 +13,7 @@ describe('matchPath()', () => {
   test('any concrete path should match an equal concrete path', () => {
     // e.g. /a/b/c should match /a/b/c
     const path = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 6 }),
       includeTemplates: false,
     });
 
@@ -23,14 +23,14 @@ describe('matchPath()', () => {
   test('none request path should match path with less fragments', () => {
     // e.g. /a/b/c should not match /a/b
     // e.g. /a/b/c should not match /{a}/b
-    const trailingSlash = faker.random.boolean();
+    const trailingSlash = faker.datatype.boolean();
     const requestPath = randomPath({
-      pathFragments: faker.random.number({ min: 4, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
       includeTemplates: false,
       trailingSlash,
     });
     const operationPath = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 3 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
       trailingSlash,
     });
 
@@ -41,11 +41,11 @@ describe('matchPath()', () => {
     // e.g. /a/b should not match /a/b/c
     // e.g. /a/b/ should not match /a/b/c
     const requestPath = randomPath({
-      pathFragments: faker.random.number({ min: 4, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
       includeTemplates: false,
     });
     const operationPath = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 3 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
       includeTemplates: false,
     });
 
@@ -78,13 +78,13 @@ describe('matchPath()', () => {
     // e.g. `/a/b` should not match /{x}/{y}/{z}
     // e.g. `/a` should not match /{x}/{y}/{z}
     const requestPath = randomPath({
-      pathFragments: faker.random.number({ min: 1, max: 3 }),
+      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
       includeTemplates: false,
       trailingSlash: false,
     });
 
     const operationPath = randomPath({
-      pathFragments: faker.random.number({ min: 4, max: 6 }),
+      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
       includeTemplates: false,
       trailingSlash: false,
     });

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -32,7 +32,9 @@ export function randomPath(opts: IRandomPathOptions = defaultRandomPathOptions):
 
   const randomPathFragments = new Array(options.pathFragments)
     .fill(0)
-    .map(() => (options.includeTemplates && faker.random.boolean() ? `{${faker.random.word()}}` : faker.random.word()));
+    .map(() =>
+      options.includeTemplates && faker.datatype.boolean() ? `{${faker.random.word()}}` : faker.random.word()
+    );
 
   const leadingSlash = options.leadingSlash ? '/' : '';
   const trailingSlash = options.trailingSlash ? '/' : '';

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -15,7 +15,7 @@ import { matchBaseUrl } from './matchBaseUrl';
 import { matchPath } from './matchPath';
 import { IMatch, MatchType } from './types';
 
-const eitherSequence = A.sequence(E.either);
+const eitherSequence = A.sequence(E.Applicative);
 
 const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig>['route'] = ({ resources, input }) => {
   const { path: requestPath, baseUrl: requestBaseUrl } = input.url;

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -15,7 +15,7 @@ import { matchBaseUrl } from './matchBaseUrl';
 import { matchPath } from './matchPath';
 import { IMatch, MatchType } from './types';
 
-const eitherSequence = A.array.sequence(E.either);
+const eitherSequence = A.sequence(E.either);
 
 const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig>['route'] = ({ resources, input }) => {
   const { path: requestPath, baseUrl: requestBaseUrl } = input.url;

--- a/packages/http/src/validator/validators/security/index.ts
+++ b/packages/http/src/validator/validators/security/index.ts
@@ -6,18 +6,19 @@ import { flatten } from 'lodash';
 import { set } from 'lodash/fp';
 import { findSecurityHandler } from './handlers';
 import { NonEmptyArray, getSemigroup } from 'fp-ts/NonEmptyArray';
-import { isNonEmpty, array } from 'fp-ts/Array';
+import { isNonEmpty, sequence } from 'fp-ts/Array';
 import { IPrismDiagnostic, ValidatorFn } from '@stoplight/prism-core';
 import { IHttpRequest } from '../../../types';
 
 type HeadersAndUrl = Pick<IHttpRequest, 'headers' | 'url'>;
 
-const EitherValidation = E.getValidation(getSemigroup<IPrismDiagnostic>());
-const eitherSequence = array.sequence(EitherValidation);
+const EitherAltValidation = E.getAltValidation(getSemigroup<IPrismDiagnostic>());
+const EitherApplicativeValidation = E.getApplicativeValidation(getSemigroup<IPrismDiagnostic>());
+const eitherSequence = sequence(EitherApplicativeValidation);
 
 function getValidationResults(securitySchemes: HttpSecurityScheme[][], input: HeadersAndUrl) {
   const [first, ...others] = getAuthenticationArray(securitySchemes, input);
-  return others.reduce((prev, current) => EitherValidation.alt(prev, () => current), first);
+  return others.reduce((prev, current) => EitherAltValidation.alt(prev, () => current), first);
 }
 
 function setErrorTag(authResults: NonEmptyArray<IPrismDiagnostic>) {


### PR DESCRIPTION
**Summary**

Replace following deprecated usage to non-deprecated one

- faker.random.number
- faker.random.uuid
- faker.random.boolean
- E.either
- E.getValidation
- A.array
- O.option
- E.stringifyJSON

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

