### PR TITLE
feat: better optional auth support

### DIFF
--- a/packages/http/src/validator/validators/security/__tests__/security.spec.ts
+++ b/packages/http/src/validator/validators/security/__tests__/security.spec.ts
@@ -447,7 +447,7 @@ describe('validateSecurity', () => {
               code: 401,
               message: 'Invalid security scheme used',
               severity: DiagnosticSeverity.Error,
-              tags: ['Bearer', 'Basic realm="*"'],
+              tags: ['Bearer', 'None'],
             },
           ])
       );

--- a/packages/http/src/validator/validators/security/__tests__/security.spec.ts
+++ b/packages/http/src/validator/validators/security/__tests__/security.spec.ts
@@ -397,6 +397,63 @@ describe('validateSecurity', () => {
     });
   });
 
+  describe('when security scheme is optional', () => {
+    const securityScheme: HttpSecurityScheme[][] = [
+      [
+        {
+          id: faker.random.word(),
+          scheme: 'bearer',
+          type: 'http',
+          key: 'sec',
+          extensions: { 'x-test': faker.random.word() },
+        },
+      ],
+      [], // yeah that's how you do optional in OpenAPI
+    ];
+
+    it('passes if no security scheme is used', () => {
+      assertRight(
+        validateSecurity({
+          element: { ...baseRequest, headers: {} },
+          resource: {
+            security: securityScheme,
+          },
+        })
+      );
+    });
+
+    it('passes the validation', () => {
+      assertRight(
+        validateSecurity({
+          element: { ...baseRequest, headers: { authorization: 'Bearer abc123' } },
+          resource: {
+            security: securityScheme,
+          },
+        })
+      );
+    });
+
+    it('fails with an invalid security scheme error', () => {
+      assertLeft(
+        validateSecurity({
+          element: { ...baseRequest, headers: { authorization: 'Basic abc123' } },
+          resource: {
+            security: securityScheme,
+          },
+        }),
+        res =>
+          expect(res).toStrictEqual([
+            {
+              code: 401,
+              message: 'Invalid security scheme used',
+              severity: DiagnosticSeverity.Error,
+              tags: ['Bearer', 'Basic realm="*"'],
+            },
+          ])
+      );
+    });
+  });
+
   describe('OR relation between security schemes', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
@@ -615,6 +672,170 @@ describe('validateSecurity', () => {
           })
         );
       });
+    });
+  });
+
+  describe('Mix of AND and OR security schemes', () => {
+    const headerScheme: HttpSecurityScheme = {
+      id: faker.random.word(),
+      in: 'header' as const,
+      type: 'apiKey' as const,
+      name: 'x-api-key' as const,
+      key: 'sec' as const,
+      extensions: { 'x-test': 'test' },
+    };
+
+    const queryScheme: HttpSecurityScheme = {
+      id: faker.random.word(),
+      in: 'query' as const,
+      type: 'apiKey' as const,
+      name: 'x-api-key' as const,
+      key: 'sec' as const,
+      extensions: { 'x-test': 'test' },
+    };
+
+    const cookieScheme: HttpSecurityScheme = {
+      id: faker.random.word(),
+      in: 'cookie' as const,
+      type: 'apiKey' as const,
+      name: 'x-api-key' as const,
+      key: 'sec' as const,
+      extensions: { 'x-test': 'test' },
+    };
+
+    const bearerScheme: HttpSecurityScheme = {
+      id: faker.random.word(),
+      scheme: 'bearer',
+      type: 'http',
+      key: 'sec',
+      extensions: { 'x-test': faker.random.word() },
+    };
+
+    const oauth2Scheme: HttpSecurityScheme = {
+      id: faker.random.word(),
+      type: 'oauth2',
+      flows: {},
+      key: 'sec',
+      extensions: { 'x-test': faker.random.word() },
+    };
+
+    const openIdScheme: HttpSecurityScheme = {
+      id: faker.random.word(),
+      type: 'openIdConnect',
+      openIdConnectUrl: 'https://google.it',
+      key: 'sec',
+      extensions: { 'x-test': faker.random.word() },
+    };
+
+    const securityScheme: HttpSecurityScheme[][] = [
+      // one of
+      [
+        // all of
+        cookieScheme,
+      ],
+      [
+        // all of
+        queryScheme,
+        oauth2Scheme,
+      ],
+      [
+        // all of
+        bearerScheme,
+        headerScheme,
+        openIdScheme,
+      ],
+    ];
+
+    it('case 1 passes the validation', () => {
+      assertRight(
+        validateSecurity({
+          element: {
+            ...baseRequest,
+            headers: { cookie: 'x-api-key=abc123' },
+          },
+          resource: {
+            security: securityScheme,
+          },
+        })
+      );
+    });
+
+    it('case 2 passes the validation', () => {
+      assertRight(
+        validateSecurity({
+          element: {
+            ...baseRequest,
+            headers: { authorization: 'Bearer abc123' },
+            url: { path: '/', query: { 'x-api-key': 'abc123' } },
+          },
+          resource: {
+            security: securityScheme,
+          },
+        })
+      );
+    });
+
+    it('case 3 passes the validation', () => {
+      assertRight(
+        validateSecurity({
+          element: {
+            ...baseRequest,
+            headers: { 'x-api-key': 'abc123', authorization: 'Bearer abc123' },
+            url: { path: '/', query: { 'x-api-key': 'abc123' } },
+          },
+          resource: {
+            security: securityScheme,
+          },
+        })
+      );
+    });
+
+    it('fails with an invalid security scheme error 1', () => {
+      assertLeft(
+        validateSecurity({
+          element: {
+            ...baseRequest,
+            headers: { 'x-api-key': 'abc123' },
+            url: { path: '/', query: { 'x-api-key': 'abc123' } },
+          },
+          resource: {
+            security: securityScheme,
+          },
+        }),
+        res =>
+          expect(res).toStrictEqual([
+            {
+              code: 401,
+              message: 'Invalid security scheme used',
+              severity: DiagnosticSeverity.Error,
+              tags: ['OAuth2', 'Bearer', 'OpenID'],
+            },
+          ])
+      );
+    });
+
+    it('fails with an invalid security scheme error 2', () => {
+      assertLeft(
+        validateSecurity({
+          element: {
+            ...baseRequest,
+            headers: { 'x-api-key': 'abc123' },
+            url: { path: '/', query: { 'x-api-key': 'abc123' } },
+          },
+          resource: {
+            security: securityScheme,
+          },
+        }),
+        res =>
+          expect(res).toStrictEqual([
+            {
+              code: 401,
+              message: 'Invalid security scheme used',
+              severity: DiagnosticSeverity.Error,
+              tags: ['OAuth2', 'Bearer', 'OpenID'],
+            },
+          ])
+      );
     });
   });
 });

