### PR TITLE
allow nullable properties in deepobject style

### DIFF
--- a/packages/cli/src/util/__tests__/paths.spec.ts
+++ b/packages/cli/src/util/__tests__/paths.spec.ts
@@ -227,6 +227,50 @@ describe('createExamplePath()', () => {
       );
     });
 
+    it('generates deepObject style with null values', () => {
+      assertRight(
+        createExamplePath({
+          id: '123',
+          path: '/path',
+          method: 'get',
+          request: {
+            query: [
+              {
+                id: faker.random.word(),
+                name: 'p',
+                style: HttpParamStyles.DeepObject,
+                examples: [{ id: faker.random.word(), key: 'foo', value: { a: { aa: 1, ab: 2 }, b: null } }],
+              },
+            ],
+          },
+          responses: [{ id: faker.random.word(), code: '200' }],
+        }),
+        r => expect(r).toEqual('/path?p%5Ba%5D%5Baa%5D=1&p%5Ba%5D%5Bab%5D=2')
+      );
+    });
+
+    it('generates deepObject style with only null values', () => {
+      assertRight(
+        createExamplePath({
+          id: '123',
+          path: '/path',
+          method: 'get',
+          request: {
+            query: [
+              {
+                id: faker.random.word(),
+                name: 'p',
+                style: HttpParamStyles.DeepObject,
+                examples: [{ id: faker.random.word(), key: 'foo', value: { a: null } }],
+              },
+            ],
+          },
+          responses: [{ id: faker.random.word(), code: '200' }],
+        }),
+        r => expect(r).toEqual('/path')
+      );
+    });
+
     it('generates pipeDelimited style', () => {
       assertRight(
         createExamplePath({

--- a/packages/cli/src/util/__tests__/paths.spec.ts
+++ b/packages/cli/src/util/__tests__/paths.spec.ts
@@ -228,6 +228,10 @@ describe('createExamplePath()', () => {
     });
 
     it('generates deepObject style with null values', () => {
+      const exampleValue = { a: { aa: 1, ab: 2 }, b: null };
+      const p_a_aa = encodeURIComponent('p[a][aa]');
+      const p_a_ab = encodeURIComponent('p[a][ab]');
+      const expected = `/path?${p_a_aa}=1&${p_a_ab}=2`;
       assertRight(
         createExamplePath({
           id: '123',
@@ -239,13 +243,13 @@ describe('createExamplePath()', () => {
                 id: faker.random.word(),
                 name: 'p',
                 style: HttpParamStyles.DeepObject,
-                examples: [{ id: faker.random.word(), key: 'foo', value: { a: { aa: 1, ab: 2 }, b: null } }],
+                examples: [{ id: faker.random.word(), key: 'foo', value: exampleValue }],
               },
             ],
           },
           responses: [{ id: faker.random.word(), code: '200' }],
         }),
-        r => expect(r).toEqual('/path?p%5Ba%5D%5Baa%5D=1&p%5Ba%5D%5Bab%5D=2')
+        r => expect(r).toEqual(expected)
       );
     });
 

--- a/packages/http/src/mocker/serializer/style/__tests__/deepObject.spec.ts
+++ b/packages/http/src/mocker/serializer/style/__tests__/deepObject.spec.ts
@@ -17,6 +17,10 @@ describe('serializeWithDeepObjectStyle()', () => {
     expect(serializeWithDeepObjectStyle('a', { aa: { aaa: { aaaa: '1' } } })).toEqual('a[aa][aaa][aaaa]=1');
   });
 
+  it('handles null objects', () => {
+    expect(serializeWithDeepObjectStyle('a', { aa: null })).toEqual(null);
+  });
+
   it('handles mixed objects and arrays', () => {
     expect(serializeWithDeepObjectStyle('a', { aa: { aaa: [{ aaaa: '1' }, { aaaa: '2' }] } })).toEqual(
       'a[aa][aaa][][aaaa]=1&a[aa][aaa][][aaaa]=2'

--- a/packages/http/src/mocker/serializer/style/deepObject.ts
+++ b/packages/http/src/mocker/serializer/style/deepObject.ts
@@ -1,14 +1,19 @@
 import { Dictionary } from '@stoplight/types';
 
-export function serializeWithDeepObjectStyle(name: string, value: string | string[] | Dictionary<unknown>) {
+export function serializeWithDeepObjectStyle(name: string, value: string | string[] | Dictionary<unknown> | null) {
   return serialize(name, [], value);
 }
 
-function serialize(name: string, path: string[], value: string | string[] | Dictionary<unknown>): string {
-  if (typeof value === 'object') {
-    return Object.keys(value)
+function serialize(name: string, path: string[], value: string | string[] | Dictionary<unknown> | null): string | null {
+  if (value === null) {
+    return null;
+  } else if (typeof value === 'object') {
+    const result = Object.keys(value)
       .map(key => serialize(name, [...path, isPositiveInteger(key) ? '' : key], value[key]))
+      .filter(key => key !== null)
       .join('&');
+
+    return result.length > 0 ? result : null;
   } else {
     return `${name}${path.map(key => `[${key}]`).join('')}=${value}`;
   }


### PR DESCRIPTION
Addresses #2058 

**Summary**

Allow nullable properties inside a [`deepObject` styled](https://swagger.io/docs/specification/serialization/#query) object.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [x] I reported errors and followed the error reporting guidelines
  - [ ] N/A
