### PR TITLE
update json-schema-faker to 0.5.3

### DIFF
--- a/docs/guides/11-dynamic-response-with-faker.md
+++ b/docs/guides/11-dynamic-response-with-faker.md
@@ -178,5 +178,5 @@ openapi: 3.1.0
 x-json-schema-faker:
    min-items: 2
    max-items: 3
-   fillproperties: false
+   fillProperties: false
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,7 @@
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "fp-ts": "^2.11.5",
-    "json-schema-faker": "0.5.0-rcv.40",
+    "json-schema-faker": "0.5.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.5",
     "pino": "^6.13.3",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -33,7 +33,7 @@
     "fp-ts": "^2.11.5",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.0",
-    "json-schema-faker": "0.5.0-rcv.40",
+    "json-schema-faker": "0.5.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.5",
     "parse-multipart-data": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5666,13 +5666,13 @@ json-schema-compare@^0.2.2:
   dependencies:
     lodash "^4.17.4"
 
-json-schema-faker@0.5.0-rcv.40:
-  version "0.5.0-rcv.40"
-  resolved "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rcv.40.tgz"
-  integrity sha512-BczZvu03jKrGh3ovCWrHusiX6MwiaKK2WZeyomKBNA8Nm/n7aBYz0mub1CnONB6cgxOZTNxx4afNmLblbUmZbA==
+json-schema-faker@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.3.tgz#92f8a102037acf68e1c8e3a2e7c85726d285512d"
+  integrity sha512-BeIrR0+YSrTbAR9dOMnjbFl1MvHyXnq+Wpdw1FpWZDHWKLzK229hZ5huyPcmzFUfVq1ODwf40WdGVoE266UBUg==
   dependencies:
     json-schema-ref-parser "^6.1.0"
-    jsonpath-plus "^5.1.0"
+    jsonpath-plus "^7.2.0"
 
 json-schema-ref-parser@^6.1.0:
   version "6.1.0"
@@ -5732,10 +5732,10 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
 
-jsonpath-plus@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz"
-  integrity sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==
+jsonpath-plus@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz#7ad94e147b3ed42f7939c315d2b9ce490c5a3899"
+  integrity sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==
 
 kind-of@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
#2386 

**Summary**

- Updates json-schema-faker to the latest version to address the issue with fill additional properties.
- fixes docs to use `fillProperties` instead of `fillproperties` in OAS x-faker-options x-extension. `fillproperties` does not work, casing matters.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

BEFORE (version `0.5.0-rcv.40`):
![image](https://github.com/stoplightio/prism/assets/33431856/a073f21d-fd9d-4935-a878-636f651083b3)

AFTER (version `0.5.3`):
![image](https://github.com/stoplightio/prism/assets/33431856/1c916e9f-494d-4d76-8972-f0a1a4d03d09)

Can still override fill additional properties using command line option:
![image](https://github.com/stoplightio/prism/assets/33431856/46f1f011-b78e-411c-b07e-137ed4e87147)

Can still override fill additional properties using schema x extension option:
![image](https://github.com/stoplightio/prism/assets/33431856/e324b0f7-17db-45cb-aabf-4255491ee45b)


