### PR TITLE
fix(http): add explicit dependency on chalk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to Semantic Versioning.
 
+# Unreleased
+
+## Fixed
+
+- Put `chalk` as an explicit dependency in the HTTP package [#x](https://github.com/stoplightio/prism/pull/x)
+- Upgrade fast-xml-parser (thanks @spriggyjeff) [#2262](https://github.com/stoplightio/prism/pull/2262)
+
 # 4.12.0 (2023.04.12)
 
 ## Added

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -28,6 +28,7 @@
     "ajv": "^8.4.0",
     "ajv-formats": "^2.1.1",
     "caseless": "^0.12.0",
+    "chalk": "^4.1.2",
     "content-type": "^1.0.4",
     "fp-ts": "^2.11.5",
     "http-proxy-agent": "^5.0.0",


### PR DESCRIPTION
when verbose logging was added, the `chalk` dependency was not added to the http package.json file. this should fix some problems with the package