### PR TITLE
feat(http): added support to Deprecation header for deprecated operat…

### DIFF
--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -70,7 +70,14 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
       })(components.logger.child({ name: 'NEGOTIATOR' }));
 
     const forwardCall = (config: IPrismProxyConfig) =>
-      components.forward({ validations: config.errors ? validations : [], data }, config.upstream.href);
+      components.forward(
+        {
+          validations: config.errors ? validations : [],
+          data,
+        },
+        config.upstream.href,
+        resource
+      );
 
     const produceOutput = isProxyConfig(config)
       ? pipe(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,7 +37,7 @@ export type IPrismComponents<Resource, Input, Output, Config extends IPrismConfi
   validateInput: ValidatorFn<Resource, Input>;
   validateSecurity: ValidatorFn<Resource, Input>;
   validateOutput: ValidatorFn<Resource, Output>;
-  forward: (input: IPrismInput<Input>, baseUrl: string) => ReaderTaskEither<Logger, Error, Output>;
+  forward: (input: IPrismInput<Input>, baseUrl: string, resource?: Resource) => ReaderTaskEither<Logger, Error, Output>;
   mock: (opts: {
     resource: Resource;
     input: IPrismInput<Input>;

--- a/packages/http/src/__tests__/fixtures/index.ts
+++ b/packages/http/src/__tests__/fixtures/index.ts
@@ -260,7 +260,53 @@ export const httpOperations: IHttpOperation[] = [
       },
     ],
   },
+  {
+    id: 'updateTodo',
+    deprecated: true,
+    method: 'patch',
+    path: '/todo/{todoId}',
+    request: {},
+    responses: [
+      {
+        code: '200',
+        headers: [],
+        contents: [
+          {
+            mediaType: 'application/json',
+            examples: [
+              {
+                key: 'application/json',
+                value: 'OK',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        code: '400',
+        headers: [],
+        contents: [
+          {
+            mediaType: 'application/json',
+            examples: [
+              {
+                key: 'application/json',
+                value: {
+                  message: 'error',
+                },
+              },
+            ],
+            encodings: [],
+          },
+        ],
+      },
+    ],
+  },
 ];
+
+export const httpOperationsByRef = {
+  deprecated: httpOperations[3],
+};
 
 export const httpInputs: IHttpRequest[] = [
   {
@@ -284,7 +330,17 @@ export const httpInputs: IHttpRequest[] = [
       'x-todos-publish': '2018-11-01T10:50:00.05Z',
     },
   },
+  {
+    method: 'patch',
+    url: {
+      path: '/todo/10',
+    },
+  },
 ];
+
+export const httpInputsByRef = {
+  updateTodo: httpInputs[3],
+};
 
 export const httpRequests: Array<IPrismInput<IHttpRequest>> = [
   {
@@ -301,6 +357,10 @@ export const httpRequests: Array<IPrismInput<IHttpRequest>> = [
       },
     ],
     data: httpInputs[1],
+  },
+  {
+    validations: [],
+    data: httpInputsByRef.updateTodo,
   },
 ];
 

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -22,7 +22,8 @@ const { version: prismVersion } = require('../../package.json'); // eslint-disab
 
 const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>['forward'] = (
   { data: input, validations }: IPrismInput<IHttpRequest>,
-  baseUrl: string
+  baseUrl: string,
+  resource
 ): RTE.ReaderTaskEither<Logger, Error, IHttpResponse> => logger =>
   pipe(
     NEA.fromArray(validations),
@@ -68,6 +69,12 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
       return TE.right(undefined);
     }),
     TE.chain(parseResponse),
+    TE.map(response => {
+      if (resource && resource.deprecated && response.headers && !response.headers.deprecation) {
+        response.headers.deprecation = 'true';
+      }
+      return response;
+    }),
     TE.map(stripHopByHopHeaders)
   );
 

--- a/packages/http/src/mocker/__tests__/functional.spec.ts
+++ b/packages/http/src/mocker/__tests__/functional.spec.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv';
 
 import { createLogger } from '@stoplight/prism-core';
-import { httpOperations, httpRequests } from '../../__tests__/fixtures';
+import { httpOperations, httpRequests, httpOperationsByRef } from '../../__tests__/fixtures';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
 import mock from '../index';
 
@@ -251,6 +251,21 @@ describe('http mocker', () => {
 
       assertRight(response, result => {
         expect(validate(result.body)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('for operation that is deprecated', () => {
+    it('should set "Deprecation" header', () => {
+      const response = mock({
+        config: { dynamic: false },
+        resource: httpOperationsByRef.deprecated,
+        input: httpRequests[2],
+      })(logger);
+
+      assertRight(response, result => {
+        expect(result.headers).toHaveProperty('deprecation', 'true');
+        expect(result.statusCode).toEqual(200);
       });
     });
   });

--- a/packages/http/src/mocker/negotiator/types.ts
+++ b/packages/http/src/mocker/negotiator/types.ts
@@ -8,6 +8,7 @@ export interface IHttpNegotiationResult {
   bodyExample?: ContentExample;
   headers: IHttpHeaderParam[];
   schema?: JSONSchema;
+  deprecated?: boolean;
 }
 
 export type NegotiationOptions = IHttpOperationConfig;


### PR DESCRIPTION
Addresses #1563

**Summary**

Responses receive "Deprecation" header once operation is deprecated.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A