### PR TITLE
feat: allow setting array item cardinality via `x-count`

### DIFF
--- a/docs/guides/11-dynamic-response-with-faker.md
+++ b/docs/guides/11-dynamic-response-with-faker.md
@@ -163,3 +163,29 @@ x-json-schema-faker:
   optionalsProbability: 0.5
   resolve-json-path: true
 ```
+
+## Setting preferred array item cardinalities
+
+You can use the `x-count` property to set the preferred number of items for an array.
+
+You may enter a range or numbers (e.g. an array of 5 to 10 dogs at random):
+
+```yaml
+dogs:
+  type: array
+  x-count: [5, 10]
+  items:
+    type: string
+    x-faker: animal.dog
+```
+
+But you may also set a fixed number of items (e.g. an array of exactly 10 cats):
+
+```yaml
+ten-cats:
+  type: array
+  x-count: 10
+  items:
+    type: string
+    x-faker: animal.cat
+```

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -17,7 +17,7 @@ JSONSchemaFaker.extend('faker', () => faker);
 /**
  * Replaces template values from the root schema.
  */
-function template(value: JsonValue, rootSchema: JSONSchemaFaker.Schema): JsonValue {
+function template(value: JsonValue, rootSchema: JSONSchema): JsonValue {
   if (Array.isArray(value)) {
     return value.map(x => template(x, rootSchema));
   }
@@ -35,11 +35,14 @@ function minItemsExtension(
   value: JsonValue,
   schema: JsonObject,
   property: string,
-  rootSchema: JSONSchemaFaker.Schema
+  rootSchema: JSONSchema
 ): JsonValue {
   value = Number(template(value, rootSchema));
   if (!isNaN(value)) {
-    if (!('minItems' in schema) || (typeof schema.minItems === 'number' && schema.minItems < value)) {
+    if (
+      (!('minItems' in schema) || (typeof schema.minItems === 'number' && schema.minItems <= value)) &&
+      (!('maxItems' in schema) || (typeof schema.maxItems === 'number' && schema.maxItems >= value))
+    ) {
       schema.minItems = value;
     }
   }
@@ -56,11 +59,14 @@ function maxItemsExtension(
   value: JsonValue,
   schema: JsonObject,
   property: string,
-  rootSchema: JSONSchemaFaker.Schema
+  rootSchema: JSONSchema
 ): JsonValue {
   value = Number(template(value, rootSchema));
   if (!isNaN(value)) {
-    if (!('maxItems' in schema) || (typeof schema.maxItems === 'number' && schema.maxItems > value)) {
+    if (
+      (!('minItems' in schema) || (typeof schema.minItems === 'number' && schema.minItems <= value)) &&
+      (!('maxItems' in schema) || (typeof schema.maxItems === 'number' && schema.maxItems >= value))
+    ) {
       schema.maxItems = value;
     }
   }
@@ -77,7 +83,7 @@ function countExtension(
   value: JsonValue,
   schema: JsonObject,
   property: string,
-  rootSchema: JSONSchemaFaker.Schema
+  rootSchema: JSONSchema
 ): JsonValue {
   value = template(value, rootSchema);
   if (Array.isArray(value) && value.length >= 2) {

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -17,7 +17,7 @@ JSONSchemaFaker.extend('faker', () => faker);
 /**
  * Replaces template values from the root schema.
  */
-function template(value: JsonValue, rootSchema: JSONSchemaFaker.Schema) {
+function template(value: JsonValue, rootSchema: JSONSchemaFaker.Schema): JsonValue {
   if (Array.isArray(value)) {
     return value.map(x => template(x, rootSchema));
   }
@@ -46,6 +46,7 @@ function minItemsExtension(
   return schema;
 }
 
+// @ts-ignore
 JSONSchemaFaker.define('min-items', minItemsExtension);
 
 /**
@@ -66,6 +67,7 @@ function maxItemsExtension(
   return schema;
 }
 
+// @ts-ignore
 JSONSchemaFaker.define('max-items', maxItemsExtension);
 
 /**
@@ -88,6 +90,7 @@ function countExtension(
   return schema;
 }
 
+// @ts-ignore
 JSONSchemaFaker.define('count', countExtension);
 
 // From https://github.com/json-schema-faker/json-schema-faker/tree/develop/docs

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -14,6 +14,21 @@ import { stripWriteOnlyProperties } from '../../utils/filterRequiredProperties';
 // @ts-ignore
 JSONSchemaFaker.extend('faker', () => faker);
 
+// allows setting array item counts via and x-count property
+// @ts-ignore
+JSONSchemaFaker.define("count", (count, schema) => {
+  if (typeof count !== "number") {
+    throw new Error("x-count must be a number");
+  }
+  if (!("minItems" in schema) || schema.minItems < count) {
+    schema.minItems = count;
+  }
+  if (!("maxItems" in schema) || schema.maxItems > count) {
+    schema.maxItems = count;
+  }
+  return schema;
+});
+
 // From https://github.com/json-schema-faker/json-schema-faker/tree/develop/docs
 // Using from entries since the types aren't 100% compatible
 const JSON_SCHEMA_FAKER_DEFAULT_OPTIONS = Object.fromEntries([

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -141,6 +141,39 @@ describe('JSONSchema generator', () => {
       });
     });
 
+    describe('when x-count is 5', () => {
+      const schema: JSONSchema & any = {
+        type: 'array',
+        'x-count': 5,
+        items: {
+          type: 'string',
+        },
+      };
+
+      it('will generate exactly 5 items', () => {
+        assertRight(generate({}, schema), instance => {
+          expect(instance.length).toEqual(5);
+        });
+      });
+    });
+
+    describe('when x-count is a range of 5 to 10', () => {
+      const schema: JSONSchema & any = {
+        type: 'array',
+        'x-count': [5, 10],
+        items: {
+          type: 'string',
+        },
+      };
+
+      it('will generate exactly 5 to 10 items', () => {
+        assertRight(generate({}, schema), instance => {
+          expect(instance.length).toBeGreaterThanOrEqual(5);
+          expect(instance.length).toBeGreaterThanOrEqual(10);
+        });
+      });
+    });
+
     describe('when used with a schema that is not valid', () => {
       const schema: JSONSchema = {
         type: 'object',

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -149,22 +149,18 @@ describe('JSONSchema generator', () => {
             arrayItems: {
               'x-count': expectedCount,
               type: 'array',
-              minItems: 0,
-              maxItems: 100,
               items: {
                 type: 'string',
                 'x-faker': 'name.findName',
               },
             },
           },
-          required: ['arrayItems'],
         };
 
         it(`will generate exactly ${expectedCount} items`, () => {
           assertRight(generate({}, schema), instance => {
             expect(instance).toHaveProperty('arrayItems');
             const items = get(instance, 'arrayItems');
-            console.log('exact', expectedCount, items);
 
             expect(items.length).toEqual(expectedCount);
           });
@@ -185,13 +181,10 @@ describe('JSONSchema generator', () => {
             arrayItems: {
               'x-count': [min, max],
               type: 'array',
-              minItems: 0,
-              maxItems: 100,
               items: {
                 type: 'string',
                 'x-faker': 'name.findName',
               },
-              required: ['items'],
             },
           },
         };
@@ -200,7 +193,6 @@ describe('JSONSchema generator', () => {
           assertRight(generate({}, schema), instance => {
             expect(instance).toHaveProperty('arrayItems');
             const items = get(instance, 'arrayItems');
-            console.log('minmax', min, max, items);
 
             expect(items.length).toBeGreaterThanOrEqual(min);
             expect(items.length).toBeLessThanOrEqual(max);
@@ -223,14 +215,12 @@ describe('JSONSchema generator', () => {
             },
           },
         },
-        required: ['arrayItems'],
       };
 
       it(`will generate at least 10 items although 2 is set`, () => {
         assertRight(generate({}, schema), instance => {
           expect(instance).toHaveProperty('arrayItems');
           const items = get(instance, 'arrayItems');
-          console.log('when x-count is smaller than minItems', items);
 
           expect(items.length).toBeGreaterThanOrEqual(10);
         });
@@ -252,14 +242,12 @@ describe('JSONSchema generator', () => {
             },
           },
         },
-        required: ['arrayItems'],
       };
 
       it(`will generate at most 20 items although 30 is set`, () => {
         assertRight(generate({}, schema), instance => {
           expect(instance).toHaveProperty('arrayItems');
           const items = get(instance, 'arrayItems');
-          console.log('when x-count is larger than maxItems', items);
 
           expect(items.length).toBeLessThanOrEqual(20);
         });

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -143,33 +143,49 @@ describe('JSONSchema generator', () => {
 
     describe('when x-count is 5', () => {
       const schema: JSONSchema & any = {
-        type: 'array',
-        'x-count': 5,
-        items: {
-          type: 'string',
+        type: 'object',
+        properties: {
+          items: {
+            type: 'array',
+            'x-count': 5,
+            items: {
+              type: 'string',
+            },
+          },
         },
       };
 
       it('will generate exactly 5 items', () => {
         assertRight(generate({}, schema), instance => {
-          expect(instance.length).toEqual(5);
+          expect(instance).toHaveProperty('items');
+          const items = get(instance, 'items');
+
+          expect(items.length).toEqual(5);
         });
       });
     });
 
     describe('when x-count is a range of 5 to 10', () => {
       const schema: JSONSchema & any = {
-        type: 'array',
-        'x-count': [5, 10],
-        items: {
-          type: 'string',
+        type: 'object',
+        properties: {
+          items: {
+            type: 'array',
+            'x-count': [5, 10],
+            items: {
+              type: 'string',
+            },
+          },
         },
       };
 
       it('will generate exactly 5 to 10 items', () => {
         assertRight(generate({}, schema), instance => {
-          expect(instance.length).toBeGreaterThanOrEqual(5);
-          expect(instance.length).toBeGreaterThanOrEqual(10);
+          expect(instance).toHaveProperty('items');
+          const items = get(instance, 'items');
+
+          expect(items.length).toBeGreaterThanOrEqual(5);
+          expect(items.length).toBeLessThanOrEqual(10);
         });
       });
     });


### PR DESCRIPTION
**Summary**

Oftentimes a schema will include arrays with no restrictions on item count (`minItems`, `maxItems`), however for the mocked values there might be some sensible item count limitations (e.g. a user account might usually have 0 to 3 addresses, item collection endpoints usually return a set number of items per page).
This PR will allow users to set a preferred item count via the `x-count` property, either as a range or as a fixed value, see added documentation for details.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
