### PR TITLE
fix: remove deprecated usage of parse

### DIFF
--- a/packages/http/src/__tests__/client.spec.ts
+++ b/packages/http/src/__tests__/client.spec.ts
@@ -43,10 +43,10 @@ describe('User Http Client', () => {
         jest.spyOn(client, 'request');
       });
 
-      afterAll(() => jest.clearAllMocks());
-
       describe('when calling with no options', () => {
         beforeAll(() => client.get('/pet'));
+
+        afterAll(() => jest.clearAllMocks());
 
         test('shall call the mocker with the default options', () =>
           expect(mock.default).toHaveBeenCalledWith({
@@ -61,6 +61,8 @@ describe('User Http Client', () => {
 
       describe('when calling a method with overridden url', () => {
         beforeAll(() => client.get('/pet', { baseUrl: 'https://www.google.it' }));
+
+        afterAll(() => jest.clearAllMocks());
 
         test('should call the mocker with the replaced full url', () => {
           expect(mock.default).toBeCalledWith({
@@ -80,6 +82,8 @@ describe('User Http Client', () => {
 
       describe('when calling a method with a full url', () => {
         beforeAll(() => client.get('https://www.google.it/pet'));
+
+        afterAll(() => jest.clearAllMocks());
 
         test('should call the mocker with the replaced full url', () => {
           expect(mock.default).toBeCalledWith({

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -48,7 +48,7 @@ export function createClientFromOperations(resources: IHttpOperation[], defaultC
       const httpUrl: IHttpUrl = {
         baseUrl,
         path: parsedUrl.pathname,
-        query: parseQueryString(parsedUrl.search.substring(1)) as IHttpNameValues,
+        query: parseQueryString(parsedUrl.search?.substring(1) || '') as IHttpNameValues,
       };
 
       return pipe(

--- a/packages/http/src/client.ts
+++ b/packages/http/src/client.ts
@@ -2,11 +2,11 @@ import { IPrismOutput } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 import { defaults } from 'lodash';
 import { parse as parseQueryString } from 'querystring';
-import { parse as parseUrl } from 'url';
 import { createInstance, IHttpNameValues } from '.';
 import { IHttpConfig, IHttpRequest, IHttpResponse, IHttpUrl } from './types';
 import { fold } from 'fp-ts/TaskEither';
 import * as Task from 'fp-ts/Task';
+import * as O from 'fp-ts/Option';
 import { pipe } from 'fp-ts/function';
 import * as pino from 'pino';
 
@@ -30,16 +30,25 @@ export function createClientFromOperations(resources: IHttpOperation[], defaultC
 
   const client: PrismHttp = {
     request(url, input, config) {
-      const parsedUrl = parseUrl(url);
-
-      if (!parsedUrl.pathname) throw new Error('Path name must always be specified');
+      if (!url) throw new Error('Path name must always be specified');
 
       const mergedConf: IClientConfig = defaults(config, defaultConfig);
+      const baseUrl = pipe(
+        O.tryCatch(() => new URL(url)),
+        O.fold(
+          () => mergedConf.baseUrl,
+          url => url.origin
+        )
+      );
+      const parsedUrl = pipe(
+        O.tryCatch(() => new URL(url)),
+        O.getOrElseW(() => new URL(url, 'https://stoplight.io'))
+      );
 
       const httpUrl: IHttpUrl = {
-        baseUrl: parsedUrl.host ? `${parsedUrl.protocol}//${parsedUrl.host}` : mergedConf.baseUrl,
+        baseUrl,
         path: parsedUrl.pathname,
-        query: parseQueryString(parsedUrl.query || '') as IHttpNameValues,
+        query: parseQueryString(parsedUrl.search.substring(1)) as IHttpNameValues,
       };
 
       return pipe(

--- a/packages/http/src/forwarder/__tests__/index.spec.ts
+++ b/packages/http/src/forwarder/__tests__/index.spec.ts
@@ -8,7 +8,7 @@ import { DiagnosticSeverity, Dictionary } from '@stoplight/types';
 jest.mock('node-fetch');
 
 function stubFetch({ json = {}, text = '', headers }: { headers: Dictionary<string>; text?: string; json?: unknown }) {
-  ((fetch as unknown) as jest.Mock).mockResolvedValue({
+  (fetch as unknown as jest.Mock).mockResolvedValue({
     headers: { get: (n: string) => headers[n], raw: () => mapValues(headers, (h: string) => h.split(' ')) },
     json: jest.fn().mockResolvedValue(json),
     text: jest.fn().mockResolvedValue(text),

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -45,13 +45,12 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
       TE.chain(body =>
         TE.tryCatch(async () => {
           const partialUrl = new URL(baseUrl);
-          const url = format({
-            ...partialUrl,
-            host: partialUrl.host,
-            protocol: partialUrl.protocol,
-            pathname: posix.join(partialUrl.pathname || '', input.url.path),
-            query: input.url.query,
-          });
+          const url = format(
+            Object.assign(partialUrl, {
+              pathname: posix.join(partialUrl.pathname || '', input.url.path),
+              query: input.url.query,
+            })
+          );
 
           logger.info(`Forwarding "${input.method}" request to ${url}...`);
           let proxyAgent = undefined;

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -1,14 +1,14 @@
 import { IPrismComponents, IPrismInput } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
 import fetch from 'node-fetch';
-import { pipe } from 'fp-ts/function';
+import { constUndefined, pipe } from 'fp-ts/function';
 import * as NEA from 'fp-ts/NonEmptyArray';
 import * as E from 'fp-ts/Either';
 import * as TE from 'fp-ts/TaskEither';
 import * as RTE from 'fp-ts/ReaderTaskEither';
 import * as J from 'fp-ts/Json';
 import { defaults, omit } from 'lodash';
-import { format, parse } from 'url';
+import { format } from 'url';
 import { posix } from 'path';
 import { Logger } from 'pino';
 import { IHttpConfig, IHttpRequest, IHttpResponse } from '../types';
@@ -32,7 +32,7 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
   logger =>
     pipe(
       NEA.fromArray(validations),
-      TE.fromOption(() => undefined),
+      TE.fromOption(constUndefined),
       TE.map(failedValidations => {
         const securityValidation = failedValidations.find(validation => validation.code === 401);
 
@@ -44,9 +44,11 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
       TE.chainEitherK(() => serializeBody(input.body)),
       TE.chain(body =>
         TE.tryCatch(async () => {
-          const partialUrl = parse(baseUrl);
+          const partialUrl = new URL(baseUrl);
           const url = format({
             ...partialUrl,
+            host: partialUrl.host,
+            protocol: partialUrl.protocol,
             pathname: posix.join(partialUrl.pathname || '', input.url.path),
             query: input.url.query,
           });

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -349,7 +349,8 @@ function computeBody(
 ): E.Either<Error, unknown> {
   if (isINodeExample(negotiationResult.bodyExample) && negotiationResult.bodyExample.value !== undefined) {
     return E.right(negotiationResult.bodyExample.value);
-  } else if (negotiationResult.schema) {
+  }
+  if (negotiationResult.schema) {
     return payloadGenerator(negotiationResult.schema);
   }
   return E.right(undefined);


### PR DESCRIPTION

**Summary**

Replace depreacted parse function to WHATWG URL.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

