### PR TITLE
readOnly and writeOnly support v2

### DIFF
--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -27,7 +27,9 @@ export function generate(bundle: unknown, source: JSONSchema): Either<Error, unk
   return pipe(
     stripWriteOnlyProperties(source),
     E.fromOption(() => Error('Cannot strip writeOnly properties')),
-    E.chain(() => tryCatch(() => jsf.generate({ ...cloneDeep(source), __bundled__: bundle }), toError))
+    E.chain(updatedSource =>
+      tryCatch(() => jsf.generate({ ...cloneDeep(updatedSource), __bundled__: bundle }), toError)
+    )
   );
 }
 

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -106,6 +106,25 @@ describe('JSONSchema generator', () => {
       it('will return a left', () => assertLeft(generate({}, schema)));
     });
 
+    describe('when writeOnly properties are provided', () => {
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string', writeOnly: true },
+        },
+        required: ['id', 'title'],
+      };
+
+      it('removes writeOnly properties', () => {
+        assertRight(generate({}, schema), instance => {
+          expect(instance).toEqual({
+            id: expect.any(String),
+          });
+        });
+      });
+    });
+
     it('operates on sealed schema objects', () => {
       const schema: JSONSchema = {
         type: 'object',

--- a/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
+++ b/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
@@ -77,4 +77,24 @@ describe('filterRequiredProperties', () => {
       });
     });
   });
+
+  it('strips writeOnly properties and leaves boolean properties', () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        name: true,
+        description: { type: 'string', writeOnly: true },
+        title: { type: 'string', readOnly: true },
+      },
+      required: ['name', 'description', 'title'],
+    };
+
+    assertSome(stripWriteOnlyProperties(schema), schema => {
+      expect(schema.required).toEqual(['name', 'title']);
+      expect(schema.properties).toEqual({
+        name: true,
+        title: { type: 'string', readOnly: true },
+      });
+    });
+  });
 });

--- a/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
+++ b/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
@@ -97,4 +97,24 @@ describe('filterRequiredProperties', () => {
       });
     });
   });
+
+  it('removes required properties that have been filterer', () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        description: { type: 'string', writeOnly: true },
+        priority: { type: 'number', default: 0 },
+      },
+      required: ['title', 'description'],
+    };
+
+    assertSome(stripWriteOnlyProperties(schema), schema => {
+      expect(schema.required).toEqual(['title']);
+      expect(schema.properties).toEqual({
+        title: { type: 'string' },
+        priority: { type: 'number', default: 0 },
+      });
+    });
+  });
 });

