### PR TITLE
feat: Resolve values using JSON Path in examples

### DIFF
--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -21,6 +21,7 @@ jsf.option({
   ignoreMissingRefs: true,
   maxItems: 20,
   maxLength: 100,
+  resolveJsonPath: true,
 });
 
 export function generate(bundle: unknown, source: JSONSchema): Either<Error, unknown> {


### PR DESCRIPTION
There's a reference to this configuration option in #1224 but otherwise, I can't find any explanation for why it is not enabled. The option is very helpful to ensure that examples are contextually correct, e.g: a valid `JSON:API` response may need to provide both a `Resource Identifier Object`  _and_ included data for that Resource. 

> [**Available options**](https://github.com/json-schema-faker/json-schema-faker/tree/v0.5.0-rcv.34/docs#available-options)
> ...
> `resolveJsonPath` — If enabled, it will expand jsonPath keywords on all generated objects (default: `false`)
