### PR TITLE
2305 document Node 18.16-or-later requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ This information refers to Open Source Prism 3.x, which is the current version m
 
 ### Install Self-hosted Prism
 
-_Prism requires NodeJS >= 16 to properly work._
+Prism requires
+- NodeJS >= 16
+- for NodeJS 18.x, [>= 18.16 is required](https://github.com/stoplightio/prism/issues/2305)
 
 ```bash
 npm install -g @stoplight/prism-cli


### PR DESCRIPTION
Addresses #2305 

**Summary**

Prism requires NodeJS 18.16 or later due to [an upstream bug in undici in NodeJS 18.15](https://github.com/nodejs/undici/pull/1910#issuecomment-1478377261) (and possibly earlier).

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**
 N/A

**Additional context**
N/A