### PR TITLE
fix: accessing the mock server with a path starting with “//”, it is recognized as “http://”

### DIFF
--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -86,10 +86,7 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
     const body = await parseRequestBody(request);
 
-    const { searchParams, pathname } = new URL(
-      url!, // url can't be empty for HTTP request
-      'http://example.com' // needed because URL can't handle relative URLs
-    );
+    const { searchParams, pathname } = new URL('http://example.com' + url);
 
     const input = {
       method: (method ? method.toLowerCase() : 'get') as HttpMethod,


### PR DESCRIPTION
**Summary**

Fixed a problem in which accessing a mock server with a pathname starting with “//” was recognized as “http://”.

There is an example using examples/petstore.oas3.yaml .
You will see results for paths that are different from those expected to be displayed.

```sh
$ curl http://127.0.0.1:4010/user/rem   
{"id":-9007199254740991,"username":"string","firstName":"string","lastName":"string","email":"string","password":"string","phone":"string","userStatus":-2147483648}

$ curl http://127.0.0.1:4010//user/rem
{"type":"https://stoplight.io/prism/errors#NO_PATH_MATCHED_ERROR","title":"Route not resolved, no path matched","status":404,"detail":"The route /rem hasn't been found in the specification file"}

% curl http://127.0.0.1:4010//a/user/rem
{"id":-9007199254740991,"username":"string","firstName":"string","lastName":"string","email":"string","password":"string","phone":"string","userStatus":-2147483648}
```

This problem is caused by URL functions in the DOM it called in `packages/http-server/src/server.ts:89`.
(Run on Chrome DevTools.)

```js
console.log(new URL('/user/rem', 'http://example.com')

URL{
  ...
  host:  "example.com"
  hostname:  "example.com"
  href:  "http://example.com/user/rem"
  origin:  "http://example.com"
  password: ""
  pathname:  "/user/rem"
  ...
}
```

```js
console.log(new URL('//user/rem', 'http://example.com'))

URL{
  ...
  host:  "user"
  hostname:  "user"
  href:  "http://user/rem"
  origin:  "http://user"
  password: ""
  pathname:  "/rem"
  ...
}
```

```js
console.log(new URL('//v1/user/rem', 'http://example.com'))

URL{
  ...
  host:  "v1"
  hostname: "v1"
  href:  "http://v1/user/rem"
  origin:  "http://v1"
  password: ""
  pathname:  "/user/rem"
  ...
}
```

Also, `http://example.com` is set to basepath in `packages/http-server/src/server.ts:89`.

```ts
    const { searchParams, pathname } = new URL(
      url!, // url can't be empty for HTTP request
      'http://example.com' // needed because URL can't handle relative URLs
    );
```

The following writing style solves this agenda and also avoids having to verify the emptiness of the relative URL path.

```ts
    const { searchParams, pathname } = new URL('http://example.com' + url);
```

```sh
$ curl http://127.0.0.1:4010/user/rem   
{"id":-9007199254740991,"username":"string","firstName":"string","lastName":"string","email":"string","password":"string","phone":"string","userStatus":-2147483648}

$ curl http://127.0.0.1:4010//user/rem  
{"type":"https://stoplight.io/prism/errors#NO_PATH_MATCHED_ERROR","title":"Route not resolved, no path matched","status":404,"detail":"The route //user/rem hasn't been found in the specification file"}

$ curl http://127.0.0.1:4010//a/user/rem
{"type":"https://stoplight.io/prism/errors#NO_PATH_MATCHED_ERROR","title":"Route not resolved, no path matched","status":404,"detail":"The route //a/user/rem hasn't been found in the specification file"}
```

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A