### PR TITLE
chore: Update Dockerfile to node:18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as compiler
+FROM node:18.20.1 as compiler
 
 WORKDIR /usr/src/prism
 
@@ -8,7 +8,7 @@ COPY packages/ /usr/src/prism/packages/
 RUN yarn && yarn build
 
 ###############################################################
-FROM node:16 as dependencies
+FROM node:18.20.1 as dependencies
 
 WORKDIR /usr/src/prism/
 
@@ -34,7 +34,7 @@ RUN if [ $(uname -m) != "aarch64" ]; then curl -sfL https://gobinaries.com/tj/no
 RUN if [ $(uname -m) != "aarch64" ]; then node-prune; fi
 
 ###############################################################
-FROM node:16-alpine
+FROM node:18.20.1-alpine
 
 WORKDIR /usr/src/prism
 ARG BUILD_TYPE=development


### PR DESCRIPTION
Addresses #2514

**Summary**

Upgrades base image in Dockerfile to `node:18.20.1` to resolve vulnerabilities flagged on the docker image.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

N/A

**Additional context**

N/A
