### PR TITLE
add json schema faker fill properties param

### DIFF
--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -20,13 +20,29 @@ const mockCommand: CommandModule = {
           boolean: true,
           default: false,
         },
+        'json-schema-faker-fillProperties': {
+          description: 'Generate additional properties when using dynamic generation.',
+          default: undefined,
+          boolean: true,
+        },
       }),
   handler: parsedArgs => {
-    const { multiprocess, dynamic, port, host, cors, document, errors, verboseLevel } =
+    parsedArgs.jsonSchemaFakerFillProperties = parsedArgs['json-schema-faker-fillProperties'];
+    const { multiprocess, dynamic, port, host, cors, document, errors, verboseLevel, jsonSchemaFakerFillProperties } =
       parsedArgs as unknown as CreateMockServerOptions;
 
     const createPrism = multiprocess ? createMultiProcessPrism : createSingleProcessPrism;
-    const options = { cors, dynamic, port, host, document, multiprocess, errors, verboseLevel };
+    const options = {
+      cors,
+      dynamic,
+      port,
+      host,
+      document,
+      multiprocess,
+      errors,
+      verboseLevel,
+      jsonSchemaFakerFillProperties,
+    };
 
     return runPrismAndSetupWatcher(createPrism, options);
   },

--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -51,7 +51,8 @@ const proxyCommand: CommandModule = {
       'errors',
       'validateRequest',
       'verboseLevel',
-      'upstreamProxy'
+      'upstreamProxy',
+      'jsonSchemaFakerFillProperties'
     );
 
     const createPrism = p.multiprocess ? createMultiProcessPrism : createSingleProcessPrism;

--- a/packages/cli/src/extensions.ts
+++ b/packages/cli/src/extensions.ts
@@ -5,20 +5,33 @@ import * as JSONSchemaFaker from 'json-schema-faker';
 import type { JSONSchemaFakerOptions } from 'json-schema-faker';
 import { resetJSONSchemaGenerator } from '@stoplight/prism-http';
 
-export async function configureExtensionsFromSpec(specFilePathOrObject: string | object): Promise<void> {
+export async function configureExtensionsUserProvided(
+  specFilePathOrObject: string | object,
+  cliParamOptions: { [option: string]: any }
+): Promise<void> {
   const result = decycle(await new $RefParser().dereference(specFilePathOrObject));
 
   resetJSONSchemaGenerator();
 
   forOwn(get(result, 'x-json-schema-faker', {}), (value: any, option: string) => {
-    if (option === 'locale') {
-      // necessary as workaround broken types in json-schema-faker
-      // @ts-ignore
-      return JSONSchemaFaker.locate('faker').setLocale(value);
-    }
+    setFakerValue(option, value);
+  });
 
+  // cli parameter takes precidence, so it is set after spec extensions are configed
+  for (const param in cliParamOptions) {
+    if (cliParamOptions[param] !== undefined) {
+      setFakerValue(param, cliParamOptions[param]);
+    }
+  }
+}
+
+function setFakerValue(option: string, value: any) {
+  if (option === 'locale') {
     // necessary as workaround broken types in json-schema-faker
     // @ts-ignore
-    JSONSchemaFaker.option(camelCase(option) as keyof JSONSchemaFakerOptions, value);
-  });
+    return JSONSchemaFaker.locate('faker').setLocale(value);
+  }
+  // necessary as workaround broken types in json-schema-faker
+  // @ts-ignore
+  JSONSchemaFaker.option(camelCase(option) as keyof JSONSchemaFakerOptions, value);
 }

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -14,7 +14,7 @@ import { createExamplePath } from './paths';
 import { attachTagsToParamsValues, transformPathParamsValues } from './colorizer';
 import { CreatePrism } from './runner';
 import { getHttpOperationsFromSpec } from '../operations';
