### PR TITLE
feat: adds more standard compliant request body handling

### DIFF
--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -42,9 +42,10 @@ function parseRequestBody(request: IncomingMessage) {
   if (
     // If the body size is null, it means the body itself is null so the promise can resolve with a null value
     request.headers['content-length'] === '0' ||
-    (request.headers['content-type'] === undefined &&
-      request.headers['transfer-encoding'] === undefined &&
-      request.headers['content-length'] === undefined)
+    // Per HTTP 1.1 - these 2 headers are the valid way to indicate that a body exists:
+    // > The presence of a message body in a request is signaled by a Content-Length or Transfer-Encoding header field.
+    // https://httpwg.org/specs/rfc9112.html#message.body
+    (request.headers['transfer-encoding'] === undefined && request.headers['content-length'] === undefined)
   ) {
     return Promise.resolve(null);
   }

--- a/packages/http/src/forwarder/errors.ts
+++ b/packages/http/src/forwarder/errors.ts
@@ -5,3 +5,10 @@ export const UPSTREAM_NOT_IMPLEMENTED: Omit<ProblemJson, 'detail'> = {
   title: 'The server does not support the functionality required to fulfill the request',
   status: 501,
 };
+
+export const PROXY_UNSUPPORTED_REQUEST_BODY: Omit<ProblemJson, 'detail'> = {
+  type: 'PROXY_UNSUPPORTED_REQUEST_BODY',
+  title:
+    'The Prism proxy does not support sending a GET/HEAD request with a message body to an upstream server. See: https://github.com/stoplightio/prism/issues/2259',
+  status: 501,
+};

--- a/test-harness/specs/proxy/proxy.get-null-body.txt
+++ b/test-harness/specs/proxy/proxy.get-null-body.txt
@@ -1,0 +1,18 @@
+====test====
+Making a  GET request with a Content-Type header through the proxy server ignores null body
+====spec====
+swagger: "2.0"
+paths:
+  /status/204:
+    get:
+      produces:
+        - text/plain
+      responses:
+        204:
+          description: No Content
+====server====
+proxy -p 4010 ${document} http://httpbin.org
+====command====
+curl -i http://localhost:4010/status/204 -X GET --header 'Content-Type: application/json'
+====expect====
+HTTP/1.1 204 No Content

--- a/test-harness/specs/proxy/proxy.get-with-body.txt
+++ b/test-harness/specs/proxy/proxy.get-with-body.txt
@@ -1,0 +1,20 @@
+====test====
+Making a GET request with request body through the proxy server rejects with 501
+====spec====
+swagger: "2.0"
+paths:
+  /status/204:
+    get:
+      produces:
+        - text/plain
+      responses:
+        204:
+          description: No Content
+====server====
+proxy -p 4010 ${document} http://httpbin.org
+====command====
+curl -i http://localhost:4010/status/204 -X GET --header 'Content-Type: application/json' --data '{}'
+====expect====
+HTTP/1.1 501 Not Implemented
+
+{"type":"https://stoplight.io/prism/errors#PROXY_UNSUPPORTED_REQUEST_BODY","title":"The Prism proxy does not support sending a GET/HEAD request with a message body to an upstream server. See: https://github.com/stoplightio/prism/issues/2259","status":501,"detail":""}


### PR DESCRIPTION
Addresses #2255

**Summary**

* removes `Content-Type` as a detection mechanism for request bodies
* adds more detailed error when the proxy detects a request body in a GET/HEAD request, which `node-fetch` does not support

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A
