### PR TITLE
docs(repo): update dynamic response generation with Faker details

### DIFF
--- a/docs/guides/01-mocking.md
+++ b/docs/guides/01-mocking.md
@@ -4,12 +4,13 @@ Prism's HTTP mock server simulates a real web API by providing endpoints and val
 
 - Does the API contain the information the client needs?
 - Is that data in the format the client needs?
-- Are the resources too "normalized" and data-centric (instead of being use-case centric) that the client has to 3292375 calls to get all the data?
+- Are the resources too "normalized" and data-centric (instead of being use-case centric) that the client has to make 3292375 calls to get all the data they need?
 - Is there enough time left for feedback to be implemented?
-- If the feedback spawns large enough work, will the client have time implement this API once it's done?
-- Avoid these problems by getting a free API to play with without spending a month building it all.
+- If the feedback spawns large enough work, will the client have time to implement this API once it's done?
 
-Catching problems early on while you're still just tweaking the API descriptions (maybe using [Studio](https://stoplight.io/studio)), means you can avoid making costly changes to the production API, deprecating old things, or creating whole new global versions which add a huge workload to every single client.
+You can avoid these problems by getting a free API to play with without spending a month building it all.
+
+Catching problems early on while you're still just tweaking the API descriptions (maybe using [Stoplight Studio](https://stoplight.io/studio)), means you can avoid making costly changes to the production API, deprecating old things, or creating whole new global versions which add a huge workload to every single client.
 
 Just like HTTP messages, there are two halves to mocking: requests and responses.
 
@@ -93,9 +94,10 @@ class 1A,1B,1D,1E,1F,1G,1H,1I,1J,1M,,1O,1P,2A,2B,2C,2D,2E,2F,2G,2H,2I,2K,3A,3B,3
 class 1C,1K,1Q,2I,2J,2M,3H,3O Red
 class 1L,1N,1X,,2L,3E,3I,3N Green
 ```
+
 ### Response Examples
 
-If a response has an example, it will be used for the response. If there are multiple examples then they can be selected by name. In the following OpenAPI description, the operation has a 200 OK response and multiple examples:
+If a response has an example, it will be used for that response. If there are multiple examples, then they can be selected by name. In the following OpenAPI description, the operation has a 200 OK response and multiple examples:
 
 ```yaml
 responses:
@@ -157,7 +159,7 @@ prism mock api.oas3.yaml # Static examples
 prism mock -d api.oas3.yaml # Dynamic examples
 ```
 
-If the HTTP server has been started in static mode, specific calls can be made in dynamic mode by specifying the `Prefer` header with the `dynamic` key to `true`.
+If the HTTP server has been started in static mode, specific calls can be made in dynamic mode by specifying the `Prefer` header with the `dynamic` key set to `true`.
 
 #### Static Response Generation
 
@@ -189,7 +191,7 @@ Pet:
         type: string
 ```
 
-When you call `curl http://127.0.0.1:4010/pets/123`, the operation references this component and a doggie is returned:
+When you call `curl http://127.0.0.1:4010/pets/123`, the operation references this component and a `doggie` is returned:
 
 ```json
 {
@@ -199,7 +201,7 @@ When you call `curl http://127.0.0.1:4010/pets/123`, the operation references th
 }
 ```
 
-Notice that `name` had an `example` with a value so Prism used it, but `photoUrls` didn't, so it just returned `"string"`. 🤷‍♂️
+Notice that `name` had an `example` with a value so Prism used it, but `photoUrls` didn't, so it just returned `"string"`.
 
 #### Dynamic Response Generation
 
@@ -272,10 +274,7 @@ example:
 
 ##### Configure JSON Schema Faker
 
-At the top level of your API Specification, create an `x-json-schema-faker`
-member containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An
-additional `locale` option is accepted to configure the `locale` of the
-underlying Faker instance.
+At the top level of your API Specification, create an `x-json-schema-faker` member containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An additional `locale` option is accepted to configure the `locale` of the underlying Faker instance.
 
 ```yaml
 openapi: 3.1.0
@@ -289,11 +288,7 @@ x-json-schema-faker:
 
 ## Request Validation
 
