### PR TITLE
Teach Prism to stop polluting the console with AJV "unknown format" warnings

### DIFF
--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -197,4 +197,15 @@ describe('validateAgainstSchema()', () => {
       );
     });
   });
+
+  describe('does not pollute the console with ajv "unknown format" warnings', () => {
+    it.each([true, false])('with coerce = %s', (coerce: boolean) => {
+      const spy = jest.spyOn(console, 'warn');
+
+      assertNone(validateAgainstSchema('test', { type: 'string', format: 'something' }, coerce));
+      expect(spy).not.toHaveBeenCalled();
+
+      spy.mockRestore();
+    });
+  });
 });

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -3,7 +3,7 @@ import { DiagnosticSeverity } from '@stoplight/types';
 import * as O from 'fp-ts/Option';
 import { pipe } from 'fp-ts/function';
 import { NonEmptyArray, fromArray, map } from 'fp-ts/NonEmptyArray';
-import Ajv, { ErrorObject, Options } from 'ajv';
+import Ajv, { ErrorObject, Logger, Options } from 'ajv';
 import type AjvCore from 'ajv/dist/core';
 import Ajv2019 from 'ajv/dist/2019';
 import Ajv2020 from 'ajv/dist/2020';
@@ -11,11 +11,25 @@ import addFormats from 'ajv-formats';
 import type { JSONSchema } from '../../';
 import { compareDateTime, date_time, fmtDef } from './dateTime';
 
+const unknownFormatSilencerLogger: Logger = {
+  warn(...args: unknown[]): void {
+    const firstArg = args[0];
+    if (typeof firstArg === 'string' && firstArg.startsWith('unknown format')) {
+      return;
+    }
+
+    console.warn(...args);
+  },
+  log: console.log,
+  error: console.error,
+};
+
 const baseAjvOptions: Partial<Options> = {
   allErrors: true,
   allowUnionTypes: true,
   allowMatchingProperties: true,
   strict: false,
+  logger: unknownFormatSilencerLogger,
 };
 
 function createAjvInstances(Ajv: typeof AjvCore) {


### PR DESCRIPTION
**Summary**

In ajv-validator/ajv#466, the author of AJV makes it very clear that people should be aware of unknown formats.

However, according to the OpenAPI spec, format is is an open string-valued property, and can have any value.

Given some traffic, all those warnings tend to pollute the console output a lot and make it very hard to follow up with what's logged by Prism.

This change intercepts AJV calls to console.warn and when they relate to unknown formats, silence them.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

Given the following spec `openapi.yaml` stored at the root of the repo workdir

```yaml
openapi: 3.1.0
paths:
  /something:
    get:
      summary: Gimme me something, anything!
      responses:
        "200":
          description: OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  this:
                    type: string
                    format: something
servers:
- url: "https://example.com"
```

From a term, run the following

```bash
$ yarn cli mock ../../openapi.yaml 
yarn run v1.22.5
$ node -r ts-node/register/transpile-only -r tsconfig-paths/register src/index.ts mock ../../openapi.yaml
$ node -r ts-node/register/transpile-only -r tsconfig-paths/register src/index.ts mock ../../openapi.yaml
[12:25:34 PM] » [CLI] ...  awaiting  Starting Prism…
[12:25:34 PM] » [CLI] i  info      GET        http://127.0.0.1:4010/something
[12:25:34 PM] » [CLI] ►  start     Prism is listening on http://127.0.0.1:4010
```

From another term, run the following

```bash
$ curl http://127.0.0.1:4010/something
{"this":"string"}
```

Switch back to intial term and observe the generated log

```bash
$ node -r ts-node/register/transpile-only -r tsconfig-paths/register src/index.ts mock ../../openapi.yaml
[12:25:34 PM] » [CLI] ...  awaiting  Starting Prism…
[12:25:34 PM] » [CLI] i  info      GET        http://127.0.0.1:4010/something
[12:25:34 PM] » [CLI] ►  start     Prism is listening on http://127.0.0.1:4010
[12:25:43 PM] » [HTTP SERVER] get /something i  info      Request received
[12:25:43 PM] »     [NEGOTIATOR] i  info      Request contains an accept header: */*
[12:25:43 PM] »     [VALIDATOR] √  success   The request passed the validation rules. Looking for the best response
[12:25:43 PM] »     [NEGOTIATOR] √  success   Found a compatible content for */*
[12:25:43 PM] »     [NEGOTIATOR] √  success   Responding with the requested status code 200
unknown format "something" ignored in schema at path "#/properties/this"
unknown format "something" ignored in schema at path "#/properties/this"
```

**Additional context**

A similar issue has been opened ages ago against Spectral (https://github.com/stoplightio/spectral/issues/396).

This PR ~shamelessly stoles~ is greatly inspired by @chris-miaskowski 's fix from https://github.com/stoplightio/spectral/pull/503
