### PR TITLE
Removed deprecated wording

### DIFF
--- a/docs/getting-started/03-cli.md
+++ b/docs/getting-started/03-cli.md
@@ -50,7 +50,7 @@ In such a case, Prism will keep serving operations loaded with the previous rest
 
 ### Modifying Responses
 
-Prism's behavior in looking for the response for your request can be modified with a series of parameters that you can either pass through the `Prefer` header or through a query string parameter. Query string parameters are _deprecated_ and will be removed in the next major release.
+Prism's behavior in looking for the response for your request can be modified with a series of parameters that you can either pass through the `Prefer` header or through a query string parameter. 
 
 Keep in mind, all the query parameters need to be prefixed with `__` — so if the Prefer header parameter is `code`, the query string will be `__code`
 


### PR DESCRIPTION
Removed: Query string parameters are deprecated and will be removed in the next major release.