-Having a mock server that only gives responses would not be useful, which is why
-Prism imitates request validation too. An OpenAPI description document is
-full of validation rules like type, format, max length, etc. Prism can
-validate incoming messages and provide validation feedback if it receives invalid
-requests.
+Having a mock server that only gives responses would not be useful, which is why Prism imitates request validation too. An OpenAPI description document is full of validation rules like type, format, max length, etc. Prism can validate incoming messages and provide validation feedback if it receives invalid requests.
 
 Read more about this in the [Prism Request Validation guide](./02-request-validation.md).
 

--- a/docs/guides/01-mocking.md
+++ b/docs/guides/01-mocking.md
@@ -209,7 +209,9 @@ Testing against the exact same piece of data over and over again isn't the best 
 
 Dynamic mode solves this by generating a random value for all the properties according to their type, and other information like `format` or even the all-powerful `x-faker` extension.
 
-All the random properties are generated using [Faker.js](https://github.com/faker-js/faker) under the hood, via [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker). The `x-faker` keyword is optional, but when present allows for a specific Faker API method to be used (of which there [are a lot](https://github.com/faker-js/faker#api)) so you get a lot of control over the response.
+All the random properties are generated using [Faker.js](https://github.com/faker-js/faker). You can pass in the `x-faker` keyword to a property, which allows for a specific Faker API method to be used so you get a lot of control over the response.
+
+If a user passes a method that doesn't exist, Prism falls back to [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker) to generate random values for that property.
 
 ```yaml
 Pet:
@@ -229,7 +231,7 @@ Pet:
         x-faker: image.imageUrl
 ```
 
-Making the call `curl http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=true"`, the operation references this component and a doggie is returned:
+Making the call `curl http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=true"`, the operation references this component and a doggie is returned with random values for `name` and `photoUrls`:
 
 ```json
 {
@@ -246,13 +248,24 @@ Making the call `curl http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=true"`,
 
 The more descriptive your description is, the better job Prism can do at creating a mock response.
 
-<!-- theme: info -->
+For a list of supported methods, you can check [Faker's documentation portal](https://v6.fakerjs.dev/api/address.html).
 
+It's important to note that Faker's version, and how you're using Prism, can have an impact on the behavior you might see. The current version of Faker that Prism is using is set to `^6.0.0`, and can be found in Prism's [package.json file](https://github.com/stoplightio/prism/blob/master/packages/http/package.json#L19). That means that any version between v6.0.0 and v6.3.1 is valid for running Prism. If a user has a local version of Faker installed that's v6.0.0, while another user has v6.3.1 installed, when running the same OpenAPI description through Prism they might see different responses.
+
+You can check which version of Faker you have installed locally by running the following command and looking for `@faker-js/faker`:
+
+```bash
+yarn list --depth 0
+```
+
+It's also worth noting that JSON Schema Faker also uses its [own version of the Faker library](https://github.com/Shinigami92/json-schema-faker/blob/master/package.json#L87), so the behavior you might see from the fallback methods will also be affected by it.
+
+<!-- theme: info -->
 > **Tip:** If your team needs help creating better quality API description documents, take a look at [Spectral](https://stoplight.io/spectral/). You could enforce the use of `example` properties, or similar.
 
 ##### Control Generated Fakes for Individual Properties
 
-In the following example there are two properties, each with specific Faker parameters.  [datatype.number](https://fakerjs.dev/api/datatype.html#number) uses named parameters while [helpers.slugify](https://fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
+In the following example there are two properties, each with specific Faker parameters. [datatype.number](https://v6.fakerjs.dev/api/datatype.html#number) uses named parameters while [helpers.slugify](https://v6.fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
 
 ```yaml
 example:
@@ -272,9 +285,68 @@ example:
         helpers.slugify: [ "two words" ]
 ```
 
+Pay close attention to the Faker docs when configuring any methods you pass in to the `x-faker` property. Some methods, such as `datatype.number`, will take in named options parameters:
+
+```yaml
+x-faker:
+  datatype.number:
+    min: 10
+    max: 11
+```
+
+While other methods, such as `finance.amount`, will take in an array:
+
+```yaml
+finance.amount:
+  - 100
+  - 10000
+  - 2
+  - '$'
+```
+
+If you're working with [dates](https://v6.fakerjs.dev/api/date.html), they're not a supported JSON Schema type, so JSON Schema Faker will return them as a string. For example, for this object:
+
+```yaml
+due_date:
+  type: string
+  x-faker: date.past
+```
+
+The output is:
+
+```json
+"due_date": "Tue Sep 14 2021 05:34:08 GMT-0500 (Central Daylight Time)",
+```
+
+If you'd like to change the date string format, you can pass in `format` property in the schema. For example:
+
+```yaml
+due_date:
+  type: string
+  x-faker: date.past
+  format: "date-time"
+```
+
+And the output will be:
+
+```json
+"due_date": "2021-11-18T00:00:00.0Z",
+```
+
 ##### Configure JSON Schema Faker
 
-At the top level of your API Specification, create an `x-json-schema-faker` member containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An additional `locale` option is accepted to configure the `locale` of the underlying Faker instance.
+JSON Schema Faker has a set of [default configuration options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options). Prism has a [few options](https://github.com/stoplightio/prism/blob/master/packages/http/src/mocker/generator/JSONSchema.ts#L51) that are set to different values than the default configuration options, namely:
+
+```js
+failOnInvalidTypes: false, // if enabled, it will throw an Error for unknown types
+failOnInvalidFormat: false, // if enabled, it will throw an Error for unknown formats
+alwaysFakeOptionals: true, //  when enabled, it will set optionalsProbability: 1.0 and fixedProbabilities: true
+optionalsProbability: 1, // a value from 0.0 to 1.0 to generate values in a consistent way, e.g. 0.5 will generate from 0% to 50% of values. Using arrays it means items, on objects they're properties, etc.
+fixedProbabilities: true, // if enabled, then optionalsProbability: 0.5 will always generate the half of values
+ignoreMissingRefs: true, // if enabled, it will resolve to {} for unknown references
+```
+
+At the top level of your API Specification, you can create an `x-json-schema-faker` object containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An additional `locale` option is accepted to configure the `locale` of the underlying Faker instance.
 
 ```yaml
 openapi: 3.1.0

--- a/docs/guides/01-mocking.md
+++ b/docs/guides/01-mocking.md
@@ -135,12 +135,6 @@ Calling `curl http://127.0.0.1:4010/pets/123` on this will give:
 
 Calling the same URL with the `Prefer` header `example=dog` `http://127.0.0.1:4010/pets/123` will yield to:
 
-<!-- theme: info -->
-
-> #### Remember to provide expected response code
->
-> It's always worth indicating the HTTP response code from which `example` should be taken. If Prism decides to change the response code due to validation or security violations, your `example` might be ignored.
-
 ```json
 {
   "id": 1,
@@ -148,6 +142,12 @@ Calling the same URL with the `Prefer` header `example=dog` `http://127.0.0.1:40
   "photoUrls": ["https://images.dog.ceo/breeds/kelpie/n02105412_893.jpg"]
 }
 ```
+
+<!-- theme: info -->
+
+> #### Remember to provide an expected response code
+>
+> It's always worth indicating the HTTP response code from which `example` should be taken. If Prism decides to change the response code due to validation or security violations, your `example` might be ignored.
 
 ### Static or Dynamic Generation
 
@@ -207,156 +207,9 @@ Notice that `name` had an `example` with a value so Prism used it, but `photoUrl
 
 Testing against the exact same piece of data over and over again isn't the best way to build a robust integration. What happens when a name is longer than you expected, or the value happens to be 0 instead of 6?
 
-Dynamic mode solves this by generating a random value for all the properties according to their type, and other information like `format` or even the all-powerful `x-faker` extension.
+Dynamic mode solves this by generating a random value for all the properties according to their type, and other information like `format` or even by using the Faker library.
 
-All the random properties are generated using [Faker.js](https://github.com/faker-js/faker). You can pass in the `x-faker` keyword to a property, which allows for a specific Faker API method to be used so you get a lot of control over the response.
-
-If a user passes a method that doesn't exist, Prism falls back to [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker) to generate random values for that property.
-
-```yaml
-Pet:
-  type: object
-  properties:
-    id:
-      type: integer
-      format: int64
-    name:
-      type: string
-      x-faker: name.firstName
-      example: doggie
-    photoUrls:
-      type: array
-      items:
-        type: string
-        x-faker: image.imageUrl
-```
-
-Making the call `curl http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=true"`, the operation references this component and a doggie is returned with random values for `name` and `photoUrls`:
-
-```json
-{
-  "id": 12608726,
-  "name": "Addison",
-  "photoUrls": [
-    "http://lorempixel.com/640/480",
-    "http://lorempixel.com/640/480",
-    "http://lorempixel.com/640/480",
-    "http://lorempixel.com/640/480"
-  ]
-}
-```
-
-The more descriptive your description is, the better job Prism can do at creating a mock response.
-
-For a list of supported methods, you can check [Faker's documentation portal](https://v6.fakerjs.dev/api/address.html).
-
-It's important to note that Faker's version, and how you're using Prism, can have an impact on the behavior you might see. The current version of Faker that Prism is using is set to `^6.0.0`, and can be found in Prism's [package.json file](https://github.com/stoplightio/prism/blob/master/packages/http/package.json#L19). That means that any version between v6.0.0 and v6.3.1 is valid for running Prism. If a user has a local version of Faker installed that's v6.0.0, while another user has v6.3.1 installed, when running the same OpenAPI description through Prism they might see different responses.
-
-You can check which version of Faker you have installed locally by running the following command and looking for `@faker-js/faker`:
-
-```bash
-yarn list --depth 0
-```
-
-It's also worth noting that JSON Schema Faker also uses its [own version of the Faker library](https://github.com/Shinigami92/json-schema-faker/blob/master/package.json#L87), so the behavior you might see from the fallback methods will also be affected by it.
-
-<!-- theme: info -->
-> **Tip:** If your team needs help creating better quality API description documents, take a look at [Spectral](https://stoplight.io/spectral/). You could enforce the use of `example` properties, or similar.
-
-##### Control Generated Fakes for Individual Properties
-
-In the following example there are two properties, each with specific Faker parameters. [datatype.number](https://v6.fakerjs.dev/api/datatype.html#number) uses named parameters while [helpers.slugify](https://v6.fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
-
-```yaml
-example:
-  type: object
-  properties:
-    ten-or-eleven:
-      type: number
-      example: 10
-      x-faker:
-        datatype.number:
-          min: 10
-          max: 11
-    slug:
-      type: string
-      example: two-words
-      x-faker:
-        helpers.slugify: [ "two words" ]
-```
-
-Pay close attention to the Faker docs when configuring any methods you pass in to the `x-faker` property. Some methods, such as `datatype.number`, will take in named options parameters:
-
-```yaml
-x-faker:
-  datatype.number:
-    min: 10
-    max: 11
-```
-
-While other methods, such as `finance.amount`, will take in an array:
-
-```yaml
-finance.amount:
-  - 100
-  - 10000
-  - 2
-  - '$'
-```
-
-If you're working with [dates](https://v6.fakerjs.dev/api/date.html), they're not a supported JSON Schema type, so JSON Schema Faker will return them as a string. For example, for this object:
-
-```yaml
-due_date:
-  type: string
-  x-faker: date.past
-```
-
-The output is:
-
-```json
-"due_date": "Tue Sep 14 2021 05:34:08 GMT-0500 (Central Daylight Time)",
-```
-
-If you'd like to change the date string format, you can pass in `format` property in the schema. For example:
-
-```yaml
-due_date:
-  type: string
-  x-faker: date.past
-  format: "date-time"
-```
-
-And the output will be:
-
-```json
-"due_date": "2021-11-18T00:00:00.0Z",
-```
-
-##### Configure JSON Schema Faker
-
-JSON Schema Faker has a set of [default configuration options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options). Prism has a [few options](https://github.com/stoplightio/prism/blob/master/packages/http/src/mocker/generator/JSONSchema.ts#L51) that are set to different values than the default configuration options, namely:
-
-```js
-failOnInvalidTypes: false, // if enabled, it will throw an Error for unknown types
-failOnInvalidFormat: false, // if enabled, it will throw an Error for unknown formats
-alwaysFakeOptionals: true, //  when enabled, it will set optionalsProbability: 1.0 and fixedProbabilities: true
-optionalsProbability: 1, // a value from 0.0 to 1.0 to generate values in a consistent way, e.g. 0.5 will generate from 0% to 50% of values. Using arrays it means items, on objects they're properties, etc.
-fixedProbabilities: true, // if enabled, then optionalsProbability: 0.5 will always generate the half of values
-ignoreMissingRefs: true, // if enabled, it will resolve to {} for unknown references
-```
-
-At the top level of your API Specification, you can create an `x-json-schema-faker` object containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An additional `locale` option is accepted to configure the `locale` of the underlying Faker instance.
-
-```yaml
-openapi: 3.1.0
-
-x-json-schema-faker:
-  locale: de
-  min-items: 2
-  max-items: 10
-  resolve-json-path: true
-```
+Read more about how to use Faker in [Dynamic Response with Faker](./11-dynamic-response-with-faker.md).
 
 ## Request Validation
 

--- a/docs/guides/11-dynamic-response-with-faker.md
+++ b/docs/guides/11-dynamic-response-with-faker.md
@@ -1,0 +1,150 @@
+# Dynamic Response Generation with Faker
+
+All the random properties are generated using [Faker.js](https://github.com/faker-js/faker). You can pass in the `x-faker` keyword to a property, which allows for a specific Faker API method to be used so you get a lot of control over the response.
+
+If a user passes a method that doesn't exist, Prism falls back to [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker) to generate random values for that property.
+
+```yaml
+Pet:
+  type: object
+  properties:
+    id:
+      type: integer
+      format: int64
+    name:
+      type: string
+      x-faker: name.firstName
+      example: doggie
+    photoUrls:
+      type: array
+      items:
+        type: string
+        x-faker: image.imageUrl
+```
+
+Making the call `curl http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=true"`, the operation references this component and a doggie is returned with random values for `name` and `photoUrls`:
+
+```json
+{
+  "id": 12608726,
+  "name": "Addison",
+  "photoUrls": [
+    "http://lorempixel.com/640/480",
+    "http://lorempixel.com/640/480",
+    "http://lorempixel.com/640/480",
+    "http://lorempixel.com/640/480"
+  ]
+}
+```
+
+The more descriptive your description is, the better job Prism can do at creating a mock response.
+
+For a list of supported methods, you can check [Faker's documentation portal](https://v6.fakerjs.dev/api/address.html).
+
+It's important to note that Faker's version, and how you're using Prism, can have an impact on the behavior you might see. The current version of Faker that Prism is using is set to `^6.0.0`, and can be found in Prism's [package.json file](https://github.com/stoplightio/prism/blob/master/packages/http/package.json#L19). That means that any version between v6.0.0 and v6.3.1 is valid for running Prism. If a user has a local version of Faker installed that's v6.0.0, while another user has v6.3.1 installed, when running the same OpenAPI description through Prism they might see different responses.
+
+You can check which version of Faker you have installed locally by running the following command and looking for `@faker-js/faker`:
+
+```bash
+yarn list --depth 0
+```
+
+It's also worth noting that JSON Schema Faker also uses its [own version of the Faker library](https://github.com/Shinigami92/json-schema-faker/blob/master/package.json#L87), so the behavior you might see from the fallback methods will also be affected by it.
+
+<!-- theme: info -->
+> **Tip:** If your team needs help creating better quality API description documents, take a look at [Spectral](https://stoplight.io/spectral/). You could enforce the use of `example` properties, or similar.
+
+##### Control Generated Fakes for Individual Properties
+
+In the following example there are two properties, each with specific Faker parameters. [datatype.number](https://v6.fakerjs.dev/api/datatype.html#number) uses named parameters while [helpers.slugify](https://v6.fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
+
+```yaml
+example:
+  type: object
+  properties:
+    ten-or-eleven:
+      type: number
+      example: 10
+      x-faker:
+        datatype.number:
+          min: 10
+          max: 11
+    slug:
+      type: string
+      example: two-words
+      x-faker:
+        helpers.slugify: [ "two words" ]
+```
+
+Pay close attention to the Faker docs when configuring any methods you pass in to the `x-faker` property. Some methods, such as `datatype.number`, will take in named options parameters:
+
+```yaml
+x-faker:
+  datatype.number:
+    min: 10
+    max: 11
+```
+
+While other methods, such as `finance.amount`, will take in an array:
+
+```yaml
+finance.amount:
+  - 100
+  - 10000
+  - 2
+  - '$'
+```
+
+If you're working with [dates](https://v6.fakerjs.dev/api/date.html), they're not a supported JSON Schema type, so JSON Schema Faker will return them as a string. For example, for this object:
+
+```yaml
+due_date:
+  type: string
+  x-faker: date.past
+```
+
+The output is:
+
+```json
+"due_date": "Tue Sep 14 2021 05:34:08 GMT-0500 (Central Daylight Time)",
+```
+
+If you'd like to change the date string format, you can pass in `format` property in the schema. For example:
+
+```yaml
+due_date:
+  type: string
+  x-faker: date.past
+  format: "date-time"
+```
+
+And the output will be:
+
+```json
+"due_date": "2021-11-18T00:00:00.0Z",
+```
+
+##### Configure JSON Schema Faker
+
+JSON Schema Faker has a set of [default configuration options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options). Prism has a [few options](https://github.com/stoplightio/prism/blob/master/packages/http/src/mocker/generator/JSONSchema.ts#L51) that are set to different values than the default configuration options, namely:
+
+```js
+failOnInvalidTypes: false, // if enabled, it will throw an Error for unknown types
+failOnInvalidFormat: false, // if enabled, it will throw an Error for unknown formats
+alwaysFakeOptionals: true, //  when enabled, it will set optionalsProbability: 1.0 and fixedProbabilities: true
+optionalsProbability: 1, // a value from 0.0 to 1.0 to generate values in a consistent way, e.g. 0.5 will generate from 0% to 50% of values. Using arrays it means items, on objects they're properties, etc.
+fixedProbabilities: true, // if enabled, then optionalsProbability: 0.5 will always generate the half of values
+ignoreMissingRefs: true, // if enabled, it will resolve to {} for unknown references
+```
+
+At the top level of your API Specification, you can create an `x-json-schema-faker` object containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An additional `locale` option is accepted to configure the `locale` of the underlying Faker instance.
+
+```yaml
+openapi: 3.1.0
+
+x-json-schema-faker:
+  locale: de
+  min-items: 2
+  max-items: 10
+  resolve-json-path: true
+```

--- a/docs/guides/11-dynamic-response-with-faker.md
+++ b/docs/guides/11-dynamic-response-with-faker.md
@@ -151,6 +151,8 @@ ignoreMissingRefs: true, // if enabled, it will resolve to {} for unknown refere
 
 At the top level of your API Specification, you can create an `x-json-schema-faker` object containing a map of [JSON Schema Faker Options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options) and their values. An additional `locale` option is accepted to configure the `locale` of the underlying Faker instance.
 
+The only option that is not supported is `random`, since that takes in a function.
+
 ```yaml
 openapi: 3.1.0
 

--- a/docs/guides/11-dynamic-response-with-faker.md
+++ b/docs/guides/11-dynamic-response-with-faker.md
@@ -1,8 +1,18 @@
 # Dynamic Response Generation with Faker
 
-All the random properties are generated using [Faker.js](https://github.com/faker-js/faker). You can pass in the `x-faker` keyword to a property, which allows for a specific Faker API method to be used so you get a lot of control over the response.
+When testing API calls, it's helpful to have dynamically generated responses to make sure your applications supports several use cases, instead of just testing with the same static piece of data over and over.
 
-If a user passes a method that doesn't exist, Prism falls back to [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker) to generate random values for that property.
+Prism uses the [Faker](https://github.com/faker-js/faker) and [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker) libraries to help with that.
+
+> Make sure you're running Prism in dynamic mode using the `-d` flag, or using the `Prefer` header with the `dynamic` key set to `true`.
+
+## How It Works
+
+In your OpenAPI description, you can pass in the `x-faker` keyword to a property, which allows for a specific Faker API method to be used.
+
+If a user passes a method that doesn't exist, Prism falls back to using [JSON Schema Faker](https://github.com/json-schema-faker/json-schema-faker) to generate random values for that property.
+
+For example, here's how you can use the `name.firstName` and `image.imageUrl` Faker methods:
 
 ```yaml
 Pet:
@@ -37,11 +47,16 @@ Making the call `curl http://127.0.0.1:4010/pets/123 -H "Prefer: dynamic=true"`,
 }
 ```
 
-The more descriptive your description is, the better job Prism can do at creating a mock response.
+The more descriptive your properties are, the better job Prism can do at creating a mock response.
 
-For a list of supported methods, you can check [Faker's documentation portal](https://v6.fakerjs.dev/api/address.html).
+<!-- theme: info -->
+> **Tip:** If your team needs help creating better quality API description documents, take a look at [Spectral](https://stoplight.io/spectral/). You could enforce the use of `example` properties, or similar.
 
-It's important to note that Faker's version, and how you're using Prism, can have an impact on the behavior you might see. The current version of Faker that Prism is using is set to `^6.0.0`, and can be found in Prism's [package.json file](https://github.com/stoplightio/prism/blob/master/packages/http/package.json#L19). That means that any version between v6.0.0 and v6.3.1 is valid for running Prism. If a user has a local version of Faker installed that's v6.0.0, while another user has v6.3.1 installed, when running the same OpenAPI description through Prism they might see different responses.
+## Faker Supported Methods
+ 
+For a list of supported methods, you can check [Faker's v6 documentation portal](https://v6.fakerjs.dev/api/address.html).
+
+It's important to note that Faker's version, and how you're using Prism, can have an impact on the behavior you might see. The current version of Faker that Prism is using is set to `^6.0.0`, and can be found in Prism's [package.json file](https://github.com/stoplightio/prism/blob/master/packages/http/package.json#L19). That means that any Faker version between v6.0.0 and v6.3.1 is valid for running Prism. If a user has a local version of Faker installed that's v6.0.0, while another user has v6.3.1 installed, when running the same OpenAPI description through Prism they might see different responses.
 
 You can check which version of Faker you have installed locally by running the following command and looking for `@faker-js/faker`:
 
@@ -49,14 +64,11 @@ You can check which version of Faker you have installed locally by running the f
 yarn list --depth 0
 ```
 
-It's also worth noting that JSON Schema Faker also uses its [own version of the Faker library](https://github.com/Shinigami92/json-schema-faker/blob/master/package.json#L87), so the behavior you might see from the fallback methods will also be affected by it.
+It's also worth noting that JSON Schema Faker also uses its [own version of the Faker library](https://github.com/Shinigami92/json-schema-faker/blob/master/package.json#L87), so the behavior you might see from the fallback methods can also be affected by it.
 
-<!-- theme: info -->
-> **Tip:** If your team needs help creating better quality API description documents, take a look at [Spectral](https://stoplight.io/spectral/). You could enforce the use of `example` properties, or similar.
+## Control Generated Fakes for Individual Properties
 
-##### Control Generated Fakes for Individual Properties
-
-In the following example there are two properties, each with specific Faker parameters. [datatype.number](https://v6.fakerjs.dev/api/datatype.html#number) uses named parameters while [helpers.slugify](https://v6.fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
+In the following example there are two properties, each with specific Faker parameters. [`datatype.number`](https://v6.fakerjs.dev/api/datatype.html#number) uses named parameters while [`helpers.slugify`](https://v6.fakerjs.dev/api/helpers.html#slugify) uses positional parameters. 
 
 ```yaml
 example:
@@ -124,7 +136,7 @@ And the output will be:
 "due_date": "2021-11-18T00:00:00.0Z",
 ```
 
-##### Configure JSON Schema Faker
+## Configure JSON Schema Faker
 
 JSON Schema Faker has a set of [default configuration options](https://github.com/json-schema-faker/json-schema-faker/tree/master/docs#available-options). Prism has a [few options](https://github.com/stoplightio/prism/blob/master/packages/http/src/mocker/generator/JSONSchema.ts#L51) that are set to different values than the default configuration options, namely:
 
@@ -146,5 +158,6 @@ x-json-schema-faker:
   locale: de
   min-items: 2
   max-items: 10
+  optionalsProbability: 0.5
   resolve-json-path: true
 ```

--- a/toc.json
+++ b/toc.json
@@ -45,6 +45,11 @@
     },
     {
       "type": "item",
+      "title": "Dynamic Response Generation with Faker",
+      "uri": "/docs/guides/02-request-validation.md"
+    },
+    {
+      "type": "item",
       "title": "Validation Proxy",
       "uri": "/docs/guides/03-validation-proxy.md"
     },


### PR DESCRIPTION
Related to #2056 and #2175. Closes https://github.com/stoplightio/platform-docs/issues/613.

**Summary**

Expand docs to explain Faker and JSON Schema Faker behavior.
