### PR TITLE
feat(proxy): add a flag to skip request validation

### DIFF
--- a/docs/getting-started/03-cli.md
+++ b/docs/getting-started/03-cli.md
@@ -139,6 +139,20 @@ curl -v -X POST http://localhost:4010/pet/
 
 The response body contains the found output violations.
 
+In some cases you may want to skip request validation. A common scenario would be where you want to check if your HTTP handlers validate the request appropriately.
+Prism will validate all requests by default, but you can skip this by setting the flag to `--validate-request` flag to `false`.
+
+```bash
+prism proxy examples/petstore.oas2.yaml https://petstore.swagger.io/v2 --errors --validate-request false
+```
+
+```bash
+curl -v -X POST http://localhost:4010/pet/ -d '{"name"": "Skip", "species": 100}'
+
+< HTTP/1.1 422 Unprocessable Entity
+{"statusCode": 400, "message": "Pet 'species' field should be a string, got integer", "code": "PET-ERROR-400"}
+```
+
 <!-- theme: info -->
 
 > Server definitions (OAS3) and Host + BasePath (OAS2) are ignored. You need to manually specify the upstream URL when invoking Prism.

--- a/packages/cli/src/commands/__tests__/commands.spec.ts
+++ b/packages/cli/src/commands/__tests__/commands.spec.ts
@@ -71,3 +71,11 @@ describe.each<{ 0: string; 1: string; 2: unknown }>([
     expect(createMultiProcessPrism).toHaveBeenLastCalledWith(expect.objectContaining({ errors: true }));
   });
 });
+
+test(`starts proxy server with default validate-request option to be overriden`, () => {
+  parser.parse(`proxy /path/to -m -h 0.0.0.0 ${new URL('http://github.com/')} --validate-request=false`);
+
+  expect(createMultiProcessPrism).toHaveBeenLastCalledWith(
+    expect.objectContaining({ validateRequest: false, host: '0.0.0.0' })
+  );
+});

--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -1,9 +1,8 @@
 import { pick } from 'lodash';
-import { CommandModule, parsed } from 'yargs';
+import { CommandModule } from 'yargs';
 import { createMultiProcessPrism, CreateProxyServerOptions, createSingleProcessPrism } from '../util/createServer';
 import sharedOptions from './sharedOptions';
 import { runPrismAndSetupWatcher } from '../util/runner';
-import { boolean } from 'fp-ts';
 
 const proxyCommand: CommandModule = {
   describe: 'Start a proxy server with the given document file',

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -73,8 +73,9 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     throw new Error('No operations found in the current file.');
   }
 
+  const validateRequest = isProxyServerOptions(options) ? options.validateRequest : true;
   const shared: Omit<IHttpConfig, 'mock'> = {
-    validateRequest: true,
+    validateRequest,
     validateResponse: true,
     checkSecurity: true,
     errors: false,
@@ -141,6 +142,7 @@ type CreateBaseServerOptions = {
 export interface CreateProxyServerOptions extends CreateBaseServerOptions {
   dynamic: false;
   upstream: URL;
+  validateRequest: boolean;
 }
 
 export type CreateMockServerOptions = CreateBaseServerOptions;


### PR DESCRIPTION
Addresses #1694 

**Summary**

This pull request adds a `--validate-request` flag to the proxy CLI. The default value is `true` (as it was before). Passing `false` means that incoming HTTP requests will not be validated.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
