### PR TITLE
fix: increased maxLength in JSONSchema from 100 to 2048.

### DIFF
--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -20,7 +20,7 @@ jsf.option({
   fixedProbabilities: true,
   ignoreMissingRefs: true,
   maxItems: 20,
-  maxLength: 100,
+  maxLength: 2048,
 });
 
 export function generate(bundle: unknown, source: JSONSchema): Either<Error, unknown> {


### PR DESCRIPTION
Addresses #1914

**Summary**

Prism was truncating long enum values to 100 chars on dynamic mode (`-d`). That limit could be easily reached when values were URIs.

Increased limit to 2048, according to this [StackOverflow answer](https://stackoverflow.com/a/417184/2177240).

I don't know which performance or memory usage implications may have this change, if any.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
- Error Reporting
  - [x] I reported errors and followed the error reporting guidelines
