### PR TITLE
ensure the forwarder passes query or search string values

### DIFF
--- a/packages/http/src/forwarder/__tests__/index.spec.ts
+++ b/packages/http/src/forwarder/__tests__/index.spec.ts
@@ -36,7 +36,13 @@ describe('forward', () => {
             data: {
               method: 'post',
               body: { some: 'data' },
-              url: { path: '/test' },
+              url: {
+                path: '/test',
+                query: {
+                  x: ['1', 'a'],
+                  y: '3',
+                },
+              },
             },
           },
           'http://example.com',
@@ -44,7 +50,7 @@ describe('forward', () => {
         )(logger),
         () => {
           expect(fetch).toHaveBeenCalledWith(
-            'http://example.com/test',
+            'http://example.com/test?x=1&x=a&y=3',
             expect.objectContaining({ method: 'post', body: '{"some":"data"}' })
           );
         }

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -19,6 +19,7 @@ import { ProblemJsonError } from '../types';
 import { UPSTREAM_NOT_IMPLEMENTED } from './errors';
 import * as createHttpProxyAgent from 'http-proxy-agent';
 import * as createHttpsProxyAgent from 'https-proxy-agent';
+import { toURLSearchParams } from '../utils/url';
 
 const { version: prismVersion } = require('../../package.json'); // eslint-disable-line
 
@@ -48,7 +49,7 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
           const url = format(
             Object.assign(partialUrl, {
               pathname: posix.join(partialUrl.pathname || '', input.url.path),
-              query: input.url.query,
+              search: toURLSearchParams(input.url.query).toString(),
             })
           );
 

--- a/packages/http/src/utils/url.ts
+++ b/packages/http/src/utils/url.ts
@@ -1,0 +1,17 @@
+import { IHttpNameValues } from '../types';
+
+export function toURLSearchParams(query: IHttpNameValues | undefined): URLSearchParams {
+  const urlSearchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query ?? {})) {
+    if (typeof value === 'string') {
+      urlSearchParams.append(key, value);
+    } else if (value instanceof Array) {
+      for (const innerValue of value) {
+        urlSearchParams.append(key, innerValue);
+      }
+    }
+  }
+
+  return urlSearchParams;
+}


### PR DESCRIPTION
Addresses a regression in 4.9.0

**Summary**

Prism 4.9.0 was not passing query string values when forwarding a request. The `format` change, didn't account for a change from `query` into `search`

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A
