### PR TITLE
Chore/change combinator

### DIFF
--- a/packages/cli/src/combinators.ts
+++ b/packages/cli/src/combinators.ts
@@ -1,6 +1,4 @@
 import * as E from 'fp-ts/Either';
-import * as A from 'fp-ts/Array';
 import { sequenceS } from 'fp-ts/Apply';
 
-export const traverseEither = A.traverse(E.Applicative);
 export const sequenceSEither = sequenceS(E.Apply);

--- a/packages/cli/src/util/paths.ts
+++ b/packages/cli/src/util/paths.ts
@@ -13,7 +13,7 @@ import {
   IHttpQueryParam,
 } from '@stoplight/types';
 import * as E from 'fp-ts/Either';
-import { sequenceSEither, traverseEither } from '../combinators';
+import { sequenceSEither } from '../combinators';
 import { pipe } from 'fp-ts/function';
 import { identity, fromPairs } from 'lodash';
 import { URI } from 'uri-template-lite';
@@ -80,7 +80,7 @@ function generateParamValue(spec: IHttpParam): E.Either<Error, unknown> {
 function generateParamValues(specs: IHttpParam[]): E.Either<Error, Dictionary<unknown>> {
   return pipe(
     specs,
-    traverseEither(spec =>
+    E.traverseArray(spec =>
       pipe(
         generateParamValue(spec),
         E.map(value => [encodeURI(spec.name), value])
@@ -112,7 +112,7 @@ function createPathUriTemplate(inputPath: string, specs: IHttpPathParam[]): E.Ei
   // defaults for query: style=Simple exploded=false
   return pipe(
     specs.filter(spec => spec.required !== false),
-    traverseEither(spec =>
+    E.traverseArray(spec =>
       pipe(
         createParamUriTemplate(spec.name, spec.style || HttpParamStyles.Simple, spec.explode || false),
         E.map(param => ({ param, name: spec.name }))

--- a/packages/http/src/combinators.ts
+++ b/packages/http/src/combinators.ts
@@ -1,10 +1,8 @@
 import { IPrismDiagnostic } from '@stoplight/prism-core';
 import * as O from 'fp-ts/Option';
-import * as A from 'fp-ts/Array';
 import { sequenceT } from 'fp-ts/Apply';
 import { getSemigroup } from 'fp-ts/NonEmptyArray';
 import { getApplicativeValidation } from 'fp-ts/Either';
 
-export const traverseOption = A.traverse(O.Applicative);
 export const sequenceOption = sequenceT(O.Apply);
 export const sequenceValidation = sequenceT(getApplicativeValidation(getSemigroup<IPrismDiagnostic>()));

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -8,7 +8,6 @@ import * as A from 'fp-ts/Array';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
 import * as J from 'fp-ts/Json';
-import { traverseOption } from '../../combinators';
 import { head } from 'fp-ts/Array';
 import { pipe } from 'fp-ts/function';
 import { generate as generateHttpParam } from '../generator/HttpParamGenerator';
@@ -90,7 +89,7 @@ const assembleHeaders = (request?: IHttpOperationRequest, bodyMediaType?: string
   pipe(
     O.fromNullable(request?.headers),
     O.chain(
-      traverseOption(param =>
+      O.traverseArray(param =>
         pipe(
           generateHttpParam(param),
           O.map(value => [param.name, value])

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -4,10 +4,11 @@ import * as accepts from 'accepts';
 import * as contentType from 'content-type';
 import * as O from 'fp-ts/Option';
 import * as A from 'fp-ts/Array';
-import { pick } from 'lodash';
+import * as N from 'fp-ts/Number';
 import * as NEA from 'fp-ts/NonEmptyArray';
-import { ord, ordNumber } from 'fp-ts/Ord';
+import { contramap } from 'fp-ts/Ord';
 import { pipe } from 'fp-ts/function';
+import { pick } from 'lodash';
 import { ContentExample } from '../../';
 
 export type IWithExampleMediaContent = IMediaTypeContent & { examples: NEA.NonEmptyArray<ContentExample> };
@@ -54,7 +55,7 @@ export function findDefaultContentType(contents: IMediaTypeContent[]): O.Option<
   );
 }
 
-const byResponseCode = ord.contramap<number, IHttpOperationResponse>(ordNumber, response => parseInt(response.code));
+const byResponseCode = contramap((response: IHttpOperationResponse) => parseInt(response.code))(N.Ord);
 
 export function findLowest2xx(httpResponses: IHttpOperationResponse[]): O.Option<IHttpOperationResponse> {
   const first2xxResponse = pipe(

--- a/packages/http/src/mocker/negotiator/InternalHelpers.ts
+++ b/packages/http/src/mocker/negotiator/InternalHelpers.ts
@@ -4,7 +4,7 @@ import * as accepts from 'accepts';
 import * as contentType from 'content-type';
 import * as O from 'fp-ts/Option';
 import * as A from 'fp-ts/Array';
-import * as N from 'fp-ts/Number';
+import * as N from 'fp-ts/number';
 import * as NEA from 'fp-ts/NonEmptyArray';
 import { contramap } from 'fp-ts/Ord';
 import { pipe } from 'fp-ts/function';

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -15,8 +15,6 @@ import { matchBaseUrl } from './matchBaseUrl';
 import { matchPath } from './matchPath';
 import { IMatch, MatchType } from './types';
 
-const eitherSequence = A.sequence(E.Applicative);
-
 const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig>['route'] = ({ resources, input }) => {
   const { path: requestPath, baseUrl: requestBaseUrl } = input.url;
 
@@ -33,7 +31,7 @@ const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig
       )
     ),
     E.chain(resources =>
-      eitherSequence(
+      E.sequenceArray(
         resources.map(resource =>
           pipe(
             matchPath(requestPath, resource.path),
@@ -136,7 +134,7 @@ const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig
 function matchServer(servers: IServer[], requestBaseUrl: string): E.Either<Error, MatchType> {
   return pipe(
     servers.map(server => matchBaseUrl(server, requestBaseUrl)),
-    eitherSequence,
+    E.sequenceArray,
     E.map(matches => matches.filter(match => match !== MatchType.NOMATCH)),
     E.map(disambiguateServers)
   );


### PR DESCRIPTION
**Summary**

- use combinator from fp-ts rather than defining own.
- remove deprecated `ordNumber`, `ord`

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

