### PR TITLE
Add the ability to disable sl-violations header

### DIFF
--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -36,6 +36,12 @@ const proxyCommand: CommandModule = {
             'If an http proxy is required to reach upstream, formatted as "{protocol}://[{user}[:{password}]@]{host}[:{port}]". eg "http://myUser:myPassword@proxy.example.com:1234"',
           string: true,
         },
+        'error-header': {
+          description:
+            'Apply "sl-violations" header to response detailing errors.',
+          boolean: true,
+          default: true,
+        },
       }),
   handler: parsedArgs => {
     parsedArgs.validateRequest = parsedArgs['validate-request'];
@@ -50,7 +56,8 @@ const proxyCommand: CommandModule = {
       'upstream',
       'errors',
       'validateRequest',
-      'upstreamProxy'
+      'upstreamProxy',
+      'errorHeader',
     );
 
     const createPrism = p.multiprocess ? createMultiProcessPrism : createSingleProcessPrism;

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -89,6 +89,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
         upstream: options.upstream,
         errors: options.errors,
         upstreamProxy: options.upstreamProxy,
+        errorHeader: options.errorHeader,
       }
     : { ...shared, mock: { dynamic: options.dynamic }, errors: options.errors };
 
@@ -151,6 +152,7 @@ export interface CreateProxyServerOptions extends CreateBaseServerOptions {
   upstream: URL;
   validateRequest: boolean;
   upstreamProxy: string | undefined;
+  errorHeader: boolean;
 }
 
 export type CreateMockServerOptions = CreateBaseServerOptions;

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -79,6 +79,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     validateResponse: true,
     checkSecurity: true,
     errors: false,
