### PR TITLE
upgrade the macOs xcode image to get node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
         name: httpbin.org
   macos:
     macos:
-      xcode: 12.5.1
+      xcode: 13.3.1
 
 orbs:
   stoplight: stoplight/cli@0.0.3


### PR DESCRIPTION
Upgrade the xcode image so that it brings in node 16 to be compatible with our node 16 upgrade.

https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
