### PR TITLE
docs: fixed markdown formatting for 'Logging Options' paragraph

### DIFF
--- a/docs/getting-started/03-cli.md
+++ b/docs/getting-started/03-cli.md
@@ -159,7 +159,7 @@ curl -v -X POST http://localhost:4010/pet/ -d '{"name"": "Skip", "species": 100}
 
 Use the `-v` command to enable verbose request and response logging for mocking, proxy, and callbacks. 
 
-Command options are ``fatal`, `error`, `warn`, `info`, `debug`, and `silent`. The `info` level is the default and the fallback for custom log levels. 
+Command options are `fatal`, `error`, `warn`, `info`, `debug`, and `silent`. The `info` level is the default and the fallback for custom log levels. 
 
 ## Running in Production
 


### PR DESCRIPTION
**Summary**

The 'Logging Options' paragraph had an extra ` in the log level list that was creating an empty inline code block that was throwing off the Markdown renderer.
I noticed this while checking the documentation website: https://docs.stoplight.io/docs/prism/beeaad4dc0227-prism-cli#logging-options

**Checklist**

- The basics
  - [X] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [X] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [X] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [X] N/A

**Screenshots**
Before:
![image](https://github.com/stoplightio/prism/assets/12892649/8b6724ce-df8a-4041-af34-39e0691cdb5b)
After:
![image](https://github.com/stoplightio/prism/assets/12892649/9e3ddf52-0682-41db-b057-951225392a39)


