### PR TITLE
Remove conflicting log levels due to Pino bug

### DIFF
--- a/packages/cli/src/commands/__tests__/commands.spec.ts
+++ b/packages/cli/src/commands/__tests__/commands.spec.ts
@@ -31,6 +31,7 @@ describe.each<{ 0: string; 1: string; 2: unknown }>([
         document: '/path/to',
         multiprocess: false,
         errors: false,
+        verboseLevel: 'info',
       })
     );
   });

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -21,7 +21,7 @@ type PrismLogDescriptor = pino.LogDescriptor & { name: keyof typeof LOG_COLOR_MA
 signale.config({ displayTimestamp: true });
 
 const cliSpecificLoggerOptions: pino.LoggerOptions = {
-  customLevels: { start: pino.levels.values['info']},
+  customLevels: { start: pino.levels.values['info'] + 1 },
   level: 'start',
   formatters: {
     level: level => ({ level }),
@@ -99,7 +99,6 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
   });
 
   const address = await server.listen(options.port, options.host);
-
   operations.forEach(resource => {
     const path = pipe(
       createExamplePath(resource, attachTagsToParamsValues),

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -10,7 +10,7 @@ export function createLogger(
     name,
     base: {},
     customLevels: {
-      success: pino.levels.values['info'],
+      success: pino.levels.values['info'] + 2,
     },
     level: 'success',
     timestamp: false,


### PR DESCRIPTION
Addresses bug introduced in PR #2231

**Summary**

There is a bug in my recently accepted pull request #2331 for verbose logging options. In PR #2331, I set custom log levels to the same log severity level as Pino's "info" level. However, when I did this all such levels ("info" and all custom levels) would end up all logging as whatever custom log name last overrode the severity rank value. For instance, if we had "info", "success", and "start" all set to 30, all logs at this level would show up as "start." I originally approached it this way so that we support an arbitrary number of custom log levels showing up when the debug level is "info", rather than limiting it to 9 (i.e. levels at 31-39 until we hit "warn" at 40). I did some digging and apparently this is a known bug in Pino: https://github.com/pinojs/pino/issues/222#issuecomment-472212376. Therefore, to deal with this Pino bug and maintain the correct behavior of the logger, I am submitting this PR to keep custom logs at their own level with the knowledge that limited custom levels can be supported with the current scheme.

I also added to the verbose commands tests to ensure that 'info' is being used as the default log level.

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [X] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [X] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [X] N/A

**Screenshots**

Before bugfix:

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/28958079/225953810-f654fa4e-dca4-46bc-955e-fac233e89446.png">

Note how all info-level log labels say "success" when only some should

After bugfix:

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/28958079/225954299-28bebd42-8988-4a57-aebe-76cefd8cbc19.png">