### PR TITLE
document, test per-property faker configuration

### DIFF
--- a/docs/guides/01-mocking.md
+++ b/docs/guides/01-mocking.md
@@ -186,6 +186,28 @@ The more descriptive your description is, the better job Prism can do at creatin
 
 > **Tip:** If your team needs help creating better quality API description documents, take a look at [Spectral](https://stoplight.io/spectral/). You could enforce the use of `example` properties, or similar.
 
+##### Control Generated Fakes for Individual Properties
+
+In the following example there are two properties, each with specific Faker parameters.  [datatype.number](https://fakerjs.dev/api/datatype.html#number) uses named parameters while [helpers.slugify](https://fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
+
+```yaml
+example:
+  type: object
+  properties:
+    ten-or-eleven:
+      type: number
+      example: 10
+      x-faker:
+        datatype.number:
+          min: 10
+          max: 11
+    slug:
+      type: string
+      example: two-words
+      x-faker:
+        helpers.slugify: [ "two words" ]
+```
+
 ##### Configure JSON Schema Faker
 
 At the top level of your API Specification, create an `x-json-schema-faker`

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -93,6 +93,53 @@ describe('JSONSchema generator', () => {
       });
     });
 
+    describe('when faker is configured per-property', () => {
+      it('with named parameters', () => {
+        const schema: JSONSchema & any = {
+          type: 'object',
+          properties: {
+            meaning: {
+              type: 'number',
+              'x-faker': {
+                'random.number': {
+                  min: 42,
+                  max: 42,
+                },
+              },
+            },
+          },
+          required: ['meaning'],
+        };
+
+        assertRight(generate({}, schema), instance => {
+          expect(instance).toHaveProperty('meaning');
+          const actual = get(instance, 'meaning');
+          expect(actual).toStrictEqual(42);
+        });
+      });
+
+      it('with positional parameters', () => {
+        const schema: JSONSchema & any = {
+          type: 'object',
+          properties: {
+            slug: {
+              type: 'string',
+              'x-faker': {
+                'helpers.slugify': ['two words'],
+              },
+            },
+          },
+          required: ['slug'],
+        };
+
+        assertRight(generate({}, schema), instance => {
+          expect(instance).toHaveProperty('slug');
+          const actual = get(instance, 'slug');
+          expect(actual).toStrictEqual('two-words');
+        });
+      });
+    });
+
     describe('when used with a schema that is not valid', () => {
       const schema: JSONSchema = {
         type: 'object',


### PR DESCRIPTION
Addresses https://github.com/stoplightio/prism/issues/1647#issuecomment-1064174921

## Summary

Faker can be configured per-property, but there were no examples of this either in tests or documentation.

## Checklist

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

## Example Schema

```yaml
openapi: 3.0.0
info:
  title: issue
  version: '1.0'
  description: asdf
  contact:
    email: example@example.com
tags: []
servers: []
paths:
  /200:
    parameters: []
    get:
      description: asdf
      tags: []
      summary: example
      operationId: example
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                type: object
                properties:
                  ten-or-eleven:
                    type: number
                    example: 10
                    x-faker:
                      datatype.number:
                        min: 10
                        max: 11
                  slug:
                    type: string
                    example: two-words
                    x-faker:
                      helpers.slugify:
                        - "two words"
components:
  schemas: {}
  securitySchemes: {}
```

Running `prism-cli mock -d example.oas`, including the `x-faker` directives, I see the following results.

```sh
% curl -s localhost:4010/200 | jq .

{
  "slug": "two-words",
  "ten-or-eleven": 11
}
```

Without the `x-faker` elements, I see the following results.

```sh
% curl -s localhost:4010/200 | jq .

{
  "slug": "consectetur",
  "ten-or-eleven": 28385379.785439685
}
```