-import { configureExtensionsFromSpec } from '../extensions';
+import { configureExtensionsUserProvided } from '../extensions';
 
 type PrismLogDescriptor = pino.LogDescriptor & {
   name: keyof typeof LOG_COLOR_MAP;
@@ -71,7 +71,10 @@ const createSingleProcessPrism: CreatePrism = options => {
 
 async function createPrismServerWithLogger(options: CreateBaseServerOptions, logInstance: pino.Logger) {
   const operations = await getHttpOperationsFromSpec(options.document);
-  await configureExtensionsFromSpec(options.document);
+  const jsonSchemaFakerCliParams: { [option: string]: any } = {
+    ['fillProperties']: options.jsonSchemaFakerFillProperties,
+  };
+  await configureExtensionsUserProvided(options.document, jsonSchemaFakerCliParams);
 
   if (operations.length === 0) {
     throw new Error('No operations found in the current file.');
@@ -140,6 +143,9 @@ function isProxyServerOptions(options: CreateBaseServerOptions): options is Crea
   return 'upstream' in options;
 }
 
+/**
+ * @property {boolean} jsonSchemaFakerFillProperties - Used to override the default json-schema-faker extension value
+ */
 type CreateBaseServerOptions = {
   dynamic: boolean;
   cors: boolean;
@@ -149,6 +155,7 @@ type CreateBaseServerOptions = {
   multiprocess: boolean;
   errors: boolean;
   verboseLevel: string;
+  jsonSchemaFakerFillProperties: boolean;
 };
 
 export interface CreateProxyServerOptions extends CreateBaseServerOptions {

--- a/test-harness/specs/json-schema-faker-fillProperties/fillProperties_false.txt
+++ b/test-harness/specs/json-schema-faker-fillProperties/fillProperties_false.txt
@@ -1,0 +1,43 @@
+====test====
+Given I mock with json-schema-faker-fillProperties false
+When I send a request to an operation,
+Then the json-schema-faker-fillProperties cli param value should influence the response.
+====spec====
+openapi: "3.0.2"
+tags:
+  - name: example-tag
+info:
+  version: "0"
+  title: JSON Schema Faker test
+  description: JSON Schema Fafillker test
+  contact:
+    email: support@stoplight.io
+servers:
+  - url: http://api.example.com
+paths:
+  /widget:
+    get:
+      description: widget details
+      operationId: widgetDetails
+      tags: 
+        - example-tag
+      responses:
+        "200":
+          description: widget details response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    default: "Super Widget"
+====server====
+mock -p 4010 -d --json-schema-faker-fillProperties=false ${document}
+====command====
+curl -i http://localhost:4010/widget
+====expect-loose====
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"name":"Super Widget"}

--- a/test-harness/specs/json-schema-faker-fillProperties/fillProperties_false_json_schema_faker_config.txt
+++ b/test-harness/specs/json-schema-faker-fillProperties/fillProperties_false_json_schema_faker_config.txt
@@ -1,0 +1,52 @@
+====test====
+Given I mock with json-schema-faker-fillProperties false
+And json-schema-faker configuration in the specification
+When I send a request to an operation,
+Then the json-schema-faker configuration should influence the response.
+====spec====
+openapi: "3.0.2"
+x-json-schema-faker:
+  minItems: 3
+  maxItems: 3
+tags:
+  - name: example-tag
+info:
+  version: "0"
+  title: JSON Schema Faker test
+  description: JSON Schema Fafillker test
+  contact:
+    email: support@stoplight.io
+servers:
+  - url: http://api.example.com
+paths:
+  /widget:
+    get:
+      description: widget details
+      operationId: widgetDetails
+      tags: 
+        - example-tag
+      responses:
+        "200":
+          description: widget details response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    default: "Super Widget"
+                  array:
+                    type: array
+                    items:
+                      type: string
+                      default: "Item"
+====server====
+mock -p 4010 -d --json-schema-faker-fillProperties=false ${document}
+====command====
+curl -i http://localhost:4010/widget
+====expect-loose====
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"name":"Super Widget","array":["Item","Item","Item"]}

--- a/test-harness/specs/json-schema-faker-fillProperties/fillProperties_false_json_schema_faker_config_fillProperties_true.txt
+++ b/test-harness/specs/json-schema-faker-fillProperties/fillProperties_false_json_schema_faker_config_fillProperties_true.txt
@@ -1,0 +1,54 @@
+====test====
+Given I mock with json-schema-faker-fillProperties false
+And json-schema-faker configuration in the specification, with fillProperties true
+When I send a request to an operation,
+Then the json-schema-faker mock param should influence the response
+And the configuration provided in the spec for fillProperties should be ignored.
+====spec====
+openapi: "3.0.2"
+x-json-schema-faker:
+  minItems: 3
+  maxItems: 3
+  fillProperties: true
+tags:
+  - name: example-tag
+info:
+  version: "0"
+  title: JSON Schema Faker test
+  description: JSON Schema Fafillker test
+  contact:
+    email: support@stoplight.io
+servers:
+  - url: http://api.example.com
+paths:
+  /widget:
+    get:
+      description: widget details
+      operationId: widgetDetails
+      tags: 
+        - example-tag
+      responses:
+        "200":
+          description: widget details response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    default: "Super Widget"
+                  array:
+                    type: array
+                    items:
+                      type: string
+                      default: "Item"
+====server====
+mock -p 4010 -d --json-schema-faker-fillProperties=false ${document}
+====command====
+curl -i http://localhost:4010/widget
+====expect-loose====
+HTTP/1.1 200 OK
+content-type: application/json
+
+{"name":"Super Widget","array":["Item","Item","Item"]}


### PR DESCRIPTION
Addresses #2046 
**Summary**
In an effort to make it easier to set the json schema faker `fillProperties` to false, without having to modify individual schemas, a new cli parameter has been added for mocking. 

With this change you can now run  `prism mock -d --json-schema-faker-fillProperties=false api.oas3.yaml` to ensure additional properties that are not explicitly named in your spec aren't returned when mocking. Setting this value with the command line will take priority over the value set in `x-json-schema-faker`

**Additional Background**
When using dynamic mocking, if `additionalProperties` is not set on each `properties` in a schema, json schema faker will fill in additional properties due to Prism's current [global setting](https://github.com/stoplightio/prism/blob/8f03c80f3643d2e213eeb36d51422a98faa7e762/packages/http/src/mocker/generator/JSONSchema.ts#L42) for `fillProperties` being set to true. 

Adding a `x-json-schema-faker` object at the top level of your schema allows you to change Prism's global settings per schema if you don't want to set it at the cli level. See [documentation](https://docs.stoplight.io/docs/prism/9528b5a8272c0-dynamic-response-generation-with-faker#configure-json-schema-faker) for further details

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
