### PR TITLE
Fix/1895 prefer header validation proxy

### DIFF
--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -22,16 +22,8 @@ const mockCommand: CommandModule = {
         },
       }),
   handler: parsedArgs => {
-    const {
-      multiprocess,
-      dynamic,
-      port,
-      host,
-      cors,
-      document,
-      errors,
-      verboseLevel
-    } = (parsedArgs as unknown) as CreateMockServerOptions;
+    const { multiprocess, dynamic, port, host, cors, document, errors, verboseLevel } =
+      parsedArgs as unknown as CreateMockServerOptions;
 
     const createPrism = multiprocess ? createMultiProcessPrism : createSingleProcessPrism;
     const options = { cors, dynamic, port, host, document, multiprocess, errors, verboseLevel };

--- a/packages/cli/src/commands/sharedOptions.ts
+++ b/packages/cli/src/commands/sharedOptions.ts
@@ -46,7 +46,7 @@ const sharedOptions: Dictionary<Options> = {
     demandOption: true,
     // log level choices: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace"
     // custom levels like "success" and "start" are set to the same severity value as "info"
-    choices: Object.keys(pino.levels.values).concat('silent')
+    choices: Object.keys(pino.levels.values).concat('silent'),
   },
 };
 

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -152,7 +152,6 @@ type CreateBaseServerOptions = {
 };
 
 export interface CreateProxyServerOptions extends CreateBaseServerOptions {
-  dynamic: false;
   upstream: URL;
   validateRequest: boolean;
   upstreamProxy: string | undefined;

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -84,18 +84,18 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     checkSecurity: true,
     errors: false,
     upstreamProxy: undefined,
+    mock: { dynamic: options.dynamic },
   };
 
   const config: IHttpConfig = isProxyServerOptions(options)
     ? {
         ...shared,
         isProxy: true,
-        mock: { dynamic: options.dynamic },
         upstream: options.upstream,
         errors: options.errors,
         upstreamProxy: options.upstreamProxy,
       }
