### PR TITLE
Upgrade fast-xml-parser to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "fast-xml-parser": "^3.20.3",
+    "fast-xml-parser": "^4.2.0",
     "gavel": "^10.0.3",
     "glob": "^7.2.0",
     "http-string-parser": "^0.0.6",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -22,7 +22,7 @@
     "@stoplight/prism-core": "^4.12.0",
     "@stoplight/prism-http": "^4.12.0",
     "@stoplight/types": "^13.0.0",
-    "fast-xml-parser": "^3.20.3",
+    "fast-xml-parser": "^4.2.0",
     "fp-ts": "^2.11.5",
     "io-ts": "^2.2.16",
     "lodash": "^4.17.21",

--- a/packages/http-server/src/serialize.ts
+++ b/packages/http-server/src/serialize.ts
@@ -1,7 +1,7 @@
-import { j2xParser } from 'fast-xml-parser';
+import { XMLBuilder } from 'fast-xml-parser';
 import { is as typeIs } from 'type-is';
 
-const xmlSerializer = new j2xParser({});
+const xmlSerializer = new XMLBuilder({});
 
 const serializers = [
   {
@@ -10,7 +10,7 @@ const serializers = [
   },
   {
     test: (value: string) => !!typeIs(value, ['application/xml', 'application/*+xml']),
-    serializer: (data: unknown) => (typeof data === 'string' ? data : xmlSerializer.parse({ xml: data })),
+    serializer: (data: unknown) => (typeof data === 'string' ? data : xmlSerializer.build({ xml: data })),
   },
   {
     test: (value: string) => !!typeIs(value, ['text/*']),

--- a/test-harness/helpers.ts
+++ b/test-harness/helpers.ts
@@ -1,6 +1,6 @@
 import { Dictionary } from '@stoplight/types/dist';
 import * as xmlDiff from 'diff-js-xml';
-import * as parser from 'fast-xml-parser';
+const { XMLValidator} = require("fast-xml-parser");
 import { is as typeIs } from 'type-is';
 
 type Result = { body: string; headers: Dictionary<string> };
@@ -12,7 +12,7 @@ export const xmlValidator = {
       'application/*+xml',
       'text/xml',
     ]);
-    const isContentXML = parser.validate(content) === true;
+    const isContentXML = XMLValidator.validate(content) === true;
 
     return doesContentTypeMatch || isContentXML;
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,12 +4195,12 @@ fast-safe-stringify@^2.0.8:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
-fast-xml-parser@^3.20.3:
-  version "3.20.3"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.20.3.tgz#c171425356d4d929efeca4e4f67f24231a31c786"
-  integrity sha512-FfHJ/QCpo4K2gquBX7dIAcmShSBG4dMtYJ3ghSiR4w7YqlUujuamrM57C+mKLNWS3mvZzmm2B2Qx8Q6Gfw+lDQ==
+fast-xml-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.0.tgz#6db2ba33b95b8b4af93f94fe024d4b4d02a50855"
+  integrity sha512-+zVQv4aVTO+o8oRUyRL7PjgeVo1J6oP8Cw2+a8UTZQcj5V0yUK5T63gTN0ldgiHDPghUjKc4OpT6SwMTwnOQug==
   dependencies:
-    strnum "^1.0.4"
+    strnum "^1.0.5"
 
 fastestsmallesttextencoderdecoder@^1.0.22:
   version "1.0.22"
@@ -8439,10 +8439,10 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strnum@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.4.tgz#e97e36a7d6ba9f93d0d6b496b2ed0678d422832b"
-  integrity sha512-lMzNMfDpaQOLt4B2mEbfzYS0+T7dvCXeojnlGf6f1AygvWDMcWyXYaLbyICfjVu29sErR8fnRagQfBW/N/hGgw==
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Addresses https://security.snyk.io/vuln/SNYK-JS-FASTXMLPARSER-3325616

**Summary**

Upgrades fast-xml-parser from 3.20.3 to 4.2.0 to address https://security.snyk.io/vuln/SNYK-JS-FASTXMLPARSER-3325616

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [X] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [X] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [X] N/A

**Additional context**

I haven't tested extensively, but the tests pass. The only breaking change upstream appeared to be the renaming of `j2xParser` and its `parse` method to `XMLBuilder` and `build` respectively.
