### PR TITLE
Update faker dependency to point to official community-maintained version

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you are interested in contributing to Prism itself, check out our [contributi
 Prism is built on top of lots of excellent packages, and here are a few we'd like to say a special thanks to.
 
 - [ajv](https://www.npmjs.com/package/ajv)
-- [faker](https://www.npmjs.com/package/faker)
+- [faker](https://www.npmjs.com/package/@faker-js/faker)
 - [fp-ts](https://www.npmjs.com/package/fp-ts)
 - [gavel](https://www.npmjs.com/package/gavel)
 - [json-schema-faker](https://www.npmjs.com/package/json-schema-faker)

--- a/packages/cli/src/util/__tests__/paths.spec.ts
+++ b/packages/cli/src/util/__tests__/paths.spec.ts
@@ -1,7 +1,7 @@
 import { HttpParamStyles } from '@stoplight/types';
 import { createExamplePath } from '../paths';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('createExamplePath()', () => {
   describe('path parameters', () => {

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -3,7 +3,7 @@ import { IHttpOperation } from '@stoplight/types';
 import fetch, { RequestInit } from 'node-fetch';
 import { createServer } from '../';
 import { ThenArg } from '../types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 const logger = createLogger('TEST', { enabled: false });
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,6 +16,7 @@
     "node": ">=16"
   },
   "dependencies": {
+    "@faker-js/faker": "^6.0.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-merge-allof": "0.7.8",
     "@stoplight/json-schema-sampler": "0.2.2",
@@ -28,7 +29,6 @@
     "ajv-formats": "^2.1.1",
     "caseless": "^0.12.0",
     "content-type": "^1.0.4",
-    "faker": "^5.5.3",
     "fp-ts": "^2.11.5",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",

--- a/packages/http/src/__tests__/fixtures/index.ts
+++ b/packages/http/src/__tests__/fixtures/index.ts
@@ -1,6 +1,6 @@
 import { IPrismInput } from '@stoplight/prism-core';
 import { DiagnosticSeverity, HttpParamStyles, IHttpOperation } from '@stoplight/types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 import { IHttpRequest, IHttpResponse } from '../../types';
 
 export const httpOperations: IHttpOperation[] = [

--- a/packages/http/src/mocker/callback/__tests__/callbacks.spec.ts
+++ b/packages/http/src/mocker/callback/__tests__/callbacks.spec.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { runCallback } from '../callbacks';
 import { mapValues } from 'lodash';
 import { HttpParamStyles } from '@stoplight/types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 jest.mock('node-fetch');
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,4 +1,4 @@
-import * as faker from 'faker';
+import * as faker from '@faker-js/faker';
 import { cloneDeep } from 'lodash';
 import { JSONSchema } from '../../types';
 

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,4 +1,4 @@
-import * as faker from '@faker-js/faker';
+import faker from '@faker-js/faker';
 import { cloneDeep } from 'lodash';
 import { JSONSchema } from '../../types';
 

--- a/packages/http/src/mocker/generator/__tests__/HttpParamGenerator.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/HttpParamGenerator.spec.ts
@@ -1,6 +1,6 @@
 import { assertNone, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { generate, improveSchema } from '../HttpParamGenerator';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('HttpParamGenerator', () => {
   describe('generate()', () => {

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -101,7 +101,7 @@ describe('JSONSchema generator', () => {
             meaning: {
               type: 'number',
               'x-faker': {
-                'random.number': {
+                'datatype.number': {
                   min: 42,
                   max: 42,
                 },

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -5,7 +5,8 @@ import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/uti
 
 describe('JSONSchema generator', () => {
   const ipRegExp = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
-  const emailRegExp = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  const emailRegExp =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   const uuidRegExp = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/;
 
   describe('generate()', () => {
@@ -101,7 +102,7 @@ describe('JSONSchema generator', () => {
             meaning: {
               type: 'number',
               'x-faker': {
-                'datatype.number': {
+                'random.number': {
                   min: 42,
                   max: 42,
                 },

--- a/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
@@ -1,6 +1,6 @@
 import { assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { findBestHttpContentByMediaType } from '../InternalHelpers';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('InternalHelpers', () => {
   describe('findBestHttpContentByMediaType()', () => {

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -6,7 +6,7 @@ import {
   INodeExample,
   INodeExternalExample,
 } from '@stoplight/types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 import * as E from 'fp-ts/Either';
 import { left, right } from 'fp-ts/ReaderEither';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
 import { HttpMethod, IHttpOperation, IServer } from '@stoplight/types';
 import { isRight } from 'fp-ts/Either';

--- a/packages/http/src/router/__tests__/matchBaseUrl.spec.ts
+++ b/packages/http/src/router/__tests__/matchBaseUrl.spec.ts
@@ -1,7 +1,7 @@
 import { convertTemplateToRegExp, matchBaseUrl } from '../matchBaseUrl';
 import { MatchType } from '../types';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('matchServer.ts', () => {
   describe('matchServer()', () => {

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -1,5 +1,5 @@
 import { matchPath } from '../matchPath';
-import * as faker from '@faker-js/faker';
+import faker from '@faker-js/faker';
 import { MatchType } from '../types';
 import { randomPath } from './utils';
 import { assertRight } from '@stoplight/prism-core/src/__tests__/utils';

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -1,5 +1,5 @@
 import { matchPath } from '../matchPath';
-import * as faker from 'faker';
+import * as faker from '@faker-js/faker';
 import { MatchType } from '../types';
 import { randomPath } from './utils';
 import { assertRight } from '@stoplight/prism-core/src/__tests__/utils';

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -1,5 +1,5 @@
 import { HttpMethod } from '@stoplight/types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 import { defaults } from 'lodash/fp';
 import { DeepNonNullable } from 'utility-types';
 

--- a/packages/http/src/validator/__tests__/functional.spec.ts
+++ b/packages/http/src/validator/__tests__/functional.spec.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity, HttpParamStyles, IHttpOperation } from '@stoplight/
 import { httpInputs, httpOperations, httpOutputs } from '../../__tests__/fixtures';
 import { validateInput, validateOutput } from '../index';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 const BAD_INPUT = Object.assign({}, httpInputs[2], {
   body: { name: 'Shopping', completed: 'yes' },

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -6,7 +6,7 @@ import * as validators from '../validators';
 import * as validator from '../';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import { ValidationContext } from '../validators/types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 const validate =
   (resourceExtension?: Partial<IHttpOperation>, inputExtension?: Partial<IHttpRequest>, length = 3) =>

--- a/packages/http/src/validator/utils/__tests__/spec.spec.ts
+++ b/packages/http/src/validator/utils/__tests__/spec.spec.ts
@@ -1,6 +1,6 @@
 import { assertNone, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { findOperationResponse } from '../spec';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('findOperationResponse()', () => {
   describe('when response for given code exists', () => {

--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -3,7 +3,7 @@ import { JSONSchema } from '../../..';
 import { validate, findContentByMediaTypeOrFirst } from '../body';
 import { assertRight, assertLeft, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { ValidationContext } from '../types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('validate()', () => {
   describe('content specs are missing', () => {

--- a/packages/http/src/validator/validators/__tests__/headers.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/headers.spec.ts
@@ -3,7 +3,7 @@ import { validate } from '../headers';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import * as O from 'fp-ts/Option';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('validate()', () => {
   beforeEach(() => {

--- a/packages/http/src/validator/validators/__tests__/path.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/path.spec.ts
@@ -3,7 +3,7 @@ import { validate } from '../path';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
 import * as O from 'fp-ts/Option';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('validate()', () => {
   beforeEach(() => {

--- a/packages/http/src/validator/validators/__tests__/query.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/query.spec.ts
@@ -3,7 +3,7 @@ import { validate } from '../query';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import * as O from 'fp-ts/Option';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 describe('validate()', () => {
   beforeEach(() => {

--- a/packages/http/src/validator/validators/security/__tests__/security.spec.ts
+++ b/packages/http/src/validator/validators/security/__tests__/security.spec.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity, HttpSecurityScheme } from '@stoplight/types';
 import { validateSecurity } from '../';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import { IHttpRequest } from '../../../../types';
-import * as faker from 'faker/locale/en';
+import * as faker from '@faker-js/faker/locale/en';
 
 const baseRequest: IHttpRequest = {
   method: 'get',

--- a/yarn.lock
+++ b/yarn.lock
@@ -444,7 +444,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@faker-js/faker@6.0.0":
+"@faker-js/faker@6.0.0", "@faker-js/faker@^6.0.0":
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.0.0.tgz#b613ebf5f5ebb2ab987afb567d8b7fe860199c13"
   integrity sha512-10zLCKhp3YEmBuko71ivcMoIZcCLXgQVck6aNswX+AWwaek/L8S3yz9i8m3tHigRkcF6F2vI+qtdtyySHK+bGA==
@@ -3149,9 +3149,9 @@ doctrine@^3.0.0:
     esutils "^2.0.2"
 
 dom-serializer@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
-  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
   dependencies:
     domelementtype "^2.0.1"
     domhandler "^4.2.0"
@@ -3568,11 +3568,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-faker@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -5893,9 +5888,9 @@ mute-stream@~0.0.4:
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 nanoid@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.2.tgz#c89622fafb4381cd221421c69ec58547a1eec557"
-  integrity sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
+  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Addresses #1968

**Summary**
This PR replaces the compromised [faker](https://www.npmjs.com/package/faker) dependency with the official community-maintained [@faker-js/faker](https://www.npmjs.com/package/@faker-js/faker) dependency. The contents of the dependency (and version number) are the same. 

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**
N/A

**Additional context**

