### PR TITLE
#1966 Adding Github Action for publishing multi-arch docker images

### DIFF
--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -1,0 +1,63 @@
+name: Build & Publish Docker image
+
+on: 
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
+
+env:
+  IS_RELEASE: ${{github.event_name == 'release'}}
+  DOCKER_BUILD_ARGS: |
+    BUILD_TYPE=production
+    YARN_NETWORK_TIMEOUT=480000
+  DOCKER_BUILD_PLATFORMS: |
+    linux/amd64
+    linux/arm64
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - 
+        name: Compute release version tags
+        if: env.IS_RELEASE == 'true'
+        run: |
+          echo "TAG_PRIMARY_VERSION=$(release='${{github.event.release.tag_name}}' && echo ${release:1:1})" >> $GITHUB_ENV
+          echo "TAG_FULL_VERSION=$(release='${{github.event.release.tag_name}}' && echo ${release:1})" >> $GITHUB_ENV
+      -
+        name: Build and Push release tags
+        if: env.IS_RELEASE == 'true'
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ${{format('{0}/prism:{1}', secrets.DOCKERHUB_USERNAME, env.TAG_FULL_VERSION)}}
+            ${{format('{0}/prism:{1}', secrets.DOCKERHUB_USERNAME, env.TAG_PRIMARY_VERSION)}}
+            ${{format('{0}/prism:{1}', secrets.DOCKERHUB_USERNAME, 'latest')}}
+          platforms: ${{env.DOCKER_BUILD_PLATFORMS}}
+          build-args: ${{env.DOCKER_BUILD_ARGS}}
+      -
+        name: Build and Push master Tag
+        if: env.IS_RELEASE != 'true'
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ${{format('{0}/prism:master', secrets.DOCKERHUB_USERNAME)}}
+          platforms: ${{env.DOCKER_BUILD_PLATFORMS}}
+          build-args: ${{env.DOCKER_BUILD_ARGS}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM node:16 as compiler
 
+ARG YARN_NETWORK_TIMEOUT=30000
+
 WORKDIR /usr/src/prism
 
 COPY package.json yarn.lock /usr/src/prism/
 COPY packages/ /usr/src/prism/packages/
 
-RUN yarn && yarn build
+RUN yarn --network-timeout $YARN_NETWORK_TIMEOUT && yarn build
 
 ###############################################################
 FROM node:16 as dependencies
+
+ARG YARN_NETWORK_TIMEOUT=30000
 
 WORKDIR /usr/src/prism/
 
@@ -28,7 +32,7 @@ COPY packages/cli/package.json /usr/src/prism/packages/cli/
 RUN mkdir -p /usr/src/prism/packages/cli/node_modules
 
 ENV NODE_ENV production
-RUN yarn --production
+RUN yarn --network-timeout $YARN_NETWORK_TIMEOUT --production
 
 RUN if [ $(uname -m) != "aarch64" ]; then curl -sfL https://gobinaries.com/tj/node-prune | bash; fi
 RUN if [ $(uname -m) != "aarch64" ]; then node-prune; fi


### PR DESCRIPTION
#1966 Adding Github Action for publishing multi-arch docker images

Github action that triggers docker image build and publish action upon:
* merging into master using tag :master
* creating a new Prism Release with tags: latest, <major-version>, <full-version>

Additionally adding YARN_NETWORK_TIMEOUT to Dockerfile with default value set to Yarn's default. This extra argument increases network timeout for arm64 Docker image builds since QEMU emulation tends to be slow.

Addresses #1966 

**Summary**

Currently, no ARM64 images are being published to DockerHub for Prism resulting in AMD64 emulation mode on ARM64 based systems.

**Requirements**
This Github action expects the following two secrets to be defined on the Github repository in order to push images to DockerHub:

* DOCKERHUB_USERNAME
* DOCKERHUB_TOKEN

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Testing Screenshots**

Merge/Push to master:
![image](https://github.com/stoplightio/prism/assets/3442453/830dd16b-2752-4950-9e95-96dcf3ad04d8)

Release Created:
![image](https://github.com/stoplightio/prism/assets/3442453/86299d8c-35c9-492b-b6b1-151316a426cc)

Personal DockerHub build results:
![image](https://github.com/stoplightio/prism/assets/3442453/a151ca8b-a53c-46c4-b899-9cc9b702a052)

