### PR TITLE
Expose the http server on prism server creation

### DIFF
--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -209,6 +209,10 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
       return components.logger;
     },
 
+    get server() {
+      return server;
+    },
+
     close() {
       return new Promise((resolve, reject) =>
         server.close(error => {

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -1,5 +1,6 @@
 import { IHttpConfig, PickRequired, PrismHttpComponents, PrismHttpInstance } from '@stoplight/prism-http';
 import { Logger } from 'pino';
+import { Server } from 'http';
 
 export interface IPrismHttpServerOpts {
   components: PickRequired<Partial<PrismHttpComponents>, 'logger'>;
@@ -10,6 +11,7 @@ export interface IPrismHttpServerOpts {
 export interface IPrismHttpServer {
   readonly prism: PrismHttpInstance;
   readonly logger: Logger;
+  readonly server: Server;
   close: () => Promise<void>;
   listen: (port: number, address?: string, backlog?: number) => Promise<string>;
 }


### PR DESCRIPTION
With this PR I am exposing the underlying micri http server. The goal and intention here is to have at our disposal all events from the server itself to be able to hook into **request** , **response** or any other event to be able to fine tune the behavoir of the server.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] N/A
- Event Tracking
  - [x] N/A
- Error Reporting
  - [x] N/A

**Additional context**

Main ask was to be able to change the response (headers and body) based on some received headers or some specific data set in the body of the request. This is not only to be used as some extra specific validators of data but also as a error injection mechanism to conduct fine grained testing.