--- a/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
+++ b/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
@@ -16,7 +16,7 @@ describe('filterRequiredProperties', () => {
 
     assertSome(stripWriteOnlyProperties(schema), schema => {
       expect(schema.required).toEqual(['name', 'title']);
-      expect(schema.properties).toMatchObject({
+      expect(schema.properties).toEqual({
         name: expect.any(Object),
         title: expect.any(Object),
       });
@@ -36,14 +36,14 @@ describe('filterRequiredProperties', () => {
 
     assertSome(stripReadOnlyProperties(schema), schema => {
       expect(schema.required).toEqual(['name', 'description']);
-      expect(schema.properties).toMatchObject({
+      expect(schema.properties).toEqual({
         name: expect.any(Object),
         description: expect.any(Object),
       });
     });
   });
 
-  it('strips nested properties', () => {
+  it('strips nested writeOnly properties', () => {
     const schema: JSONSchema = {
       type: 'object',
       properties: {
@@ -63,7 +63,7 @@ describe('filterRequiredProperties', () => {
 
     assertSome(stripWriteOnlyProperties(schema), schema => {
       expect(schema.required).toEqual(['name', 'title', 'author']);
-      expect(schema.properties).toMatchObject({
+      expect(schema.properties).toEqual({
         name: expect.any(Object),
         title: expect.any(Object),
         author: expect.objectContaining({

--- a/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
+++ b/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
@@ -42,4 +42,39 @@ describe('filterRequiredProperties', () => {
       });
     });
   });
+
+  it('strips nested properties', () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        title: { type: 'string', readOnly: true },
+        author: {
+          type: 'object',
+          properties: {
+            userId: { type: 'string' },
+            username: { type: 'string', writeOnly: true },
+          },
+          required: ['userId', 'username'],
+        },
+      },
+      required: ['name', 'title', 'author'],
+    };
+
+    assertSome(stripWriteOnlyProperties(schema), schema => {
+      expect(schema.required).toEqual(['name', 'title', 'author']);
+      expect(schema.properties).toMatchObject({
+        name: expect.any(Object),
+        title: expect.any(Object),
+        author: expect.objectContaining({
+          properties: {
+            userId: {
+              type: 'string',
+            },
+          },
+          required: ['userId'],
+        }),
+      });
+    });
+  });
 });

--- a/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
+++ b/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
@@ -1,0 +1,45 @@
+import { JSONSchema } from '../../types';
+import { stripReadOnlyProperties, stripWriteOnlyProperties } from '../filterRequiredProperties';
+import { assertSome } from '@stoplight/prism-core/src/__tests__/utils';
+
+describe('filterRequiredProperties', () => {
+  it('strips writeOnly properties', () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        description: { type: 'string', writeOnly: true },
+        title: { type: 'string', readOnly: true },
+      },
+      required: ['name', 'description', 'title'],
+    };
+
+    assertSome(stripWriteOnlyProperties(schema), schema => {
+      expect(schema.required).toEqual(['name', 'title']);
+      expect(schema.properties).toMatchObject({
+        name: expect.any(Object),
+        title: expect.any(Object),
+      });
+    });
+  });
+
+  it('strips readOnly properties', () => {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        description: { type: 'string', writeOnly: true },
+        title: { type: 'string', readOnly: true },
+      },
+      required: ['name', 'description', 'title'],
+    };
+
+    assertSome(stripReadOnlyProperties(schema), schema => {
+      expect(schema.required).toEqual(['name', 'description']);
+      expect(schema.properties).toMatchObject({
+        name: expect.any(Object),
+        description: expect.any(Object),
+      });
+    });
+  });
+});

--- a/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
+++ b/packages/http/src/utils/__tests__/filterRequiredProperties.test.ts
@@ -98,7 +98,7 @@ describe('filterRequiredProperties', () => {
     });
   });
 
-  it('removes required properties that have been filterer', () => {
+  it('removes required properties that have been filtered', () => {
     const schema: JSONSchema = {
       type: 'object',
       properties: {

--- a/packages/http/src/utils/filterRequiredProperties.ts
+++ b/packages/http/src/utils/filterRequiredProperties.ts
@@ -1,58 +1,83 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
-import { mapValues, intersection, pickBy } from 'lodash/fp';
 import { pipe } from 'fp-ts/function';
-import * as O from 'fp-ts/lib/Option';
+import * as O from 'fp-ts/Option';
+import { Option } from 'fp-ts/Option';
+import * as A from 'fp-ts/Array';
+import { JSONSchema } from '../types';
+
+type Properties = Record<string, JSONSchema6 | JSONSchema7 | JSONSchema4 | boolean>;
 
 type RequiredSchemaSubset = {
   readOnly?: boolean;
   writeOnly?: boolean;
-  properties?: Record<string, JSONSchema6 | JSONSchema7 | JSONSchema4 | boolean>;
+  properties?: Properties;
   required?: string[] | false;
 };
 
-type SchemaFilterFunc = <S extends RequiredSchemaSubset>(schema: S) => O.Option<S>;
-
-const buildSchemaFilter = (predicate: (schema: RequiredSchemaSubset) => boolean): SchemaFilterFunc => {
-  const filter = <S extends RequiredSchemaSubset>(inputSchema: S): O.Option<S> => {
-    if (!predicate(inputSchema)) {
-      return O.none;
-    }
-
-    const strippedProperties = pipe(
-      O.fromNullable(inputSchema.properties),
-      O.map(
-        mapValues(val => {
-          return pipe(
-            O.some(val),
-            O.chain(val => (typeof val === 'boolean' ? O.none : filter(val))),
-            O.toUndefined
-          );
-        })
+const buildSchemaFilter = <S extends RequiredSchemaSubset>(
+  keepPropertyPredicate: (schema: S) => Option<S>
+): ((schema: S) => Option<S>) => {
+  function filterProperties(schema: S): Option<S> {
+    return pipe(
+      O.fromNullable(schema.properties),
+      O.map(properties =>
+        pipe(
+          Object.keys(properties),
+          A.reduce({} as Properties, (filteredProperties: Properties, propertyName) =>
+            pipe(
+              properties[propertyName],
+              p => (typeof p === 'boolean' ? O.none : filter(p as S)),
+              O.map(v => ({ ...filteredProperties, [propertyName]: v } as Properties)),
+              O.fold(
+                () => filteredProperties,
+                v => v
+              )
+            )
+          )
+        )
       ),
-      O.map(pickBy(val => val !== undefined))
+      O.map(filteredProperties => ({
+        ...schema,
+        properties: filteredProperties,
+      })),
+      O.alt(() => O.some(schema))
     );
+  }
 
-    const strippedPropertyKeys = pipe(
-      strippedProperties,
-      O.map(Object.keys),
-      O.getOrElse(() => [] as string[])
+  function filterRequired(updatedSchema: S, originalSchema: S): Option<S> {
+    return pipe(
+      updatedSchema,
+      O.fromPredicate((schema: S) => Array.isArray(schema.required)),
+      O.map(schema => Object.keys(schema.properties || {})),
+      O.map(updatedProperties => {
+        const originalPropertyNames = Object.keys(originalSchema.properties || {});
+        return originalPropertyNames.filter(name => updatedProperties.includes(name));
+      }),
+      O.map(required => {
+        return {
+          ...updatedSchema,
+          required,
+        };
+      }),
+      O.alt(() => O.some(updatedSchema))
     );
+  }
 
-    const requiredPropertyKeys = pipe(
-      O.fromNullable(inputSchema.required || null),
-      O.map(intersection(strippedPropertyKeys)),
-      O.toUndefined
+  function filter(inputSchema: S): Option<S> {
+    return pipe(
+      inputSchema,
+      keepPropertyPredicate,
+      O.chain(inputSchema => filterProperties(inputSchema)),
+      O.chain(schema => filterRequired(schema, inputSchema))
     );
-
-    return O.some({
-      ...inputSchema,
-      properties: O.toUndefined(strippedProperties),
-      required: requiredPropertyKeys,
-    });
-  };
+  }
 
   return filter;
 };
 
-export const stripReadOnlyProperties = buildSchemaFilter(schema => schema.readOnly !== true);
-export const stripWriteOnlyProperties = buildSchemaFilter(schema => schema.writeOnly !== true);
+export const stripReadOnlyProperties = buildSchemaFilter(
+  O.fromPredicate((schema: JSONSchema) => schema.readOnly !== true)
+);
+export const stripWriteOnlyProperties = buildSchemaFilter(
+  O.fromPredicate((schema: JSONSchema) => schema.writeOnly !== true)
+);

--- a/packages/http/src/utils/filterRequiredProperties.ts
+++ b/packages/http/src/utils/filterRequiredProperties.ts
@@ -1,0 +1,58 @@
+import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
+import { mapValues, intersection, pickBy } from 'lodash/fp';
+import { pipe } from 'fp-ts/function';
+import * as O from 'fp-ts/lib/Option';
+
+type RequiredSchemaSubset = {
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  properties?: Record<string, JSONSchema6 | JSONSchema7 | JSONSchema4 | boolean>;
+  required?: string[] | false;
+};
+
+type SchemaFilterFunc = <S extends RequiredSchemaSubset>(schema: S) => O.Option<S>;
+
+const buildSchemaFilter = (predicate: (schema: RequiredSchemaSubset) => boolean): SchemaFilterFunc => {
+  const filter = <S extends RequiredSchemaSubset>(inputSchema: S): O.Option<S> => {
+    if (!predicate(inputSchema)) {
+      return O.none;
+    }
+
+    const strippedProperties = pipe(
+      O.fromNullable(inputSchema.properties),
+      O.map(
+        mapValues(val => {
+          return pipe(
+            O.some(val),
+            O.chain(val => (typeof val === 'boolean' ? O.none : filter(val))),
+            O.toUndefined
+          );
+        })
+      ),
+      O.map(pickBy(val => val !== undefined))
+    );
+
+    const strippedPropertyKeys = pipe(
+      strippedProperties,
+      O.map(Object.keys),
+      O.getOrElse(() => [] as string[])
+    );
+
+    const requiredPropertyKeys = pipe(
+      O.fromNullable(inputSchema.required || null),
+      O.map(intersection(strippedPropertyKeys)),
+      O.toUndefined
+    );
+
+    return O.some({
+      ...inputSchema,
+      properties: O.toUndefined(strippedProperties),
+      required: requiredPropertyKeys,
+    });
+  };
+
+  return filter;
+};
+
+export const stripReadOnlyProperties = buildSchemaFilter(schema => schema.readOnly !== true);
+export const stripWriteOnlyProperties = buildSchemaFilter(schema => schema.writeOnly !== true);

--- a/packages/http/src/utils/filterRequiredProperties.ts
+++ b/packages/http/src/utils/filterRequiredProperties.ts
@@ -28,7 +28,13 @@ const buildSchemaFilter = <S extends RequiredSchemaSubset>(
             (filteredProperties: Properties, propertyName): Properties => {
               return pipe(
                 properties[propertyName],
-                O.fromPredicate(p => typeof p !== 'boolean'),
+                O.fromPredicate(p => {
+                  if (typeof p === 'boolean') {
+                    filteredProperties[propertyName] = properties[propertyName];
+                    return false;
+                  }
+                  return true;
+                }),
                 O.chain(p => filter(p as S)),
                 O.map(v => ({ ...filteredProperties, [propertyName]: v } as Properties)),
                 O.fold(

--- a/packages/http/src/utils/filterRequiredProperties.ts
+++ b/packages/http/src/utils/filterRequiredProperties.ts
@@ -61,8 +61,11 @@ const buildSchemaFilter = <S extends RequiredSchemaSubset>(
       O.map(schema => Object.keys(schema.properties || {})),
       O.map(updatedProperties => {
         const originalPropertyNames = Object.keys(originalSchema.properties || {});
-        return originalPropertyNames.filter(name => updatedProperties.includes(name));
+        return originalPropertyNames.filter(name => !updatedProperties.includes(name));
       }),
+      O.map(removedProperties =>
+        (originalSchema.required as string[]).filter(name => !removedProperties.includes(name))
+      ),
       O.map(required => {
         return {
           ...updatedSchema,

--- a/packages/http/src/utils/filterRequiredProperties.ts
+++ b/packages/http/src/utils/filterRequiredProperties.ts
@@ -23,16 +23,20 @@ const buildSchemaFilter = <S extends RequiredSchemaSubset>(
       O.map(properties =>
         pipe(
           Object.keys(properties),
-          A.reduce({} as Properties, (filteredProperties: Properties, propertyName) =>
-            pipe(
-              properties[propertyName],
-              p => (typeof p === 'boolean' ? O.none : filter(p as S)),
-              O.map(v => ({ ...filteredProperties, [propertyName]: v } as Properties)),
-              O.fold(
-                () => filteredProperties,
-                v => v
-              )
-            )
+          A.reduce(
+            {} as Properties,
+            (filteredProperties: Properties, propertyName): Properties => {
+              return pipe(
+                properties[propertyName],
+                O.fromPredicate(p => typeof p !== 'boolean'),
+                O.chain(p => filter(p as S)),
+                O.map(v => ({ ...filteredProperties, [propertyName]: v } as Properties)),
+                O.fold(
+                  () => filteredProperties,
+                  v => v
+                )
+              );
+            }
           )
         )
       ),

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -5,6 +5,7 @@ import { IHttpRequest } from '../../types';
 import * as validators from '../validators';
 import * as validator from '../';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
+import { ValidationContext } from '../validators/types';
 
 const validate = (
   resourceExtension?: Partial<IHttpOperation>,
@@ -201,7 +202,13 @@ describe('HttpValidator', () => {
             error => expect(error).toHaveLength(2)
           );
 
-          expect(validators.validateBody).toHaveBeenCalledWith(undefined, [], undefined, undefined);
+          expect(validators.validateBody).toHaveBeenCalledWith(
+            undefined,
+            [],
+            ValidationContext.Output,
+            undefined,
+            undefined
+          );
           expect(validators.validateHeaders).toHaveBeenCalled();
         });
       });

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -10,7 +10,9 @@ import { is as typeIs } from 'type-is';
 import { JSONSchema } from '../../types';
 import { body } from '../deserializers';
 import { validateAgainstSchema } from './utils';
-import { validateFn } from './types';
+import { ValidationContext, validateFn } from './types';
+
+import { stripReadOnlyProperties, stripWriteOnlyProperties } from '../../utils/filterRequiredProperties';
 
 export function deserializeFormBody(
   schema: JSONSchema,
@@ -82,13 +84,20 @@ function deserializeAndValidate(content: IMediaTypeContent, schema: JSONSchema, 
   );
 }
 
-export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, mediaType, bundle) => {
+const normalizeSchemaProcessorMap: Record<ValidationContext, (schema: JSONSchema) => O.Option<JSONSchema>> = {
+  [ValidationContext.Input]: stripReadOnlyProperties,
+  [ValidationContext.Output]: stripWriteOnlyProperties,
+};
+
+export const validate: validateFn<unknown, IMediaTypeContent> = (target, specs, context, mediaType, bundle) => {
   const findContentByMediaType = pipe(
     O.Do,
     O.bind('mediaType', () => O.fromNullable(mediaType)),
     O.bind('contentResult', ({ mediaType }) => findContentByMediaTypeOrFirst(specs, mediaType)),
     O.alt(() => O.some({ contentResult: { content: specs[0] || {}, mediaType: 'random' } })),
-    O.bind('schema', ({ contentResult }) => O.fromNullable(contentResult.content.schema))
+    O.bind('schema', ({ contentResult }) =>
+      pipe(O.fromNullable(contentResult.content.schema), O.chain(normalizeSchemaProcessorMap[context]))
+    )
   );
 
   return pipe(
@@ -143,7 +152,7 @@ function validateAgainstReservedCharacters(
       const property = encoding.property;
       const value = encodedUriParams[property];
 
-      if (!allowReserved && typeof value === 'string' && /[/?#[\]@!$&'()*+,;=]/.test(value)) {
+      if (!allowReserved && /[/?#[\]@!$&'()*+,;=]/.test(value)) {
         diagnostics.push({
           path: [property],
           message: 'Reserved characters used in request body',

--- a/packages/http/src/validator/validators/types.ts
+++ b/packages/http/src/validator/validators/types.ts
@@ -2,9 +2,15 @@ import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { Either } from 'fp-ts/Either';
 import { NonEmptyArray } from 'fp-ts/NonEmptyArray';
 
+export enum ValidationContext {
+  Input,
+  Output,
+}
+
 export type validateFn<Target, Specs> = (
   target: Target,
   specs: Specs[],
+  context: ValidationContext,
   mediaType?: string,
   bundle?: unknown
 ) => Either<NonEmptyArray<IPrismDiagnostic>, Target>;


### PR DESCRIPTION
`validate` requires a new context parameter, that will define validation context - input or output. Based on the context either readOnly or writeOnly parameters will be removed from the required list.

Addresses #1142

**Summary**

Replace this with something that explains what this PR is for and why it matters.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A


**Additional context**

> Read-Only and Write-Only Properties
> If a readOnly or writeOnly property is included in the required list, required affects just the relevant scope – responses only or requests only. That is, read-only required properties apply to responses only, and write-only required properties – to requests only.

This PR based on @marcelltoth PR  [https://github.com/stoplightio/prism/pull/1619](https://github.com/stoplightio/prism/pull/1619) It's quite old, and it was quite difficult to resolve merge conflicts. 

I also made `Context` a required parameter and removed `none` option. Since we always have either input or output context. 
