### PR TITLE
Don't parse response body as json on 204

### DIFF
--- a/packages/http/src/utils/__tests__/parseResponse.spec.ts
+++ b/packages/http/src/utils/__tests__/parseResponse.spec.ts
@@ -10,6 +10,7 @@ describe('parseResponseBody()', () => {
           headers: new Headers({ 'content-type': 'application/json' }),
           json: jest.fn().mockResolvedValue({ test: 'test' }),
           text: jest.fn(),
+          status: 200,
         };
 
         expect(response.text).not.toHaveBeenCalled();
@@ -20,6 +21,7 @@ describe('parseResponseBody()', () => {
     describe('body is not parseable', () => {
       it('returns error', () => {
         const response = {
+          status: 200,
           headers: new Headers({ 'content-type': 'application/json' }),
           json: jest.fn().mockRejectedValue(new Error('Big Bada Boom')),
           text: jest.fn(),
@@ -35,6 +37,7 @@ describe('parseResponseBody()', () => {
     describe('body is readable', () => {
       it('returns body text', () => {
         const response = {
+          status: 200,
           headers: new Headers({ 'content-type': 'text/html' }),
           json: jest.fn(),
           text: jest.fn().mockResolvedValue('<html>Test</html>'),
@@ -48,9 +51,11 @@ describe('parseResponseBody()', () => {
     describe('body is not readable', () => {
       it('returns error', () => {
         const response = {
+          status: 200,
           headers: new Headers(),
           json: jest.fn(),
           text: jest.fn().mockRejectedValue(new Error('Big Bada Boom')),
+
         };
 
         expect(response.json).not.toHaveBeenCalled();
@@ -62,6 +67,7 @@ describe('parseResponseBody()', () => {
   describe('content-type header not set', () => {
     it('returns body text', () => {
       const response = {
+        status: 200,
         headers: new Headers(),
         json: jest.fn(),
         text: jest.fn().mockResolvedValue('Plavalaguna'),
@@ -69,6 +75,20 @@ describe('parseResponseBody()', () => {
 
       expect(response.json).not.toHaveBeenCalled();
       return assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual('Plavalaguna'));
+    });
+  });
+
+  describe('content-type header is set', () => {
+    it('does not call json() on 204', () => {
+      const response = {
+        status: 204,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: jest.fn(),
+        text: jest.fn().mockResolvedValue(''),
+      };
+
+      expect(response.json).not.toHaveBeenCalled();
+      return assertResolvesRight(parseResponseBody(response), body => expect(body).toEqual(''));
     });
   });
 });

--- a/packages/http/src/utils/parseResponse.ts
+++ b/packages/http/src/utils/parseResponse.ts
@@ -8,11 +8,11 @@ import { Dictionary } from '@stoplight/types';
 import { IHttpResponse } from '../types';
 
 export const parseResponseBody = (
-  response: Pick<Response, 'headers' | 'json' | 'text'>
+  response: Pick<Response, 'headers' | 'json' | 'text' | 'status'>
 ): TE.TaskEither<Error, unknown> =>
   TE.tryCatch(
     () =>
-      typeIs(response.headers.get('content-type') || '', ['application/json', 'application/*+json'])
+      (response.status != 204 && typeIs(response.headers.get('content-type') || '', ['application/json', 'application/*+json']))
         ? response.json()
         : response.text(),
     E.toError


### PR DESCRIPTION
Addresses ----

**Summary**

Currently, the response is parsed as json when content-type of `application/json`.  However in the case of `204` responses, this should not happen as the body would be empty and will raise an exception.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Additional context**

We recently ran into an issue where an endpoint returns a response with header `Content-type: application/json` on a `204 No Content` status code. This was raising an exception as the body was getting parsed as json. As it seems the behavior is to read body as text on all non `application/json` response types, I think it should be safe to do the same for 204 responses as well since a valid json body is not expected.