### PR TITLE
2195 upgrade @stoplight/json-schema-ref-parser

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@stoplight/http-spec": "^5.9.2",
     "@stoplight/json": "^3.18.1",
-    "@stoplight/json-schema-ref-parser": "9.2.4",
+    "@stoplight/json-schema-ref-parser": "9.2.5",
     "@stoplight/prism-core": "^5.0.0",
     "@stoplight/prism-http": "^5.0.0",
     "@stoplight/prism-http-server": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,10 +2027,10 @@
     json-schema-compare "^0.2.2"
     lodash "^4.17.4"
 
-"@stoplight/json-schema-ref-parser@9.2.4":
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-ref-parser/-/json-schema-ref-parser-9.2.4.tgz#659dde1b6743b0e257572aa3762f1275ef80dc1e"
-  integrity sha512-alWys5FhpfBtCJpZmWq47fZ4BBGcOGUqEI8b7AkJRZ+OaEoUIQtm8BReWY+JbU4D7+tBozX8Y+LF9Oxa9mYDSg==
+"@stoplight/json-schema-ref-parser@9.2.5":
+  version "9.2.5"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-ref-parser/-/json-schema-ref-parser-9.2.5.tgz#2039445d06123758d17cf926f3ad6014d8e35d52"
+  integrity sha512-7UI3pX5oyGzAdGPah001CyPnIsJZJW+38sGjvx862zXQFidBe0sxFO5MUety61Zr/RaygCQ2RU/KfD7hSfOLxg==
   dependencies:
     "@jsdevtools/ono" "^7.1.3"
     "@stoplight/path" "^1.3.2"


### PR DESCRIPTION
#2195 

**Summary**

Upgrade dependency `@stoplight/json-schema-ref-parser` in order to get a better error message when a `$ref` cannot be resolved.

Rather than the error message

```
    Token "definitions" does not exist.
```

instead provide the message

```
    at "#/components/examples/AppUserSchemaResponse/value/properties/profile/allOf/0", token "definitions" in "#/definitions/base" does not exist
```

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [x] I reported errors and followed the error reporting guidelines
  - [ ] N/A
