### PR TITLE
allow for empty request bodies to skip validation, fixes #1939

### DIFF
--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -373,6 +373,37 @@ describe('body params validation', () => {
             },
           },
         },
+        {
+          id: '?http-operation-id?',
+          method: 'get',
+          path: '/empty-body',
+          responses: [
+            {
+              code: '200',
+              headers: [],
+              contents: [
+                {
+                  mediaType: 'text/plain',
+                  schema: {
+                    type: 'string',
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                  },
+                  examples: [],
+                  encodings: [],
+                },
+              ],
+            },
+          ],
+          servers: [],
+          request: {
+            headers: [],
+            query: [],
+            cookie: [],
+            path: [],
+          },
+          tags: [],
+          security: [],
+        },
       ]);
     });
 
@@ -452,6 +483,16 @@ describe('body params validation', () => {
           const response = await makeRequest('/json-body-optional', { method: 'POST' });
           expect(response.status).toBe(200);
         });
+
+        describe('and no content is specified', () => {
+          test('returns 200', async () => {
+            const response = await makeRequest('/empty-body', {
+              method: 'GET',
+              headers: { 'content-type': 'application/json' },
+            });
+            expect(response.status).toBe(200);
+          });
+        });
       });
 
       describe('when body with unsupported content-type is used', () => {
@@ -459,6 +500,7 @@ describe('body params validation', () => {
           const response = await makeRequest('/json-body-optional', {
             method: 'POST',
             headers: { 'content-type': 'application/xml' },
+            body: 'some xml',
           });
           expect(response.status).toBe(415);
         });
@@ -472,6 +514,7 @@ describe('body params validation', () => {
           headers: {
             'content-type': 'application/csv',
           },
+          body: 'type,name\nfoo,foobar',
         });
         expect(response.status).toBe(415);
         await expect(response.json()).resolves.toMatchObject({ type: 'foo' });

--- a/test-harness/specs/validate-body-params/enforce-content-type-if-body-included.oas3_1.txt
+++ b/test-harness/specs/validate-body-params/enforce-content-type-if-body-included.oas3_1.txt
@@ -1,0 +1,26 @@
+====test====
+Given a request body when the spec hasn't specified one
+then return 415
+====spec====
+openapi: '3.1.0'
+paths:
+  /path:
+    post:
+      responses:
+        200:
+          content:
+            text/plain:
+              example: ok
+        415:
+          content:
+            text/plain:
+              example: no body allowed
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -X POST http://localhost:4010/path -H "Content-Type: text/plain" --data "empty"
+====expect====
+HTTP/1.1 415 Bad Request
+content-type: text/plain
+
+no body allowed

--- a/test-harness/specs/validate-body-params/ignore-content-type-if-empty-body.oas3_1.txt
+++ b/test-harness/specs/validate-body-params/ignore-content-type-if-empty-body.oas3_1.txt
@@ -1,0 +1,22 @@
+====test====
+Given a request declaring a content-type but has no body
+then return 200
+====spec====
+openapi: '3.1.0'
+paths:
+  /path:
+    post:
+      responses:
+        200:
+          content:
+            text/plain:
+              example: ok
+====server====
+mock -p 4010 ${document}
+====command====
+curl -i -X POST http://localhost:4010/path -H "Content-Type: text/plain"
+====expect====
+HTTP/1.1 200 OK
+content-type: text/plain
+
+ok


### PR DESCRIPTION
Addresses #1939

**Summary**

inspects the request content-length header for making the decision to enforce the content-type on the request. if it is >1 then the content-type header must be one of the request body types.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A
