### PR TITLE
Define the multipleOfPrecision option for ajv to handle javascript number precision

### DIFF
--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -28,6 +28,7 @@ const baseAjvOptions: Partial<Options> = {
   allErrors: true,
   allowUnionTypes: true,
   allowMatchingProperties: true,
+  multipleOfPrecision: 3,
   strict: false,
   logger: unknownFormatSilencerLogger,
 };


### PR DESCRIPTION
**Summary**

Prism had trouble with the OAI multipleOf number constraint because the default ajv validation does not behave properly with non integer multipliers cf. https://github.com/ajv-validator/ajv/blob/master/lib/vocabularies/validation/multipleOf.ts 

Eg: -4.02 multipleOf 0.01 was rejected because JS says `-4.02 / 0.01 = -401.99999999999994`

This PR adds the AJV option to handle an error margin (1/1000th at the moment)

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Context**

https://github.com/ajv-validator/ajv/issues/84
https://github.com/ajv-validator/ajv/issues/652
