### PR TITLE
Release 4.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to Semantic Versioning.
 
+# 4.10.5 (2022.10.05)
+
+## Fixed
+
+- Fixed breaking change with mock command in v4.10.4. [#2138](https://github.com/stoplightio/prism/issues/2138)
+
 # 4.10.4 (2022.09.14)
 
 ## Changed

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,6 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "4.10.4",
+  "version": "4.10.5",
   "independent": false
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
@@ -10,9 +10,9 @@
     "@stoplight/http-spec": "^5.5.2",
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-ref-parser": "9.2.1",
-    "@stoplight/prism-core": "^4.10.4",
-    "@stoplight/prism-http": "^4.10.4",
-    "@stoplight/prism-http-server": "^4.10.4",
+    "@stoplight/prism-core": "^4.10.5",
+    "@stoplight/prism-http": "^4.10.5",
+    "@stoplight/prism-http-server": "^4.10.5",
     "@stoplight/types": "^13.6.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^4.10.4",
-    "@stoplight/prism-http": "^4.10.4",
+    "@stoplight/prism-core": "^4.10.5",
+    "@stoplight/prism-http": "^4.10.5",
     "@stoplight/types": "^13.0.0",
     "fast-xml-parser": "^3.20.3",
     "fp-ts": "^2.11.5",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "4.10.4",
+  "version": "4.10.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-merge-allof": "0.7.8",
     "@stoplight/json-schema-sampler": "0.2.2",
-    "@stoplight/prism-core": "^4.10.4",
+    "@stoplight/prism-core": "^4.10.5",
     "@stoplight/types": "^13.0.0",
     "@stoplight/yaml": "^4.2.3",
     "abstract-logging": "^2.0.1",


### PR DESCRIPTION
Addresses #[2138]

**Summary**
Releases PR [#2143](https://github.com/stoplightio/prism/pull/2143).

This fixes the mock command regression introduced in 4.10.4 by reverting [this commit ](https://github.com/stoplightio/prism/pull/2119/commits/f6c4e9f6929f65f40a7c8d1f35dc0c3ca691b80c). The reason these breaking code changes were made was partly due to an issue with the type definitions for the core node cluster module. See [this issue](https://github.com/stoplightio/prism/pull/2119/commits/f6c4e9f6929f65f40a7c8d1f35dc0c3ca691b80c).

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
