### PR TITLE
Added alphabetical ordering to generated objects 

### DIFF
--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -33,7 +33,7 @@ jsf.option({
 });
 
 export function generate(bundle: unknown, source: JSONSchema): Either<Error, unknown> {
-  var test = pipe(
+  return pipe(
     stripWriteOnlyProperties(source),
     E.fromOption(() => Error('Cannot strip writeOnly properties')),
     E.chain(updatedSource =>
@@ -42,8 +42,6 @@ export function generate(bundle: unknown, source: JSONSchema): Either<Error, unk
       tryCatch(() => sortSchemaAlphabetically(jsf.generate({ ...cloneDeep(updatedSource), __bundled__: bundle })), toError)
     )
   );
-
-  return test
 }
 
 //sort alphabetically by keys

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -44,14 +44,14 @@ export function generate(bundle: unknown, source: JSONSchema): Either<Error, unk
 
 //sort alphabetically by keys
 export function sortSchemaAlphabetically(source: any): any {
-  if (Array.isArray(source)) {
+  if (source && Array.isArray(source)) {
     for (const i of source) {
       if (typeof source[i] === 'object') {
         source[i] = sortSchemaAlphabetically(source[i]);
       }
     }
     return source;
-  } else if (typeof source === 'object') {
+  } else if (source && typeof source === 'object') {
     Object.keys(source).forEach((key: string) => {
       if (typeof source[key] === 'object') {
         source[key] = sortSchemaAlphabetically(source[key]);

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,5 +1,5 @@
 import * as faker from 'faker';
-import { cloneDeep, forEach, isString, keys, values } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { JSONSchema } from '../../types';
 
 import * as jsf from 'json-schema-faker';
@@ -9,11 +9,6 @@ import { IHttpOperation } from '@stoplight/types';
 import { pipe } from 'fp-ts/function';
 import * as E from 'fp-ts/lib/Either';
 import { stripWriteOnlyProperties } from '../../utils/filterRequiredProperties';
-import { JSONSchema7Type } from 'json-schema';
-import { right } from 'fp-ts/lib/EitherT';
-import { sort } from 'fp-ts/lib/ReadonlyNonEmptyArray';
-import { isFalsy } from 'utility-types';
-// import obj from 'http/src/validator/validators';
 
 // necessary as workaround broken types in json-schema-faker
 // @ts-ignore
@@ -37,33 +32,36 @@ export function generate(bundle: unknown, source: JSONSchema): Either<Error, unk
     stripWriteOnlyProperties(source),
     E.fromOption(() => Error('Cannot strip writeOnly properties')),
     E.chain(updatedSource =>
-      // necessary as workaround broken types in json-schema-faker
-      // @ts-ignore
-      tryCatch(() => sortSchemaAlphabetically(jsf.generate({ ...cloneDeep(updatedSource), __bundled__: bundle })), toError)
+      tryCatch(
+        // necessary as workaround broken types in json-schema-faker
+        // @ts-ignore
+        () => sortSchemaAlphabetically(jsf.generate({ ...cloneDeep(updatedSource), __bundled__: bundle })),
+        toError
+      )
     )
   );
 }
 
 //sort alphabetically by keys
 export function sortSchemaAlphabetically(source: any): any {
-  if (Array.isArray(source)){
-    for (let i in source) {
-      if(typeof(source[i] == "object")){
-        source[i] = sortSchemaAlphabetically(source[i])
-      } 
+  if (Array.isArray(source)) {
+    for (const i of source) {
+      if (typeof source[i] === 'object') {
+        source[i] = sortSchemaAlphabetically(source[i]);
+      }
     }
-    return source
-  } else if(typeof(source) == "object"){
-    Object.keys(source).forEach((key:string)=>{
-        if(typeof(source[key]) == "object"){
-          source[key] = sortSchemaAlphabetically(source[key])
-        } 
-      });
-    return Object.fromEntries(Object.entries(source).sort())
+    return source;
+  } else if (typeof source === 'object') {
+    Object.keys(source).forEach((key: string) => {
+      if (typeof source[key] === 'object') {
+        source[key] = sortSchemaAlphabetically(source[key]);
+      }
+    });
+    return Object.fromEntries(Object.entries(source).sort());
   }
 
   //just return if not array or object
-  return source
+  return source;
 }
 
 export function generateStatic(resource: IHttpOperation, source: JSONSchema): Either<Error, unknown> {

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -1,11 +1,12 @@
 import { get } from 'lodash';
 import { JSONSchema } from '../../../types';
-import { generate } from '../JSONSchema';
+import { generate, sortSchemaAlphabetically } from '../JSONSchema';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 
 describe('JSONSchema generator', () => {
   const ipRegExp = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/;
-  const emailRegExp = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  const emailRegExp =
+    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   const uuidRegExp = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/;
 
   describe('generate()', () => {
@@ -184,6 +185,51 @@ describe('JSONSchema generator', () => {
       Object.defineProperty(schema.properties, 'name', { writable: false });
 
       return expect(generate({}, schema)).toBeTruthy();
+    });
+  });
+
+  describe('sortSchemaAlphabetically()', () => {
+    it('should leave source untouched if not array or object', () => {
+      const source = 'string';
+
+      expect(sortSchemaAlphabetically(source)).toEqual('string');
+    });
+
+    it('should leave source untouched if array of non-objects', () => {
+      const source = ['string'];
+
+      expect(sortSchemaAlphabetically(source)).toEqual(['string']);
+    });
+
+    it('should alphabetize properties of objects in array', () => {
+      const source = ['string', { d: 'd value', a: 'a value', b: 'b value', c: 'c value' }];
+
+      expect(sortSchemaAlphabetically(source)).toEqual([
+        'string',
+        { a: 'a value', b: 'b value', c: 'c value', d: 'd value' },
+      ]);
+    });
+
+    it('should alphabetize properties of object', () => {
+      const source = { d: 'd value', a: 'a value', b: 'b value', c: 'c value' };
+
+      expect(sortSchemaAlphabetically(source)).toEqual({ a: 'a value', b: 'b value', c: 'c value', d: 'd value' });
+    });
+
+    it('should alphabetize properties of nested objects', () => {
+      const source = {
+        d: { d3: 'd3 value', d1: 'd1 value', d4: 'd4 value', d2: 'd2 value' },
+        a: 'a value',
+        b: { b2: 'b2 value', b1: 'b1 value', b3: 'b3 value' },
+        c: 'c value',
+      };
+
+      expect(sortSchemaAlphabetically(source)).toEqual({
+        a: 'a value',
+        b: { b1: 'b1 value', b2: 'b2 value', b3: 'b3 value' },
+        c: 'c value',
+        d: { d1: 'd1 value', d2: 'd2 value', d3: 'd3 value', d4: 'd4 value' },
+      });
     });
   });
 });

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -189,6 +189,11 @@ describe('JSONSchema generator', () => {
   });
 
   describe('sortSchemaAlphabetically()', () => {
+    it('should handle nulls', () => {
+      const source = null;
+      expect(sortSchemaAlphabetically(source)).toEqual(null);
+    });
+
     it('should leave source untouched if not array or object', () => {
       const source = 'string';
 

--- a/test-harness/README.md
+++ b/test-harness/README.md
@@ -92,6 +92,13 @@ Connection: keep-alive
 - The outputs get converted using `http-string-parser`, a veeery old package transforming curl output to a consumable format
 - Gavel is used to validate the request — it will automagically ignore headers that can change and consider only the "fundamental" one such as content negotiation ones and stuff around.
 
+## Different Types of Expects
+
+There are 3 different keywords you can use for the "expect" portion of the test: `expect`, `expect-loose`, `expect-keysOnly`. With each of these, `gavel` will be used to validate the actual output with the expected output. `expect-loose` will not add any additional checks on top of the `gavel` validation. `expect` and `expect-keysOnly` will add additional checks on the output as described below:
+
+- `expect`: additionally uses jest's `.toStrictEqual()` which ensures the output matches exactly with the expected body supplied. This includes all keys and values match and are in the exact order.
+- `expect-keysOnly`: additionally validates that only the keys are exactly the same and in the exact order. The values of the output are not validated. This is useful when you want to test `dynamic` mode, where the values will be different every time, but also want to validate that the order of the keys of the response are correct.
+
 ## Troubleshooting Harness Tests
 
 - `Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout` --> most likely the binary is crashing, failing to start Prism. The best way to troubleshoot is to copy the openapi content from your harness test into a separate OpenAPI file, and try mocking that file with the CLI directly. That will give you more information as to why Prism failed to start.

--- a/test-harness/README.md
+++ b/test-harness/README.md
@@ -97,7 +97,7 @@ Connection: keep-alive
 There are 3 different keywords you can use for the "expect" portion of the test: `expect`, `expect-loose`, `expect-keysOnly`. With each of these, `gavel` will be used to validate the actual output with the expected output. `expect-loose` will not add any additional checks on top of the `gavel` validation. `expect` and `expect-keysOnly` will add additional checks on the output as described below:
 
 - `expect`: additionally uses jest's `.toStrictEqual()` which ensures the output matches exactly with the expected body supplied. This includes all keys and values match and are in the exact order.
-- `expect-keysOnly`: additionally validates that only the keys are exactly the same and in the exact order. The values of the output are not validated. This is useful when you want to test `dynamic` mode, where the values will be different every time, but also want to validate that the order of the keys of the response are correct.
+- `expect-keysOnly`: additionally validates that only the keys are exactly the same and in the exact order. The values of the output are not validated. This is useful when you want to test `dynamic` mode, where the values will be different every time, but also want to validate that the order of the keys of the response are correct. This is meant to be used only for tests that return a a JSON object. This is not meant to work with any other response body/type.
 
 ## Troubleshooting Harness Tests
 

--- a/test-harness/helpers.ts
+++ b/test-harness/helpers.ts
@@ -26,7 +26,7 @@ export const xmlValidator = {
 };
 
 export function parseSpecFile(spec: string) {
-  const regex = /====(server|test|spec|command|expect|expect-loose)====\r?\n/gi;
+  const regex = /====(server|test|spec|command|expect|expect-loose|expect-keysOnly)====\r?\n/gi;
   const splitted = spec.split(regex);
 
   const testIndex = splitted.findIndex(t => t === 'test');
@@ -35,6 +35,7 @@ export function parseSpecFile(spec: string) {
   const commandIndex = splitted.findIndex(t => t === 'command');
   const expectIndex = splitted.findIndex(t => t === 'expect');
   const expectLooseIndex = splitted.findIndex(t => t === 'expect-loose');
+  const expectKeysOnlyIndex = splitted.findIndex(t => t === 'expect-keysOnly');
 
   return {
     test: splitted[1 + testIndex],
@@ -43,5 +44,6 @@ export function parseSpecFile(spec: string) {
     command: splitted[1 + commandIndex],
     expect: splitted[1 + expectIndex],
     expectLoose: splitted[1 + expectLooseIndex],
+    expectKeysOnly: splitted[1 + expectKeysOnlyIndex],
   };
 }

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -75,10 +75,10 @@ describe('harness', () => {
         }
 
         const isValid = validate(expected, output).valid;
+
         if (!!isValid) {
           expect(isValid).toBeTruthy();
-        } else if(parsed.expectLoose) {
-          console.log('loose...');
+        } else {
           expect(output).toMatchObject(expected);
         }
         if (parsed.expect) {

--- a/test-harness/index.ts
+++ b/test-harness/index.ts
@@ -59,7 +59,7 @@ describe('harness', () => {
           windowsVerbatimArguments: false,
         });
         const output: any = parseResponse(clientCommandHandle.stdout.trim());
-        const expected: any = parseResponse((parsed.expect || parsed.expectLoose).trim());
+        const expected: any = parseResponse((parsed.expect || parsed.expectLoose || parsed.expectKeysOnly).trim());
 
         const isXml = xmlValidator.test(get(output, ['header', 'content-type'], ''), expected.body);
 
@@ -75,14 +75,18 @@ describe('harness', () => {
         }
 
         const isValid = validate(expected, output).valid;
-
         if (!!isValid) {
           expect(isValid).toBeTruthy();
-        } else {
+        } else if(parsed.expectLoose) {
+          console.log('loose...');
           expect(output).toMatchObject(expected);
         }
         if (parsed.expect) {
           expect(output.body).toStrictEqual(expected.body);
+        } else if (parsed.expectKeysOnly){
+          const jsonOutput = JSON.parse(output.body);
+          const jsonExpected = JSON.parse(expected.body);
+          expect(Object.keys(jsonOutput)).toStrictEqual(Object.keys(jsonExpected));
         }
       });
     });

--- a/test-harness/specs/dynamic-responses/dynamic_json_alphabetize_response.oas2.txt
+++ b/test-harness/specs/dynamic-responses/dynamic_json_alphabetize_response.oas2.txt
@@ -1,0 +1,39 @@
+====test====
+Prism generates dynamic values when instructed to do so.
+
+Given there are no examples defined for an operation
+And this operation can produce application/json response
+And this operation response defines a Schema Object
+And I make a request to this operation
+And the request has Accept header of application/json
+Then I should get a response with dynamically generated JSON as payload that is aplphabetized.
+====spec====
+swagger: "2.0"
+info:
+  title: 'title'
+  version: '1.0'
+paths:
+  /todos:
+    get:
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Get Todo Items
+          schema:
+            type: object
+            properties:
+              title:
+                type: string
+              description:
+                type: string
+              priority:
+                type: integer
+====server====
+mock -d -p 4010 ${document}
+====command====
+curl -i http://localhost:4010/todos -H "accept: application/json"
+====expect-keysOnly====
+HTTP/1.1 200 OK
+
+{"description": "any string","priority": "any string","title": "any string"}


### PR DESCRIPTION
Ordering by the original JSON schema would be optimal but this seems better than random?

Addresses #2038 

**Summary**

Json parameters are returned in (random?) order from dynamic mocking.  Ugly at best, hard to find what you are looking for.

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

![image](https://user-images.githubusercontent.com/86619553/164043775-5f5b2043-c5aa-488f-a9df-2fde45e82e2d.png)
<img width="981" alt="image" src="https://user-images.githubusercontent.com/86619553/164043846-1752186a-15ae-4d5b-bdda-2a76818cc3c5.png">


**Additional context**

Please overly scrutinize this, but also be gentle ;) -  I'd love to be helpful but don't want my help to be detrimental.  And I'm pretty new to TypeScript generally.

Obvious concerns are recursion, typing, unintended consequences - I don't know the project context.

It also seems like https://github.com/json-schema-faker/json-schema-faker might be the place to really address some of this?
