### PR TITLE
fix: decode path before matching it

### DIFF
--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -477,6 +477,31 @@ describe('http router', () => {
           );
         });
 
+        test('given encoded path should match to not encoded path', () => {
+          const method = pickOneHttpMethod();
+          const url = faker.internet.url();
+          const path = randomPath({ includeTemplates: false, includeSpaces: true });
+
+          const expectedResource = createResource(method, path, [
+            {
+              url,
+            },
+          ]);
+          assertRight(
+            route({
+              resources: [expectedResource],
+              input: {
+                method,
+                url: {
+                  baseUrl: url,
+                  path: encodeURI(path),
+                },
+              },
+            }),
+            resource => expect(resource).toBe(expectedResource)
+          );
+        });
+
         describe('given a concrete and a templated path', () => {
           const path = '/test/fixed';
           const templatedPath = '/test/{userId}';

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -10,6 +10,17 @@ describe('matchPath()', () => {
     assertRight(matchPath(path, path), e => expect(e).toEqual(MatchType.CONCRETE));
   });
 
+  test('any concrete path with spaces should match an equal concrete path', () => {
+    // e.g. /a b/c should match /a b/c
+    const path = randomPath({
+      pathFragments: faker.datatype.number({ min: 2, max: 6 }),
+      includeTemplates: false,
+      includeSpaces: true,
+    });
+
+    assertRight(matchPath(path, path), e => expect(e).toEqual(MatchType.CONCRETE));
+  });
+
   test('any concrete path should match an equal concrete path', () => {
     // e.g. /a/b/c should match /a/b/c
     const path = randomPath({

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -18,6 +18,7 @@ type IRandomPathOptions = {
   includeTemplates?: boolean;
   trailingSlash?: boolean;
   leadingSlash?: boolean;
+  includeSpaces?: boolean;
 };
 
 const defaultRandomPathOptions: DeepNonNullable<IRandomPathOptions> = {
@@ -25,16 +26,21 @@ const defaultRandomPathOptions: DeepNonNullable<IRandomPathOptions> = {
   includeTemplates: true,
   leadingSlash: true,
   trailingSlash: false,
+  includeSpaces: true,
 };
 
 export function randomPath(opts: IRandomPathOptions = defaultRandomPathOptions): string {
   const options = defaults(defaultRandomPathOptions, opts);
 
-  const randomPathFragments = new Array(options.pathFragments)
-    .fill(0)
-    .map(() =>
-      options.includeTemplates && faker.datatype.boolean() ? `{${faker.random.word()}}` : faker.random.word()
-    );
+  const randomPathFragments = new Array(options.pathFragments).fill(0).map(() => {
+    const words = faker.random.words(options.includeSpaces ? 3 : 1);
+
+    if (options.includeTemplates && faker.datatype.boolean()) {
+      return `{${words}}`;
+    }
+
+    return words;
+  });
 
   const leadingSlash = options.leadingSlash ? '/' : '';
   const trailingSlash = options.trailingSlash ? '/' : '';

--- a/test-harness/specs/routing/support-encoded-path.oas3.txt
+++ b/test-harness/specs/routing/support-encoded-path.oas3.txt
@@ -1,0 +1,35 @@
+====test====
+When path is encoded, selects the correct response based on decoded path
+====spec====
+openapi: 3.0.0
+paths:
+  /test path > with | unsafe % characters:
+    post:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  response-for-post:
+                    type: string
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  response-for-get:
+                    type: string
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -X GET http://localhost:4010/test%20path%20%3E%20with%20%7C%20unsafe%20%25%20characters
+====expect====
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"response-for-get":"string"}

--- a/test-harness/specs/routing/support-encoded-path.oas3.txt
+++ b/test-harness/specs/routing/support-encoded-path.oas3.txt
@@ -1,29 +1,16 @@
 ====test====
 When path is encoded, selects the correct response based on decoded path
 ====spec====
-openapi: 3.0.0
+openapi: 3.0.2
 paths:
   /test path > with | unsafe % characters:
-    post:
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  response-for-post:
-                    type: string
     get:
       responses:
-        '200':
+        200:
           content:
+            description: ok
             application/json:
-              schema:
-                type: object
-                properties:
-                  response-for-get:
-                    type: string
+              example: "ok"
 ====server====
 mock -p 4010 ${document}
 ====command====
@@ -32,4 +19,4 @@ curl -i -X GET http://localhost:4010/test%20path%20%3E%20with%20%7C%20unsafe%20%
 HTTP/1.1 200 OK
 content-type: application/json
 
-{"response-for-get":"string"}
+"ok"


### PR DESCRIPTION
**Summary**

You have a spec with `/some path` in it and you're trying to mock this path with mocker. If you'll send an encoded path (`/some%20path`) to the mocker it wont be able to find a corresponding path in the spec at will throw `NO_PATH_MATCHED_ERROR` which is not correct.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A