### PR TITLE
1839 specs that includes CORS response headers

### DIFF
--- a/docs/guides/05-cors.md
+++ b/docs/guides/05-cors.md
@@ -2,7 +2,7 @@
 
 By default, Prism will handle all the [preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) responding with a `204` and with headers that will allow all the methods and all the origins.
 
-This is regardless of your OpenAPI description. A request to `OPTIONS /api/todo` will receive a `204` as a response even though your description document does not specify the `OPTIONS` verb for that endpoint, **and** even if your description document does **not** have an `/api/todo` path at all.
+This is done automatically, even when your OpenAPI description includes no CORS response headers. A request to `OPTIONS /api/todo` will receive a `204` as a response even though your description document does not specify the `OPTIONS` verb for that endpoint, **and** even if your description document does **not** have an `/api/todo` path at all.  However, if your OpenAPI description includes CORS headers Prism will not override them, and you must ensure they enable requests from a browser on your own.
 
 In case your OpenAPI Document specifies an `OPTIONS` handler (returning a custom status code or different headers) it will still be called when the subsequent `OPTIONS` request will be made. This is because Prism is able to differentiate between a preflight request and a regular `OPTIONS` request.
 


### PR DESCRIPTION
Addresses #1839 

**Summary**

Describe how Prism handles OpenAPI specs that explicitly include CORS response headers.
