### PR TITLE
fix flakey json-schena-faker test introduced in #8294 commit 986001be

### DIFF
--- a/test-harness/specs/dynamic-responses/dynamic_response_json_schema_faker_config.txt
+++ b/test-harness/specs/dynamic-responses/dynamic_response_json_schema_faker_config.txt
@@ -42,7 +42,7 @@ paths:
 mock -p 4010 -d ${document}
 ====command====
 curl -i http://localhost:4010/widget
-====expect====
+====expect-loose====
 HTTP/1.1 200 OK
 content-type: application/json
 


### PR DESCRIPTION
Addresses #8294

**Summary**

Fixes a flakey test introduced in https://github.com/stoplightio/prism/pull/1899

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