+    errorHeader: true,
     upstreamProxy: undefined,
   };
 

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -24,7 +24,7 @@ describe('validation', () => {
   };
 
   const prismInstance = factory<string, string, string, IPrismConfig>(
-    { mock: { dynamic: false }, validateRequest: false, validateResponse: false, checkSecurity: true, errors: false, upstreamProxy: undefined },
+    { mock: { dynamic: false }, validateRequest: false, validateResponse: false, checkSecurity: true, errors: false, errorHeader: true, upstreamProxy: undefined },
     components
   );
 
@@ -37,6 +37,7 @@ describe('validation', () => {
         const obj: IPrismConfig = {
           checkSecurity: true,
           errors: true,
+          errorHeader: true,
           validateRequest: false,
           validateResponse: false,
           mock: {},

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -77,6 +77,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
         },
         config.upstream.href,
         config.upstreamProxy,
+        config.errorHeader,
         resource
       );
 
@@ -113,7 +114,8 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
                 components.forward(
                   { data: input, validations: [] },
                   config.upstream.href,
-                  config.upstreamProxy
+                  config.upstreamProxy,
+                  config.errorHeader
                 )(components.logger.child({ name: 'PROXY' })),
                 TE.map(createWarningOutput)
               );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,6 +20,7 @@ type IPrismBaseConfig = {
   validateResponse: boolean;
   errors: boolean;
   upstreamProxy: string | undefined;
+  errorHeader: boolean;
 };
 
 export type IPrismMockConfig = IPrismBaseConfig & {
@@ -42,6 +43,7 @@ export type IPrismComponents<Resource, Input, Output, Config extends IPrismConfi
     input: IPrismInput<Input>,
     baseUrl: string,
     upstreamProxy: Config['upstreamProxy'],
+    errorHeader: boolean,
     resource?: Resource
   ) => ReaderTaskEither<Logger, Error, Output>;
   mock: (opts: {

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -17,6 +17,7 @@ async function instantiatePrism(operations: IHttpOperation[]) {
       validateResponse: true,
       mock: { dynamic: false },
       errors: false,
+      errorHeader: true,
       upstreamProxy: undefined,
     },
   });

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -31,6 +31,7 @@ async function instantiatePrism(specPath: string, configOverride?: Partial<IHttp
         validateRequest: true,
         validateResponse: true,
         errors: false,
+        errorHeader: true,
         mock: { dynamic: false },
         upstreamProxy: undefined,
       },

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -101,7 +101,9 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         const inputOutputValidationErrors = inputValidationErrors.concat(outputValidationErrors);
 
         if (inputOutputValidationErrors.length > 0) {
-          reply.setHeader('sl-violations', JSON.stringify(inputOutputValidationErrors));
+          if (opts.config.errorHeader) {
+            reply.setHeader('sl-violations', JSON.stringify(inputOutputValidationErrors));
+          }
 
           const errorViolations = outputValidationErrors.filter(
             v => v.severity === DiagnosticSeverity[DiagnosticSeverity.Error]

--- a/packages/http/src/__tests__/client.spec.ts
+++ b/packages/http/src/__tests__/client.spec.ts
@@ -12,6 +12,7 @@ describe('User Http Client', () => {
         validateRequest: true,
         validateResponse: true,
         errors: false,
+        errorHeader: true,
         checkSecurity: true,
         upstreamProxy: undefined,
       };

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -63,6 +63,7 @@ describe('Http Client .request', () => {
           validateResponse: true,
           mock: { dynamic: false },
           errors: false,
+          errorHeader: true,
           upstreamProxy: undefined,
         },
         { logger }
@@ -163,6 +164,7 @@ describe('Http Client .request', () => {
           validateRequest: true,
           validateResponse: true,
           errors,
+          errorHeader: true,
           upstream: new URL(baseUrl),
           upstreamProxy: undefined,
         };
@@ -194,6 +196,7 @@ describe('Http Client .request', () => {
           validateRequest: true,
           validateResponse: true,
           errors: false,
+          errorHeader: true,
           upstream: new URL(baseUrl),
           upstreamProxy: undefined,
         };
@@ -234,6 +237,7 @@ describe('Http Client .request', () => {
           validateResponse: true,
           mock: { dynamic: false },
           errors: false,
+          errorHeader: true,
           upstreamProxy: undefined,
         },
         { logger }
@@ -364,6 +368,7 @@ describe('Http Client .request', () => {
         validateRequest: true,
         validateResponse: true,
         errors: false,
+        errorHeader: true,
         upstreamProxy: undefined,
       },
       { logger }
@@ -407,6 +412,7 @@ describe('proxy server', () => {
           validateResponse: true,
           upstream: new URL(baseUrl),
           errors: false,
+          errorHeader: true,
           upstreamProxy: undefined,
         },
         { logger }

--- a/packages/http/src/__tests__/memory-leak-prevention.spec.ts
+++ b/packages/http/src/__tests__/memory-leak-prevention.spec.ts
@@ -21,6 +21,7 @@ describe('Checks if memory leaks', () => {
       validateResponse: true,
       checkSecurity: true,
       errors: true,
+      errorHeader: true,
       mock: {
         dynamic: false,
       },

--- a/packages/http/src/forwarder/__tests__/index.spec.ts
+++ b/packages/http/src/forwarder/__tests__/index.spec.ts
@@ -46,7 +46,8 @@ describe('forward', () => {
             },
           },
           'http://example.com',
-          undefined
+          undefined,
+          true
         )(logger),
         () => {
           expect(fetch).toHaveBeenCalledWith(
@@ -78,7 +79,8 @@ describe('forward', () => {
             },
           },
           'http://example.com',
-          undefined
+          undefined,
+          true
         )(logger)
       );
     });
@@ -103,7 +105,8 @@ describe('forward', () => {
             },
           },
           'http://example.com',
-          undefined
+          undefined,
+          true
         )(logger),
         () => {
           expect(fetch).toHaveBeenCalledWith(
@@ -127,7 +130,8 @@ describe('forward', () => {
         forward(
           { validations: [], data: { method: 'get', url: { path: '/test' } } },
           'http://example.com',
-          undefined
+          undefined,
+          true
         )(logger),
         r =>
           hopByHopHeaders.forEach(hopHeader => {
@@ -149,7 +153,8 @@ describe('forward', () => {
             },
           },
           'http://example.com',
-          undefined
+          undefined,
+          true
         )(logger),
         e => expect(e).toHaveProperty('status', 422)
       ));
@@ -172,6 +177,7 @@ describe('forward', () => {
           },
           'http://example.com',
           undefined,
+          true,
           {
             deprecated: true,
             method: 'post',
@@ -198,6 +204,7 @@ describe('forward', () => {
           },
           'http://example.com',
           undefined,
+          true,
           {
             deprecated: true,
             method: 'post',

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -28,6 +28,7 @@ const forward: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHt
     { data: input, validations }: IPrismInput<IHttpRequest>,
     baseUrl: string,
     upstreamProxy: IHttpConfig['upstreamProxy'],
+    errorHeader,
     resource
   ): RTE.ReaderTaskEither<Logger, Error, IHttpResponse> =>
   logger =>

--- a/test-harness/specs/proxy/proxy.validation.noHttpHeader.txt
+++ b/test-harness/specs/proxy/proxy.validation.noHttpHeader.txt
@@ -1,6 +1,5 @@
 ====test====
-Returns response violations as sl-violations header
-but won't touch the response body
+Does not return response violations as sl-violations header when provided with --error-header false
 ====spec====
 swagger: "2.0"
 paths:

--- a/test-harness/specs/proxy/proxy.validation.noHttpHeader.txt
+++ b/test-harness/specs/proxy/proxy.validation.noHttpHeader.txt
@@ -1,0 +1,35 @@
+====test====
+Returns response violations as sl-violations header
+but won't touch the response body
+====spec====
+swagger: "2.0"
+paths:
+  /json:
+    get:
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            required:
+              - title
+              - description
+            properties:
+              title:
+                type: string
+                example: Work
+              description:
+                type: string
+              priority:
+                type: number
+                default: 0
+====server====
+proxy -p 4010 ${document} http://httpbin.org --error-header false
+====command====
+curl -i http://localhost:4010/json
+====expect====
+HTTP/1.1 200 OK
+
+{"slideshow":{"author":"Yours Truly","date":"date of publication","slides":[{"title":"Wake up to WonderWidgets!","type":"all"},{"items":["Why <em>WonderWidgets</em> are great","Who <em>buys</em> WonderWidgets"],"title":"Overview","type":"all"}],"title":"Sample Slide Show"}}


### PR DESCRIPTION

**Summary**
When parsing CLI output in proxy mode to validate specifications the sl-violations header may not be required. In some cases where there is a significant delta between the specification and response this header can exceed size limitations and cause failures.


**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

