### PR TITLE
2138: Fix mock command regression

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+logs
+coverage
+cli-binaries

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^27.0.2",
     "@types/json-schema": "^7.0.9",
     "@types/lodash": "^4.14.175",
-    "@types/node": "^18.7.10",
+    "@types/node": "^13.1.1",
     "@types/node-fetch": "2.5.10",
     "@types/pino": "6.3.8",
     "@types/postman-collection": "^3.5.7",

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@stoplight/prism-core';
 import { IHttpConfig, IHttpRequest } from '@stoplight/prism-http';
 import { createServer as createHttpServer } from '@stoplight/prism-http-server';
 import * as chalk from 'chalk';
-import cluster from 'node:cluster';
+import * as cluster from 'cluster';
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import { LogDescriptor, Logger, LoggerOptions } from 'pino';
@@ -46,7 +46,7 @@ const createMultiProcessPrism: CreatePrism = async options => {
 
     return createPrismServerWithLogger(options, logInstance).catch((e: Error) => {
       logInstance.fatal(e.message);
-      cluster.worker?.kill();
+      cluster.worker.kill();
       throw e;
     });
   }

--- a/packages/http/src/__tests__/memory-leak-prevention.spec.ts
+++ b/packages/http/src/__tests__/memory-leak-prevention.spec.ts
@@ -33,14 +33,12 @@ describe('Checks if memory leaks', () => {
 
     for (let i = 0; i < 5000; i++) {
       round(client);
-      if (i % 100 === 0 && global.gc) {
+      if (i % 100 === 0) {
         global.gc();
       }
     }
 
-    if (global.gc) {
-      global.gc();
-    }
+    global.gc();
     expect(process.memoryUsage().heapUsed).toBeLessThanOrEqual(baseMemoryUsage * 1.03);
   });
 });

--- a/test-harness/specs/multi-process-mode/smoke-test.oas3.text
+++ b/test-harness/specs/multi-process-mode/smoke-test.oas3.text
@@ -1,0 +1,15 @@
+====test====
+Prism mocking works with multi-process mode
+====spec====
+openapi: 3.0.2
+paths:
+  /pets:
+    get:
+      responses:
+        204: {}
+====server====
+mock -p 4010 ${document} -m
+====command====
+curl -i http://localhost:4010/pets
+====expect====
+HTTP/1.1 204 No Content

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,10 +2246,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^18.7.10":
-  version "18.7.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.10.tgz#f642dc9ded1bdd8c2cd847246466e71182b0fd67"
-  integrity sha512-SST7B//wF7xlGoLo1IEVB0cQ4e7BgXlDk5IaPgb5s0DlYLjb4if07h8+0zbQIvahfPNXs6e7zyT0EH1MqaS+5g==
+"@types/node@*", "@types/node@^13.1.1":
+  version "13.13.52"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
+  integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Addresses #2138

**Summary**

This fixes the mock command regression introduced in 4.10.4 by reverting [this commit ](https://github.com/stoplightio/prism/pull/2119/commits/f6c4e9f6929f65f40a7c8d1f35dc0c3ca691b80c).  The reason these breaking code changes were made was partly due to an issue with the type definitions for the core node cluster module.  See [this issue](https://github.com/stoplightio/prism/pull/2119/commits/f6c4e9f6929f65f40a7c8d1f35dc0c3ca691b80c).  I've added an .eslintignore as well because the lint errors were distracting when scanning the build output.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Additional context**

Node 16.17 is in LTS as of today, and I'm not sure we should bump to 18 yet.  @types/node generally should line up with the version of node we are on.  However due to the issue linked above I've left those @13.1 as before.
