### PR TITLE
minor doc fix

### DIFF
--- a/docs/guides/06-errors.md
+++ b/docs/guides/06-errors.md
@@ -188,7 +188,7 @@ curl http://localhost:4010/todos -H "accept: application/json"`
 
 **Explanation:** This error occurs when the current request is asking for a specific status code that the document is not listing or it's asking for a specific example that does not exist in the current document
 
-### VIOLATIONS
+### VIOLATIONS
 
 **Message: Request/Response not valid**
 


### PR DESCRIPTION
**Summary**

There is invalid white space in `06-erros.md`. so `###` is not parsed as header.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A
