### PR TITLE
Removes `content-encoding` response header since we decompressed response body

### DIFF
--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -20,63 +20,65 @@ import { UPSTREAM_NOT_IMPLEMENTED } from './errors';
 
 const { version: prismVersion } = require('../../package.json'); // eslint-disable-line
 
-const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>['forward'] = (
-  { data: input, validations }: IPrismInput<IHttpRequest>,
-  baseUrl: string,
-  resource
-): RTE.ReaderTaskEither<Logger, Error, IHttpResponse> => logger =>
-  pipe(
-    NEA.fromArray(validations),
-    TE.fromOption(() => undefined),
-    TE.map(failedValidations => {
-      const securityValidation = failedValidations.find(validation => validation.code === 401);
+const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpConfig>['forward'] =
+  (
+    { data: input, validations }: IPrismInput<IHttpRequest>,
+    baseUrl: string,
+    resource
+  ): RTE.ReaderTaskEither<Logger, Error, IHttpResponse> =>
+  logger =>
+    pipe(
+      NEA.fromArray(validations),
+      TE.fromOption(() => undefined),
+      TE.map(failedValidations => {
+        const securityValidation = failedValidations.find(validation => validation.code === 401);
 
-      return securityValidation
-        ? createUnauthorisedResponse(securityValidation.tags)
-        : createUnprocessableEntityResponse(failedValidations);
-    }),
-    TE.swap,
-    TE.chainEitherK(() => serializeBody(input.body)),
-    TE.chain(body =>
-      TE.tryCatch(async () => {
-        const partialUrl = parse(baseUrl);
-        const url = format({
-          ...partialUrl,
-          pathname: posix.join(partialUrl.pathname || '', input.url.path),
-          query: input.url.query,
-        });
+        return securityValidation
+          ? createUnauthorisedResponse(securityValidation.tags)
+          : createUnprocessableEntityResponse(failedValidations);
+      }),
+      TE.swap,
+      TE.chainEitherK(() => serializeBody(input.body)),
+      TE.chain(body =>
+        TE.tryCatch(async () => {
+          const partialUrl = parse(baseUrl);
+          const url = format({
+            ...partialUrl,
+            pathname: posix.join(partialUrl.pathname || '', input.url.path),
+            query: input.url.query,
+          });
 
-        logger.info(`Forwarding "${input.method}" request to ${url}...`);
+          logger.info(`Forwarding "${input.method}" request to ${url}...`);
 
-        return fetch(url, {
-          body,
-          method: input.method,
-          headers: defaults(omit(input.headers, ['host']), {
-            'accept-encoding': '*',
-            accept: 'application/json, text/plain, */*',
-            'user-agent': `Prism/${prismVersion}`,
-          }),
-        });
-      }, E.toError)
-    ),
-    TE.chainFirst(response => {
-      if (response.status === 501) {
-        logger.warn(`Upstream call to ${input.url.path} has returned 501`);
-        return TE.left(ProblemJsonError.fromTemplate(UPSTREAM_NOT_IMPLEMENTED));
-      }
+          return fetch(url, {
+            body,
+            method: input.method,
+            headers: defaults(omit(input.headers, ['host']), {
+              'accept-encoding': '*',
+              accept: 'application/json, text/plain, */*',
+              'user-agent': `Prism/${prismVersion}`,
+            }),
+          });
+        }, E.toError)
+      ),
+      TE.chainFirst(response => {
+        if (response.status === 501) {
+          logger.warn(`Upstream call to ${input.url.path} has returned 501`);
+          return TE.left(ProblemJsonError.fromTemplate(UPSTREAM_NOT_IMPLEMENTED));
+        }
 
-      logger.info(`The upstream call to ${input.url.path} has returned ${response.status}`);
-      return TE.right(undefined);
-    }),
-    TE.chain(parseResponse),
-    TE.map(response => {
-      if (resource && resource.deprecated && response.headers && !response.headers.deprecation) {
-        response.headers.deprecation = 'true';
-      }
-      return response;
-    }),
-    TE.map(stripHopByHopHeaders)
-  );
+        logger.info(`The upstream call to ${input.url.path} has returned ${response.status}`);
+        return TE.right(undefined);
+      }),
+      TE.chain(parseResponse),
+      TE.map(response => {
+        if (resource && resource.deprecated && response.headers && !response.headers.deprecation) {
+          response.headers.deprecation = 'true';
+        }
+        return response;
+      }),
+      TE.map(stripHopByHopHeaders)
+    );
 
 export default forward;
 

--- a/packages/http/src/forwarder/resources.ts
+++ b/packages/http/src/forwarder/resources.ts
@@ -7,4 +7,5 @@ export const hopByHopHeaders: string[] = [
   'te',
   'trailers',
   'upgrade',
+  'content-encoding',
 ];


### PR DESCRIPTION
Addresses #1064

**Summary**

In proxy mode, when a client requests an endpoint with "Accept-Encoding: gzip" we fetched compressed response but node-fetch decompress content automatically so we can validate response format. We send back a decompressed response but at the same time we pass back original headers that contain "Content-Encoding: gzip". In the end the client gets `Content-Encoding: gzip` header and tries to decompress the content and gets an error since the content is already decompressed.

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [X] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [X] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [X] N/A

**Steps to reproduce**

[prism_testing.zip](https://github.com/stoplightio/prism/files/7569403/prism_testing.zip)

- import Postman collection from the attached files
- run Prism in proxy mode `yarn cli  proxy ../../prismtest.oas2.json http://reqres.in -p 4014`
- Run a request from Postman
- Make sure that Postman gets a response successfully

**Screenshots**

<img width="1721" alt="Screenshot 2021-11-19 at 13 04 08" src="https://user-images.githubusercontent.com/293785/142604975-bd25b538-d0df-4a8f-8c7e-854f9c65f58a.png">

**Additional context**

Perhaps we could go even further and return a compressed response (as the original server does), but I don't think that is necessary, at least for the moment.
