### PR TITLE
Include support for NOT following redirects via a custom header

### DIFF
--- a/docs/getting-started/03-cli.md
+++ b/docs/getting-started/03-cli.md
@@ -90,6 +90,22 @@ curl -v http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=false"
 
 > **Remember:** you can combine `code`, `example` and `dynamic` parameters. By default, when the `code` parameter is not given, Prism will always try to fetch an example using the `exampleKey` from the 200 HTTP responses **only**. You'll need to use the `code` parameter alongside the `example` one for any specific example using a different HTTP status code than 200.
 
+#### Redirect Handling
+
+By default, Prism will follow all redirects (3XX HTTP responses). In some cases, your API may be designed to return a
+specific redirect. If you are trying to validate a 3XX response, you can do so by disabling redirect following on a
+per-request basis.
+
+```bash
+curl -v http://127.0.0.1:4010/pets/123 -H "Follow-Redirects: false"
+
+HTTP/1.1 302 Found
+content-length: 0
+Date: Thu, 09 May 2019 15:26:07 GMT
+Connection: keep-alive
+Location: http://127.0.0.1:4010/v1/pets/123
+```
+
 #### Circular references
 
 Even though Prism is technically able to internally handle circular references, the CLI will refuse to mock the provided document in case any circular reference is detected. This is essentially because serialising a circular reference is difficult and very dependant on the content type.

--- a/packages/http/src/forwarder/__tests__/index.spec.ts
+++ b/packages/http/src/forwarder/__tests__/index.spec.ts
@@ -137,6 +137,47 @@ describe('forward', () => {
     });
   });
 
+  describe('redirects are handled properly', () => {
+    it('defaults to follow', () => {
+      return assertResolvesRight(
+        forward(
+          { validations: [], data: { method: 'get', url: { path: '/test' } } },
+          'http://example.com',
+          undefined
+        )(logger),
+        () => {
+          expect(fetch).toHaveBeenCalledWith(
+            'http://example.com/test',
+            expect.objectContaining({ method: 'get', redirect: 'follow' })
+          );
+        }
+      );
+    });
+
+    it('configurable to NOT follow', () => {
+      return assertResolvesRight(
+        forward(
+          {
+            validations: [],
+            data: { method: 'get', url: { path: '/test' }, headers: { 'follow-redirects': 'false' } },
+          },
+          'http://example.com',
+          undefined
+        )(logger),
+        () => {
+          expect(fetch).toHaveBeenCalledWith(
+            'http://example.com/test',
+            expect.objectContaining({
+              method: 'get',
+              redirect: 'manual',
+              headers: expect.not.objectContaining({ 'follow-redirects': 'false' }),
+            })
+          );
+        }
+      );
+    });
+  });
+
   describe('and there are input validation errors', () => {
     it('will refuse to forward and return an error', () =>
       assertResolvesLeft(

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -62,11 +62,18 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
                 : createHttpProxyAgent(upstreamProxy);
           }
 
+          // Default behavior is to follow redirects
+          let redirect: RequestRedirect = 'follow';
+          if (input.headers !== undefined && input.headers['follow-redirects'] === 'false') {
+            redirect = 'manual';
+          }
+
           return fetch(url, {
             agent: proxyAgent,
             body,
             method: input.method,
-            headers: defaults(omit(input.headers, ['host']), {
+            redirect,
+            headers: defaults(omit(input.headers, ['host', 'follow-redirects']), {
               'accept-encoding': '*',
               accept: 'application/json, text/plain, */*',
               'user-agent': `Prism/${prismVersion}`,


### PR DESCRIPTION
Addresses #1977 

**Summary**

This adds a new custom header `Follow-Redirects` to the Prism proxy. If unspecified, Prism will continue following its current behavior of following redirects and returning the final response. If specified as `"false"`, Prism will pass `redirect: "manual"` to the fetch call, indicating that 3XX responses should be returned intact.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A