--- a/packages/http/src/validator/validators/security/__tests__/security.spec.ts
+++ b/packages/http/src/validator/validators/security/__tests__/security.spec.ts
@@ -790,31 +790,7 @@ describe('validateSecurity', () => {
       );
     });
 
-    it('fails with an invalid security scheme error 1', () => {
-      assertLeft(
-        validateSecurity({
-          element: {
-            ...baseRequest,
-            headers: { 'x-api-key': 'abc123' },
-            url: { path: '/', query: { 'x-api-key': 'abc123' } },
-          },
-          resource: {
-            security: securityScheme,
-          },
-        }),
-        res =>
-          expect(res).toStrictEqual([
-            {
-              code: 401,
-              message: 'Invalid security scheme used',
-              severity: DiagnosticSeverity.Error,
-              tags: ['OAuth2', 'Bearer', 'OpenID'],
-            },
-          ])
-      );
-    });
-
-    it('fails with an invalid security scheme error 2', () => {
+    it('fails with an invalid security scheme error', () => {
       assertLeft(
         validateSecurity({
           element: {

--- a/packages/http/src/validator/validators/security/handlers/index.ts
+++ b/packages/http/src/validator/validators/security/handlers/index.ts
@@ -2,6 +2,7 @@ import { apiKeyInCookie, apiKeyInHeader, apiKeyInQuery } from './apiKey';
 import { httpBasic } from './basicAuth';
 import { httpDigest } from './digestAuth';
 import { bearer, oauth2, openIdConnect } from './bearer';
+import { none } from './none';
 import { HttpSecurityScheme, DiagnosticSeverity } from '@stoplight/types';
 import { ValidateSecurityFn } from './utils';
 import { Either, fromNullable } from 'fp-ts/Either';
@@ -20,6 +21,7 @@ const securitySchemeHandlers: {
     basic: ValidateSecurityFn;
     bearer: ValidateSecurityFn;
   };
+  none: ValidateSecurityFn;
 } = {
   openIdConnect,
   oauth2,
@@ -33,6 +35,7 @@ const securitySchemeHandlers: {
     basic: httpBasic,
     bearer,
   },
+  none,
 };
 
 function createDiagnosticFor(scheme: string): IPrismDiagnostic {
@@ -55,3 +58,5 @@ export function findSecurityHandler(scheme: HttpSecurityScheme): Either<IPrismDi
   }
   return fromNullable(createDiagnosticFor(scheme.type))(securitySchemeHandlers[scheme.type]);
 }
+
+export { none as noneSecurityHandler };

--- a/packages/http/src/validator/validators/security/handlers/none.ts
+++ b/packages/http/src/validator/validators/security/handlers/none.ts
@@ -1,0 +1,12 @@
+import { get } from 'lodash';
+
+import { when } from './utils';
+import { Dictionary } from '@stoplight/types';
+import { IHttpRequest } from '../../../../types';
+
+// Makes sure there aren't any auth headers
+function isNoAuth(inputHeaders: Dictionary<string>) {
+  return get(inputHeaders, 'authorization') == undefined;
+}
+
+export const none = (input: Pick<IHttpRequest, 'headers' | 'url'>) => when(isNoAuth(input.headers || {}), 'None');


### PR DESCRIPTION
Addresses #2393

**Summary**

> Optional is supported, but we'd like to change that support. Currently, the support is such that if Optional is included as a valid scheme, you can hand prism any authorization header (malformed, from a security type that isn't supported explicitly, etc) - and this will return a 200.
>
> Given an endpoint that supports, say, Basic OR None, this should be interpreted as - either don't include an auth header (NONE case), or include one that is proper for the Basic.

I found it a bit tricky to cover every case, so I just covered the Authorization header case, which covers Basic, Bearer, OpenId, OAuth2.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A
