### PR TITLE
Upgrading minimum node engine to 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@ version: 2.1
 executors:
   docker-node:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
   docker-harness:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
       - image: kennethreitz/httpbin
         name: httpbin.org
   macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,10 @@ version: 2.1
 executors:
   docker-node:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:16
   docker-harness:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:16
       - image: kennethreitz/httpbin
         name: httpbin.org
   macos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 as compiler
+FROM node:14 as compiler
 
 WORKDIR /usr/src/prism
 
@@ -8,7 +8,7 @@ COPY packages/ /usr/src/prism/packages/
 RUN yarn && yarn build
 
 ###############################################################
-FROM node:12 as dependencies
+FROM node:14 as dependencies
 
 WORKDIR /usr/src/prism/
 
@@ -34,7 +34,7 @@ RUN if [ $(uname -m) != "aarch64" ]; then curl -sfL https://install.goreleaser.c
 RUN if [ $(uname -m) != "aarch64" ]; then ./bin/node-prune; fi
 
 ###############################################################
-FROM node:12-alpine
+FROM node:14-alpine
 
 WORKDIR /usr/src/prism
 ARG BUILD_TYPE=development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14 as compiler
+FROM node:16 as compiler
 
 WORKDIR /usr/src/prism
 
@@ -8,7 +8,7 @@ COPY packages/ /usr/src/prism/packages/
 RUN yarn && yarn build
 
 ###############################################################
-FROM node:14 as dependencies
+FROM node:16 as dependencies
 
 WORKDIR /usr/src/prism/
 
@@ -34,7 +34,7 @@ RUN if [ $(uname -m) != "aarch64" ]; then curl -sfL https://install.goreleaser.c
 RUN if [ $(uname -m) != "aarch64" ]; then ./bin/node-prune; fi
 
 ###############################################################
-FROM node:14-alpine
+FROM node:16-alpine
 
 WORKDIR /usr/src/prism
 ARG BUILD_TYPE=development

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prism is a set of packages for API mocking and contract testing with **OpenAPI v
 
 ### Installation
 
-_Prism requires NodeJS >= 12 to properly work._
+_Prism requires NodeJS >= 14 to properly work._
 
 ```bash
 npm install -g @stoplight/prism-cli
@@ -50,7 +50,7 @@ Learn more about [how the mock server works](docs/guides/01-mocking.md).
 
 ### Validation Proxy
 
-Prism can help you check for discrepencies between your API implementation and the OpenAPI document that describes, letting you funnel HTTP traffic through it with the `prism proxy` command. 
+Prism can help you check for discrepencies between your API implementation and the OpenAPI document that describes, letting you funnel HTTP traffic through it with the `prism proxy` command.
 
 ```bash
 prism proxy examples/petstore.oas2.yaml https://petstore.swagger.io/v2
@@ -148,4 +148,3 @@ If you would like to thank us for creating Prism, we ask that you [**buy the wor
 [npm]: https://www.npmjs.com/package/@stoplight/prism-cli
 [npm_image]: https://img.shields.io/npm/dw/@stoplight/prism-http?color=blue
 [stoplight_forest]: https://ecologi.com/stoplightinc
-

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Prism is a set of packages for API mocking and contract testing with **OpenAPI v
 
 ### Installation
 
-_Prism requires NodeJS >= 14 to properly work._
+_Prism requires NodeJS >= 16 to properly work._
 
 ```bash
 npm install -g @stoplight/prism-cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "yargs": "^16.2.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "/dist"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "yargs": "^16.2.0"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "files": [
     "/dist"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "/dist"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "dependencies": {
     "fp-ts": "^2.11.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "/dist"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
     "fp-ts": "^2.11.5",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/stoplightio/prism.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "files": [
     "/dist"

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/stoplightio/prism.git"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "files": [
     "/dist"

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -13,7 +13,7 @@
     "/dist"
   ],
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "dependencies": {
     "@stoplight/json": "^3.13.7",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -13,7 +13,7 @@
     "/dist"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "dependencies": {
     "@stoplight/json": "^3.13.7",


### PR DESCRIPTION
Addresses #2022 

**Summary**
This PR upgrades the minimum node engine version from 12 to 16, as node version 12 is [approaching end-of-life](https://nodejs.org/en/about/releases/) on 04-30-2022. Specifying the minimum version of 16 will allow us to use dependencies that require a minimum version of 16. 

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**
N/A

