### PR TITLE
Support for wildcard mimetypes in mock response

### DIFF
--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -304,6 +304,13 @@ describe('HttpValidator', () => {
                   type: 'string',
                 },
               },
+              {
+                id: faker.random.word(),
+                mediaType: 'image/*',
+                schema: {
+                  type: 'string',
+                }
+              }
             ],
           },
         ],
@@ -320,7 +327,7 @@ describe('HttpValidator', () => {
               expect(error).toEqual([
                 {
                   message:
-                    'The received media type "application/xml" does not match the one specified in the current response: application/json',
+                    'The received media type "application/xml" does not match the ones specified in the current response: application/json, image/*',
                   severity: DiagnosticSeverity.Error,
                 },
               ])
@@ -329,7 +336,7 @@ describe('HttpValidator', () => {
       });
 
       describe('when the response has a content type declared in the spec', () => {
-        it('returns an error', () => {
+        it('returns success', () => {
           assertRight(
             validator.validateOutput({
               resource,
@@ -338,6 +345,17 @@ describe('HttpValidator', () => {
           );
         });
       });
+
+      describe('when the response matches a wildcard content type declared in the spec', () => {
+        it('returns success', () => {
+          assertRight(
+            validator.validateOutput({
+              resource,
+              element: { statusCode: 200, headers: { 'content-type': 'image/png' } },
+            })
+          );
+        });
+      })
     });
   });
 });

--- a/packages/http/src/validator/utils/__tests__/wildcardMediaTypeMatch.spec.ts
+++ b/packages/http/src/validator/utils/__tests__/wildcardMediaTypeMatch.spec.ts
@@ -21,6 +21,15 @@ describe('wildcardMediaTypeMatch', () => {
     ])('ignores parameters: %s - %s', (a, b) => {
       expect(wildcardMediaTypeMatch(a, b)).toBe(true);
     });
+
+    it.each([
+      ['text/html', '*/html'],
+      ['text/html', 'text/*'],
+      ['text/html', '*/*'],
+      ['application/x-custom+json', '*/*+json'],
+    ])('with wildcards: %s - %s', (a, b) => {
+      expect(wildcardMediaTypeMatch(a, b)).toBe(true);
+    });
   });
 
   describe('does not match', () => {

--- a/packages/http/src/validator/utils/wildcardMediaTypeMatch.ts
+++ b/packages/http/src/validator/utils/wildcardMediaTypeMatch.ts
@@ -10,7 +10,7 @@ export function wildcardMediaTypeMatch(mediaTypeA: string, mediaTypeB: string) {
     O.fold(
       () => false,
       ({ a, b }) => {
-        return a.type === b.type && a.subtype === b.subtype;
+        return (a.type === b.type || b.type === '*') && (a.subtype === b.subtype || b.subtype === '*');
       }
     )
   );


### PR DESCRIPTION
**Summary**

Adds support for wildcard mimetypes in response definitions. This is supported by the spec: https://spec.openapis.org/oas/v3.1.0#path-item-object-example

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [X] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
