### PR TITLE
Feature/tls proxy docker compose example

### DIFF
--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -54,7 +54,7 @@ services:
     volumes:
       - ./api.oas3.yml:/tmp/api.oas3.yml:ro
     ports:
-      # Serve the mockAPI locally as available on port 8080
+      # Serve the mocked API locally as available on port 8080
       - "8080:4010"
 ```
 The above can be expanded if you with to [support TLS termination](../guides/10-nginx-tls-proxy.md).

--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -40,4 +40,23 @@ If you want to start the proxy server, you can run a command like this:
 docker run --init --rm -d -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:4 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
 ```
 
+## Docker Compose
+
+Alternatively, you may wish to use prism as part of a docker compose file to aid development environment portability. Below is a minimal example of a working `docker-compose.yml` supporting mocking:
+
+```yaml
+---
+version: "3.9"
+services:
+  prism:
+    image: stoplight/prism:4
+    command: "mock -h 0.0.0.0 /tmp/api.oas3.yml"
+    volumes:
+      - ./api.oas3.yml:/tmp/api.oas3.yml:ro
+    ports:
+      # Serve the mockAPI locally as available on port 8080
+      - "8080:4010"
+```
+The above can be expanded if you with to [support TLS termination](../guides/10-nginx-tls-proxy.md).
+
 Now everything is installed, let's look at some of the [concepts](./02-concepts.md).

--- a/docs/guides/10-nginx-tls-proxy.md
+++ b/docs/guides/10-nginx-tls-proxy.md
@@ -5,18 +5,20 @@ While prism doesn't natively support TLS, it can be fairly easily provided by us
 If you don't already have a self-signed certificate and configuration for nginx, there is [an excellent post](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04) by Digital Ocean that may help. The examples below used the steps outlined to create the configuration and certificates, but the steps have been abbreviated.
 
 The below files assume the following folder structure:
-
+```
 📦cool-website
  ┣ 📂 nginx
  ┃ ┗ 📜 default.conf
- ┣ 📂 tls
+ ┃ 📂 tls
  ┃ ┗ 📜 dhparam.pem
  ┃ ┗ 📜 tls-proxy.crt
  ┃ ┗ 📜 tls-proxy.key
- ┣ 📜.gitignore
+ ┣ 📜 .gitignore
  ┣ 📜 api.oas3.yml
  ┗ 📜 docker-compose.yml
+```
 
+Extending the basic `docker-compose.yml` from the installation guide to include nginx and a simple network:
 
 ```yaml
 ---
@@ -86,4 +88,4 @@ server {
 }
 ```
 
-This should set up a minimal TLS termination layer which proxies all requests on port 443 back to prism. You may wish to extend the example to allow for switching HTTP requests over to HTTPS by redirecting them.
+This should set up a minimal TLS termination layer which proxies all requests on port 443 back to prism. You may wish to extend the example to allow for switching HTTP requests over to HTTPS by redirecting them, or use a `.env` file and environmental variables to control file and ports.

--- a/docs/guides/10-nginx-tls-proxy.md
+++ b/docs/guides/10-nginx-tls-proxy.md
@@ -1,0 +1,89 @@
+# Supporting TLS with nginx as a TLS termination
+
+While prism doesn't natively support TLS, it can be fairly easily provided by using a TLS termination layer. In this example, we will be using `docker compose` and `nginx` to support accessing prism via TLS.
+
+If you don't already have a self-signed certificate and configuration for nginx, there is [an excellent post](https://www.digitalocean.com/community/tutorials/how-to-create-a-self-signed-ssl-certificate-for-nginx-in-ubuntu-16-04) by Digital Ocean that may help. The examples below used the steps outlined to create the configuration and certificates, but the steps have been abbreviated.
+
+The below files assume the following folder structure:
+
+📦cool-website
+ ┣ 📂 nginx
+ ┃ ┗ 📜 default.conf
+ ┣ 📂 tls
+ ┃ ┗ 📜 dhparam.pem
+ ┃ ┗ 📜 tls-proxy.crt
+ ┃ ┗ 📜 tls-proxy.key
+ ┣ 📜.gitignore
+ ┣ 📜 api.oas3.yml
+ ┗ 📜 docker-compose.yml
+
+
+```yaml
+---
+# ./docker-compose.yml
+version: "3.9"
+services:
+  prism:
+    image: stoplight/prism:4
+    command: "mock -h 0.0.0.0 /tmp/api.oas3.yml"
+    volumes:
+      - ./api.oas3.yml:/tmp/api.oas3.yml:ro
+    networks:
+      - prism
+    expose:
+      - "4010"
+  nginx-tls-proxy:
+    image: nginx:mainline
+    volumes:
+      # Override default config to act as TLS proxy
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      # Self-signed certificates etc in here
+      - ./tls:/etc/tls:ro
+    depends_on:
+      - prism
+    networks:
+      - prism
+    ports:
+      - "443:443"
+networks:
+  prism:
+```
+
+```nginx
+# ./nginx/default.conf
+upstream prism {
+  server prism:4010;
+}
+
+server {
+  listen 443 ssl default_server;
+  server_name _;
+  ssl_protocols TLSv1.3 TLSv1.2;
+
+  ssl_certificate /etc/tls/tls-proxy.crt;
+  ssl_certificate_key /etc/tls/tls-proxy.key;
+
+  ssl_prefer_server_ciphers on;
+  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+  ssl_ecdh_curve secp384r1;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  resolver 8.8.8.8 8.8.4.4 valid=300s;
+  resolver_timeout 5s;
+
+  ssl_dhparam /etc/tls/dhparam.pem;
+
+  set $trace_id $connection-$connection_requests-$msec;
+
+  location / {
+    # And now pass all traffic back to prism...
+    proxy_pass http://prism;
+    # And pass any additional headers you wish (in this example, a correlation ID).
+    proxy_set_header X-Request-Id $trace_id;
+  }
+}
+```
+
+This should set up a minimal TLS termination layer which proxies all requests on port 443 back to prism. You may wish to extend the example to allow for switching HTTP requests over to HTTPS by redirecting them.


### PR DESCRIPTION
Addresses #[ISSUE_NUMBER]

**Summary**

Found it difficult initially to work out how to use the docker image with `docker compose`, and then after learning how to, thought you might appreciate a documentation update

**Checklist**

- The basics
  - [ x ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ x ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ x ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ x ] N/A


**Additional context**

Added a TLS termination docker compose example, in case mocking with HTTPS was necessary (it was for my use case).
