### PR TITLE
keep encoded value if decoding fails.

### DIFF
--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -1,6 +1,6 @@
 import { HttpParamStyles, IMediaTypeContent } from '@stoplight/types';
 import { JSONSchema } from '../../..';
-import { validate, findContentByMediaTypeOrFirst } from '../body';
+import { validate, findContentByMediaTypeOrFirst, decodeUriEntities } from '../body';
 import { assertRight, assertLeft, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { ValidationContext } from '../types';
 import * as faker from '@faker-js/faker/locale/en';
@@ -277,5 +277,22 @@ describe('findContentByMediaTypeOrFirst()', () => {
 
       it('should return the generic content', () => assertSome(foundContent));
     });
+  });
+});
+
+describe('decodeUriEntities', () => {
+  it('should decode both key and value', () => {
+    const target = { 'profile%2DImage': 'outer%20space' };
+    const results = decodeUriEntities(target);
+    expect(results).toEqual({ 'profile-Image': 'outer space' });
+  });
+
+  it('should decode the key but leave the value as encoded if decoding fails', () => {
+    const target = {
+      'profile%2DImage':
+        '�PNG\r\n\u001a\n\u0000\u0000\u0000\rIHDR\u0000\u0000\u0000\u0001\u0000\u0000\u0000\u0001\u0001\u0003\u0000\u0000\u0000%�V�\u0000\u0000\u0000\u0003PLTE\u0000\u0000\u0000�z=�\u0000\u0000\u0000\u0001tRNS\u0000@��f\u0000\u0000\u0000\nIDAT\b�c`\u0000\u0000\u0000\u0002\u0000\u0001�!�3\u0000\u0000\u0000\u0000IEND�B`�',
+    };
+    const results = decodeUriEntities(target);
+    expect(results).toEqual({ 'profile-Image': target['profile%2DImage'] });
   });
 });

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -87,7 +87,14 @@ export function parseMultipartFormDataParams(
 
 export function decodeUriEntities(target: Dictionary<string>) {
   return Object.entries(target).reduce((result, [k, v]) => {
-    result[decodeURIComponent(k)] = decodeURIComponent(v);
+    try {
+      // NOTE: this will decode the value even if it shouldn't (i.e when text/plain mime type).
+      // the decision to decode or not should be made before calling this function
+      result[decodeURIComponent(k)] = decodeURIComponent(v);
+    } catch (e) {
+      // when the data is binary, for example, uri decoding will fail so leave value as-is
+      result[decodeURIComponent(k)] = v;
+    }
     return result;
   }, {});
 }


### PR DESCRIPTION
#2376 

**Summary**

Handles when uri decoding binary data fails.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

Using the following curl request:
```
curl -X POST -H "Content-Type: multipart/form-data" -F "profileImage=@/Users/chelsea/Downloads/1x1.png" "http://127.0.0.1:4010/anything"
```
the behavior is as follows for the different versions of Prism:

**Version 4.14.1**
![image](https://github.com/stoplightio/prism/assets/33431856/e0cf18e3-8acf-4dfb-afff-ae4b81d7001f)

**Version 5.3.1**
![image](https://github.com/stoplightio/prism/assets/33431856/25c0c9b1-f52b-4237-8f67-9a66f9a386c2)

**Local With Fixes**
![image](https://github.com/stoplightio/prism/assets/33431856/2fb515ae-0b84-4c3a-a77a-a3c0d63e8235)
