### PR TITLE
Send a User-Agent when fetching remote spec content

### DIFF
--- a/packages/cli/src/operations.ts
+++ b/packages/cli/src/operations.ts
@@ -14,7 +14,7 @@ export async function getHttpOperationsFromSpec(specFilePathOrObject: string | o
   const prismVersion = require('../package.json').version;
   const httpResolverOpts: HTTPResolverOptions = {
     headers: {
-      'User-Agent': `Prism Mock Server v${prismVersion} (${os.type()} ${os.arch()} ${os.release()})`,
+      'User-Agent': `PrismMockServer/${prismVersion} (${os.type()} ${os.arch()} ${os.release()})`,
     },
   };
   const result = decycle(await dereference(specFilePathOrObject, { resolve: { http: httpResolverOpts } }));

--- a/packages/cli/src/operations.ts
+++ b/packages/cli/src/operations.ts
@@ -1,16 +1,23 @@
 import { transformOas3Operations } from '@stoplight/http-spec/oas3/operation';
 import { transformOas2Operations } from '@stoplight/http-spec/oas2/operation';
 import { transformPostmanCollectionOperations } from '@stoplight/http-spec/postman/operation';
-import { dereference } from '@stoplight/json-schema-ref-parser';
+import { dereference, HTTPResolverOptions } from '@stoplight/json-schema-ref-parser';
 import { bundleTarget, decycle } from '@stoplight/json';
 import { IHttpOperation } from '@stoplight/types';
 import { get } from 'lodash';
+import * as os from 'os';
 import type { Spec } from 'swagger-schema-official';
 import type { OpenAPIObject } from 'openapi3-ts';
 import type { CollectionDefinition } from 'postman-collection';
 
 export async function getHttpOperationsFromSpec(specFilePathOrObject: string | object): Promise<IHttpOperation[]> {
-  const result = decycle(await dereference(specFilePathOrObject));
+  const prismVersion = require('../package.json').version;
+  const httpResolverOpts: HTTPResolverOptions = {
+    headers: {
+      'User-Agent': `Prism Mock Server v${prismVersion} (${os.type()} ${os.arch()} ${os.release()})`,
+    },
+  };
+  const result = decycle(await dereference(specFilePathOrObject, { resolve: { http: httpResolverOpts } }));
 
   let operations: IHttpOperation[] = [];
   if (isOpenAPI2(result)) operations = transformOas2Operations(result);


### PR DESCRIPTION
Addresses #2092. Happy Hacktoberfest!

**Summary**

Introduces a User-Agent request header when resolving remote OAS specs or Postman collections by passing the appropriate options to [json-schema-ref-parser](https://github.com/stoplightio/json-schema-ref-parser).

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] Wasn't sure where or how to automate, but I'm happy to do so with a little guidance
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**
Screenshot of a simple server that dumps headers:
![image](https://user-images.githubusercontent.com/1878152/196480190-3bc61392-7bea-4983-88d8-dacbbed4e5f1.png)
