### PR TITLE
Minor matchPath fixes

### DIFF
--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -146,7 +146,7 @@ describe('matchPath()', () => {
   });
 
   // This test will likely never fail because strings are always different
-  test('none path should match templated operation with more path fragments', () => {
+  test('none path should match templated operation with more path fragments (dynamic)', () => {
     // e.g. `/a/b` should not match /{x}/{y}/{z}
     // e.g. `/a` should not match /{x}/{y}/{z}
     const requestPath = randomPath({
@@ -160,6 +160,13 @@ describe('matchPath()', () => {
       includeTemplates: true,
       trailingSlash: false,
     });
+
+    assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
+  });
+
+  test('none path should match templated operation with more path fragments', () => {
+    const requestPath = '/a/b/c';
+    const operationPath = '/{d}/{e}/{f}/{g}';
 
     assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
   });

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -188,4 +188,18 @@ describe('matchPath()', () => {
       expect(e).toEqual(MatchType.TEMPLATED)
     );
   });
+
+  test.each([
+    '%3A', // column
+    '%2F', // forward slash
+  ])('parameters can contain encoded "special characters" (%s)', (encoded: string) => {
+    const requestPath = `/bef${encoded}17/test.smthg${encoded}32.sub${encoded}47/aft${encoded}96`;
+
+    assertRight(matchPath(requestPath, `/{prefix}/test.{format}.{extension}/{suffix}`), e =>
+      expect(e).toEqual(MatchType.TEMPLATED)
+    );
+    assertRight(matchPath(requestPath, '/{prefix}/test.{global}/{suffix}'), e =>
+      expect(e).toEqual(MatchType.TEMPLATED)
+    );
+  });
 });

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -172,7 +172,7 @@ describe('matchPath()', () => {
   });
 
   test('it does not match if separators are not equal', () => {
-    assertRight(matchPath('a:b/c', 'a/b:c'), e => expect(e).toEqual(MatchType.NOMATCH));
+    assertRight(matchPath('/a:b/c', '/a/b:c'), e => expect(e).toEqual(MatchType.NOMATCH));
   });
 
   test('it accepts columns as part of templated params', () => {

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -168,6 +168,10 @@ describe('matchPath()', () => {
     assertRight(matchPath('a:b/c', 'a/b:c'), e => expect(e).toEqual(MatchType.NOMATCH));
   });
 
+  test('it accepts columns as part of templated params', () => {
+    assertRight(matchPath('/a:b/c', '/{something}/c'), e => expect(e).toEqual(MatchType.TEMPLATED));
+  });
+
   test('it properly processes fragments containing both concrete and templated parts', () => {
     assertRight(matchPath('/a', '/a.{json}'), e => expect(e).toEqual(MatchType.NOMATCH));
     assertRight(matchPath('/test.json', '/test.{format}'), e => expect(e).toEqual(MatchType.TEMPLATED));

--- a/packages/http/src/router/matchPath.ts
+++ b/packages/http/src/router/matchPath.ts
@@ -1,11 +1,8 @@
 import { MatchType } from './types';
 import * as E from 'fp-ts/Either';
-import { isEqual } from 'lodash';
-
-const pathSeparatorsRegex = /[/:]/g;
 
 function fragmentize(path: string): string[] {
-  return path.split(pathSeparatorsRegex).slice(1).map(decodePathFragment);
+  return path.split('/').slice(1).map(decodePathFragment);
 }
 
 function isTemplated(pathFragment: string) {
@@ -23,20 +20,12 @@ function decodePathFragment(pathFragment: string) {
   }
 }
 
-function isSeparationEqual(path1: string, path2: string): boolean {
-  return isEqual(path1.match(pathSeparatorsRegex), path2.match(pathSeparatorsRegex));
-}
-
 function escapeRegExp(string: string) {
   // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
 export function matchPath(requestPath: string, operationPath: string): E.Either<Error, MatchType> {
-  if (!isSeparationEqual(requestPath, operationPath)) {
-    return E.right(MatchType.NOMATCH);
-  }
-
   const operationPathFragments = fragmentize(operationPath);
   const requestPathFragments = fragmentize(requestPath);
 

--- a/packages/http/src/router/matchPath.ts
+++ b/packages/http/src/router/matchPath.ts
@@ -2,6 +2,10 @@ import { MatchType } from './types';
 import * as E from 'fp-ts/Either';
 
 function fragmentize(path: string): string[] {
+  if (path.length === 0 || !path.startsWith('/')) {
+    throw new Error(`Malformed path '${path}'`);
+  }
+
   return path.split('/').slice(1).map(decodePathFragment);
 }
 

--- a/packages/http/src/router/matchPath.ts
+++ b/packages/http/src/router/matchPath.ts
@@ -29,6 +29,10 @@ export function matchPath(requestPath: string, operationPath: string): E.Either<
   const operationPathFragments = fragmentize(operationPath);
   const requestPathFragments = fragmentize(requestPath);
 
+  if (operationPathFragments.length != requestPathFragments.length) {
+    return E.right(MatchType.NOMATCH);
+  }
+
   let isTemplatedOperationPath = false;
 
   for (const requestPathFragment of requestPathFragments) {


### PR DESCRIPTION
**Summary**

Some quick fixes to `matchPath` and related tests:
 - Drop code related to special casing the column character (`:`). It's no longer needed.
   - Incidentally this fixes a bug where `/part/ab:17/process` wasn't considered a valid match for `/part/{something}/process`
 - Fix a code regression that was show casing as a flaky test
   - Created a specific test case to isolate (and fix) the regression. The issue wasn't caught by CI builds, because most of the dynamically generated test cases were statistically comparing against **partially** templated paths (eg `/a/b/c` vs `/{d}/e/{f}/g`).
 - Added a guard to ensure processed paths always start with a leading slash
   - Fixed a related test that was passing for the wrong reason

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

/cc @chohmann 