### PR TITLE
5.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 # Unreleased
 
+# 5.5.2 (2023.12.01)
+
+- added support for default JSON deserialization for arrays of objects in form data request bodies in OpenAPI 3 [#2379](https://github.com/stoplightio/prism/pull/2379) - thanks @ilanashapiro for your contribution!
+
 # 5.5.1 (2023.10.30)
 
 - fixed issue with int64 [#2420](https://github.com/stoplightio/prism/pull/2420)

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "packages": ["packages/*"],
   "npmClient": "yarn",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "independent": false,
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-cli",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "author": "Stoplight <support@stoplight.io>",
   "bin": {
     "prism": "./dist/index.js"
@@ -10,9 +10,9 @@
     "@stoplight/http-spec": "^6.0.2",
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-ref-parser": "9.2.7",
-    "@stoplight/prism-core": "^5.5.1",
-    "@stoplight/prism-http": "^5.5.1",
-    "@stoplight/prism-http-server": "^5.5.1",
+    "@stoplight/prism-core": "^5.5.2",
+    "@stoplight/prism-http": "^5.5.2",
+    "@stoplight/prism-http-server": "^5.5.2",
     "@stoplight/types": "^14.0.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-core",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http-server",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -19,8 +19,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@stoplight/prism-core": "^5.5.1",
-    "@stoplight/prism-http": "^5.5.1",
+    "@stoplight/prism-core": "^5.5.2",
+    "@stoplight/prism-http": "^5.5.2",
     "@stoplight/types": "^14.0.0",
     "fast-xml-parser": "^4.2.0",
     "fp-ts": "^2.11.5",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",
@@ -20,7 +20,7 @@
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-merge-allof": "0.7.8",
     "@stoplight/json-schema-sampler": "0.3.0",
-    "@stoplight/prism-core": "^5.5.1",
+    "@stoplight/prism-core": "^5.5.2",
     "@stoplight/types": "^14.0.0",
     "@stoplight/yaml": "^4.2.3",
     "abstract-logging": "^2.0.1",


### PR DESCRIPTION
Releases https://github.com/stoplightio/prism/pull/2379 in version 5.5.2.