-    : { ...shared, isProxy: false, mock: { dynamic: options.dynamic }, errors: options.errors };
+    : { ...shared, isProxy: false, errors: options.errors };
 
   const server = createHttpServer(operations, {
     cors: options.cors,

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -16,7 +16,11 @@ import { CreatePrism } from './runner';
 import { getHttpOperationsFromSpec } from '../operations';
 import { configureExtensionsFromSpec } from '../extensions';
 
-type PrismLogDescriptor = pino.LogDescriptor & { name: keyof typeof LOG_COLOR_MAP; offset?: number; input: IHttpRequest };
+type PrismLogDescriptor = pino.LogDescriptor & {
+  name: keyof typeof LOG_COLOR_MAP;
+  offset?: number;
+  input: IHttpRequest;
+};
 
 signale.config({ displayTimestamp: true });
 
@@ -74,7 +78,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
   }
 
   const validateRequest = isProxyServerOptions(options) ? options.validateRequest : true;
-  const shared: Omit<IHttpConfig, 'mock'> = {
+  const shared = {
     validateRequest,
     validateResponse: true,
     checkSecurity: true,
@@ -85,12 +89,13 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
   const config: IHttpConfig = isProxyServerOptions(options)
     ? {
         ...shared,
-        mock: false,
+        isProxy: true,
+        mock: { dynamic: options.dynamic },
         upstream: options.upstream,
         errors: options.errors,
         upstreamProxy: options.upstreamProxy,
       }
-    : { ...shared, mock: { dynamic: options.dynamic }, errors: options.errors };
+    : { ...shared, isProxy: false, mock: { dynamic: options.dynamic }, errors: options.errors };
 
   const server = createHttpServer(operations, {
     cors: options.cors,

--- a/packages/core/src/__tests__/factory.test.ts
+++ b/packages/core/src/__tests__/factory.test.ts
@@ -24,7 +24,15 @@ describe('validation', () => {
   };
 
   const prismInstance = factory<string, string, string, IPrismConfig>(
-    { mock: { dynamic: false }, validateRequest: false, validateResponse: false, checkSecurity: true, errors: false, upstreamProxy: undefined },
+    {
+      mock: { dynamic: false },
+      validateRequest: false,
+      validateResponse: false,
+      checkSecurity: true,
+      errors: false,
+      upstreamProxy: undefined,
+      isProxy: false,
+    },
     components
   );
 
@@ -41,6 +49,7 @@ describe('validation', () => {
           validateResponse: false,
           mock: {},
           upstreamProxy: undefined,
+          isProxy: false,
         };
 
         obj[fieldType] = true;

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -66,7 +66,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
       components.mock({
         resource,
         input: { data, validations },
-        config: config.mock || {},
+        config: config.requestConfig || config.mock || {},
       })(components.logger.child({ name: 'NEGOTIATOR' }));
 
     const forwardCall = (config: IPrismProxyConfig) =>

--- a/packages/core/src/factory.ts
+++ b/packages/core/src/factory.ts
@@ -12,7 +12,7 @@ import { identity } from 'fp-ts/function';
 const eitherSequence = A.sequence(E.getApplicativeValidation(getSemigroup<IPrismDiagnostic>()));
 
 function isProxyConfig(p: IPrismConfig): p is IPrismProxyConfig {
-  return !p.mock;
+  return p.isProxy;
 }
 
 function createWarningOutput<Output>(output: Output): IPrismOutput<Output> {
@@ -66,7 +66,7 @@ export function factory<Resource, Input, Output, Config extends IPrismConfig>(
       components.mock({
         resource,
         input: { data, validations },
-        config: config.requestConfig || config.mock || {},
+        config: config.mock || {},
       })(components.logger.child({ name: 'NEGOTIATOR' }));
 
     const forwardCall = (config: IPrismProxyConfig) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,14 +21,15 @@ type IPrismBaseConfig = {
   errors: boolean;
   upstreamProxy: string | undefined;
   isProxy: boolean;
+  mock: unknown;
 };
 
 export type IPrismMockConfig = IPrismBaseConfig & {
-  mock: object;
+  isProxy: false;
 };
 
 export type IPrismProxyConfig = IPrismBaseConfig & {
-  mock: object;
+  isProxy: true;
   upstream: URL;
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,7 +20,7 @@ type IPrismBaseConfig = {
   validateResponse: boolean;
   errors: boolean;
   upstreamProxy: string | undefined;
-  requestConfig?: object;
+  isProxy: boolean;
 };
 
 export type IPrismMockConfig = IPrismBaseConfig & {
@@ -28,7 +28,7 @@ export type IPrismMockConfig = IPrismBaseConfig & {
 };
 
 export type IPrismProxyConfig = IPrismBaseConfig & {
-  mock: false;
+  mock: object;
   upstream: URL;
 };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,6 +20,7 @@ type IPrismBaseConfig = {
   validateResponse: boolean;
   errors: boolean;
   upstreamProxy: string | undefined;
+  requestConfig?: object;
 };
 
 export type IPrismMockConfig = IPrismBaseConfig & {

--- a/packages/http-server/README.md
+++ b/packages/http-server/README.md
@@ -22,6 +22,7 @@ async function createPrismServer() {
       validateRequest: true,
       validateResponse: true,
       mock: { dynamic: false },
+      isProxy: false,
       errors: false,
     },
   });

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -18,6 +18,7 @@ async function instantiatePrism(operations: IHttpOperation[]) {
       mock: { dynamic: false },
       errors: false,
       upstreamProxy: undefined,
+      isProxy: false,
     },
   });
 

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -33,6 +33,7 @@ async function instantiatePrism(specPath: string, configOverride?: Partial<IHttp
         errors: false,
         mock: { dynamic: false },
         upstreamProxy: undefined,
+        isProxy: false,
       },
       configOverride
     ),

--- a/packages/http-server/src/__tests__/server.oas.spec.ts
+++ b/packages/http-server/src/__tests__/server.oas.spec.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@stoplight/prism-core';
 import { getHttpOperationsFromSpec } from '@stoplight/prism-cli/src/operations';
-import { IHttpConfig } from '@stoplight/prism-http';
+import { IHttpConfig, IHttpMockConfig } from '@stoplight/prism-http';
 import { resolve } from 'path';
 import { merge } from 'lodash';
 import fetch, { RequestInit } from 'node-fetch';
@@ -25,7 +25,7 @@ async function instantiatePrism(specPath: string, configOverride?: Partial<IHttp
   const operations = await getHttpOperationsFromSpec(specPath);
   const server = createServer(operations, {
     components: { logger },
-    config: merge(
+    config: merge<IHttpMockConfig, Partial<IHttpConfig> | undefined>(
       {
         checkSecurity: true,
         validateRequest: true,

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -83,11 +83,19 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
     components.logger.info({ input }, 'Request received');
 
+    const configFromRequest = getHttpConfigFromRequest(input);
+
     const requestConfig: E.Either<Error, IHttpConfig> =
       config.mock === false
-        ? E.right(config)
+        ? pipe(
+            configFromRequest,
+            E.map(operationSpecificConfig => ({
+              ...config,
+              requestConfig: merge(config.requestConfig, operationSpecificConfig),
+            }))
+          )
         : pipe(
-            getHttpConfigFromRequest(input),
+            configFromRequest,
             E.map(operationSpecificConfig => ({ ...config, mock: merge(config.mock, operationSpecificConfig) }))
           );
 

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -83,21 +83,10 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
     components.logger.info({ input }, 'Request received');
 
-    const configFromRequest = getHttpConfigFromRequest(input);
-
-    const requestConfig: E.Either<Error, IHttpConfig> =
-      config.mock === false
-        ? pipe(
-            configFromRequest,
-            E.map(operationSpecificConfig => ({
-              ...config,
-              requestConfig: merge(config.requestConfig, operationSpecificConfig),
-            }))
-          )
-        : pipe(
-            configFromRequest,
-            E.map(operationSpecificConfig => ({ ...config, mock: merge(config.mock, operationSpecificConfig) }))
-          );
+    const requestConfig: E.Either<Error, IHttpConfig> = pipe(
+      getHttpConfigFromRequest(input),
+      E.map(operationSpecificConfig => ({ ...config, mock: merge(config.mock, operationSpecificConfig) }))
+    );
 
     pipe(
       TE.fromEither(requestConfig),

--- a/packages/http/src/__tests__/client.spec.ts
+++ b/packages/http/src/__tests__/client.spec.ts
@@ -14,6 +14,7 @@ describe('User Http Client', () => {
         errors: false,
         checkSecurity: true,
         upstreamProxy: undefined,
+        isProxy: false,
       };
 
       beforeAll(() => {

--- a/packages/http/src/__tests__/fixtures/dynamic-generation.oas3.json
+++ b/packages/http/src/__tests__/fixtures/dynamic-generation.oas3.json
@@ -1,0 +1,75 @@
+{
+    "openapi": "3.0.0",
+    "x-stoplight": {
+      "id": "onkt7wj0054vs"
+    },
+    "paths": {
+      "/todos": {
+        "get": {
+          "responses": {
+            "200": {
+              "description": "Expected response to a valid request",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "x-faker": "name.firstName"
+                      },
+                      "surname": {
+                        "type": "string",
+                        "format": "string",
+                        "x-faker": "name.lastName"
+                      }
+                    },
+                    "required": [
+                      "name",
+                      "surname"
+                    ]
+                  },
+                  "examples": {
+                    "Example1": {
+                      "value": {
+                        "name": "jhon",
+                        "surname": "doe"
+                      }
+                    },
+                    "Example2": {
+                      "value": {
+                        "name": "doe",
+                        "surname": "jhon"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "default": {
+              "description": "unexpected error",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "required": [
+                      "code",
+                      "message"
+                    ],
+                    "properties": {
+                      "code": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/packages/http/src/__tests__/fixtures/dynamic-generation.oas3.json
+++ b/packages/http/src/__tests__/fixtures/dynamic-generation.oas3.json
@@ -1,68 +1,61 @@
 {
-    "openapi": "3.0.0",
-    "x-stoplight": {
-      "id": "onkt7wj0054vs"
-    },
-    "paths": {
-      "/todos": {
-        "get": {
-          "responses": {
-            "200": {
-              "description": "Expected response to a valid request",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "type": "object",
-                    "properties": {
-                      "name": {
-                        "type": "string",
-                        "x-faker": "name.firstName"
-                      },
-                      "surname": {
-                        "type": "string",
-                        "format": "string",
-                        "x-faker": "name.lastName"
-                      }
+  "openapi": "3.0.0",
+  "x-stoplight": {
+    "id": "onkt7wj0054vs"
+  },
+  "paths": {
+    "/todos": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "x-faker": "name.firstName"
                     },
-                    "required": [
-                      "name",
-                      "surname"
-                    ]
+                    "surname": {
+                      "type": "string",
+                      "format": "string",
+                      "x-faker": "name.lastName"
+                    }
                   },
-                  "examples": {
-                    "Example1": {
-                      "value": {
-                        "name": "jhon",
-                        "surname": "doe"
-                      }
-                    },
-                    "Example2": {
-                      "value": {
-                        "name": "doe",
-                        "surname": "jhon"
-                      }
+                  "required": ["name", "surname"]
+                },
+                "examples": {
+                  "Example1": {
+                    "value": {
+                      "name": "john",
+                      "surname": "doe"
+                    }
+                  },
+                  "Example2": {
+                    "value": {
+                      "name": "doe",
+                      "surname": "john"
                     }
                   }
                 }
               }
-            },
-            "default": {
-              "description": "unexpected error",
-              "content": {
-                "application/json": {
-                  "schema": {
-                    "required": [
-                      "code",
-                      "message"
-                    ],
-                    "properties": {
-                      "code": {
-                        "type": "integer",
-                        "format": "int32"
-                      },
-                      "message": {
-                        "type": "string"
-                      }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": ["code", "message"],
+                  "properties": {
+                    "code": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "message": {
+                      "type": "string"
                     }
                   }
                 }
@@ -73,3 +66,4 @@
       }
     }
   }
+}

--- a/packages/http/src/__tests__/http-prism-instance.spec.ts
+++ b/packages/http/src/__tests__/http-prism-instance.spec.ts
@@ -65,6 +65,7 @@ describe('Http Client .request', () => {
           mock: { dynamic: false },
           errors: false,
           upstreamProxy: undefined,
+          isProxy: false,
         },
         { logger }
       );
@@ -159,13 +160,14 @@ describe('Http Client .request', () => {
         [true, 'fails the operation'],
       ])('errors flag is %s', (errors, testText) => {
         const config: IHttpProxyConfig = {
-          mock: false,
+          mock: { dynamic: false },
           checkSecurity: true,
           validateRequest: true,
           validateResponse: true,
           errors,
           upstream: new URL(baseUrl),
           upstreamProxy: undefined,
+          isProxy: true,
         };
 
         describe('path is not valid', () => {
@@ -190,13 +192,14 @@ describe('Http Client .request', () => {
 
       describe('Prism user-agent header', () => {
         const config: IHttpProxyConfig = {
-          mock: false,
+          mock: { dynamic: false },
           checkSecurity: true,
           validateRequest: true,
           validateResponse: true,
           errors: false,
           upstream: new URL(baseUrl),
           upstreamProxy: undefined,
+          isProxy: true,
         };
 
         describe('when the defaults are used', () => {
@@ -236,6 +239,7 @@ describe('Http Client .request', () => {
           mock: { dynamic: false },
           errors: false,
           upstreamProxy: undefined,
+          isProxy: false,
         },
         { logger }
       );
@@ -366,6 +370,7 @@ describe('Http Client .request', () => {
         validateResponse: true,
         errors: false,
         upstreamProxy: undefined,
+        isProxy: false,
       },
       { logger }
     );
@@ -402,13 +407,14 @@ describe('proxy server', () => {
     it('will take in account when proxying', async () => {
       const prism = createInstance(
         {
-          mock: false,
+          mock: { dynamic: false },
           checkSecurity: true,
           validateRequest: true,
           validateResponse: true,
           upstream: new URL(baseUrl),
           errors: false,
           upstreamProxy: undefined,
+          isProxy: true,
         },
         { logger }
       );
@@ -428,14 +434,14 @@ describe('proxy server', () => {
 
     let prism = createInstance(
       {
-        mock: false,
+        mock: { dynamic: false },
         checkSecurity: true,
         validateRequest: true,
         validateResponse: true,
         upstream: new URL(baseUrl),
         errors: false,
         upstreamProxy: undefined,
-        requestConfig: { code: undefined, exampleKey: undefined, dynamic: undefined },
+        isProxy: true,
       },
       { logger }
     );
@@ -453,14 +459,14 @@ describe('proxy server', () => {
     it('return dynamic response when Prefer header set to dynamic=true', async () => {
       prism = createInstance(
         {
-          mock: false,
+          mock: { dynamic: true },
           checkSecurity: true,
           validateRequest: true,
           validateResponse: true,
           upstream: new URL(baseUrl),
           errors: false,
           upstreamProxy: undefined,
-          requestConfig: { code: undefined, exampleKey: undefined, dynamic: true },
+          isProxy: true,
         },
         { logger }
       );
@@ -482,14 +488,14 @@ describe('proxy server', () => {
     it('return example response when Prefer header set to example=ExampleName', async () => {
       prism = createInstance(
         {
-          mock: false,
+          mock: { dynamic: false, exampleKey: 'Example2' },
           checkSecurity: true,
           validateRequest: true,
           validateResponse: true,
           upstream: new URL(baseUrl),
           errors: false,
           upstreamProxy: undefined,
-          requestConfig: { code: undefined, exampleKey: 'Example2', dynamic: undefined },
+          isProxy: true,
         },
         { logger }
       );

--- a/packages/http/src/__tests__/memory-leak-prevention.spec.ts
+++ b/packages/http/src/__tests__/memory-leak-prevention.spec.ts
@@ -26,6 +26,7 @@ describe('Checks if memory leaks', () => {
       },
       upstreamProxy: undefined,
       logger,
+      isProxy: false,
     });
 
     round(client);

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -92,16 +92,16 @@ const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpM
 
 function mockResponseLogger(logger: Logger) {
   const prefix = chalk.grey('> ');
-  
+
   return (response: IHttpResponse) => {
     logger.info(`${prefix}Responding with "${response.statusCode}"`);
-  
+
     logResponse({
       logger,
       prefix,
       ...pick(response, 'statusCode', 'body', 'headers'),
     });
-  
+
     return response;
   };
 }
@@ -122,7 +122,9 @@ function runCallbacks({
         pipe(
           callbacks,
           A.map(callback =>
-            runCallback({ callback, request: parseBodyIfUrlEncoded(request, resource), response })(logger.child({ name: 'CALLBACK' }))()
+            runCallback({ callback, request: parseBodyIfUrlEncoded(request, resource), response })(
+              logger.child({ name: 'CALLBACK' })
+            )()
           )
         )
       )
@@ -180,7 +182,7 @@ export function createInvalidInputResponse(
   return pipe(
     withLogger(logger => {
       logger.warn({ name: 'VALIDATOR' }, 'Request did not pass the validation rules');
-      failedValidations.map(failedValidation => (logger.error({ name: 'VALIDATOR' }, failedValidation.message)));
+      failedValidations.map(failedValidation => logger.error({ name: 'VALIDATOR' }, failedValidation.message));
     }),
     R.chain(() =>
       pipe(

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -16,7 +16,7 @@ export interface IHttpOperationConfig {
 }
 
 export type IHttpMockConfig = Overwrite<IPrismMockConfig, { mock: IHttpOperationConfig }>;
-export type IHttpProxyConfig = IPrismProxyConfig;
+export type IHttpProxyConfig = Overwrite<IPrismProxyConfig, { mock: IHttpOperationConfig }>;
 
 export type IHttpConfig = IHttpProxyConfig | IHttpMockConfig;
 


### PR DESCRIPTION
Addresses #1895 

**Summary**

Added a  non required field on the BaseConfig type to ensure request specific configuration would be available to Prism Proxy.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

https://github.com/stoplightio/prism/assets/19455540/fb5be96b-902d-478d-b6c3-e6829b0ce87a

<img width="275" alt="Screenshot 2023-05-16 at 11 57 07 AM" src="https://github.com/stoplightio/prism/assets/19455540/b36f23a2-43bc-48ad-bd39-d35af876b7bc">


**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
<img width="1263" alt="Screenshot 2023-05-16 at 11 56 55 AM" src="https://github.com/stoplightio/prism/assets/19455540/82d0369f-7229-469e-b747-3c860957635b">
