### PR TITLE
feat: Update faker version 8.

### DIFF
--- a/packages/cli/src/util/__tests__/paths.spec.ts
+++ b/packages/cli/src/util/__tests__/paths.spec.ts
@@ -1,7 +1,7 @@
 import { HttpParamStyles } from '@stoplight/types';
 import { createExamplePath } from '../paths';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 describe('createExamplePath()', () => {
   describe('path parameters', () => {
@@ -14,14 +14,14 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.Simple,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path/test')
       );
@@ -36,14 +36,14 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-id',
                 style: HttpParamStyles.Simple,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path/test')
       );
@@ -58,14 +58,14 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.Label,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path/.test')
       );
@@ -80,14 +80,14 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-id',
                 style: HttpParamStyles.Label,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path/.test')
       );
@@ -102,14 +102,14 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.Matrix,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path/;p=test')
       );
@@ -124,14 +124,14 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-a',
                 style: HttpParamStyles.Matrix,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path/;p-a=test')
       );
@@ -148,14 +148,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.Form,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path?p=test')
       );
@@ -170,14 +170,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-a',
                 style: HttpParamStyles.Form,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path?p-a=test')
       );
@@ -192,14 +192,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.DeepObject,
-                examples: [{ id: faker.random.word(), key: 'foo', value: { a: { aa: 1, ab: 2 } } }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: { a: { aa: 1, ab: 2 } } }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path?p%5Ba%5D%5Baa%5D=1&p%5Ba%5D%5Bab%5D=2')
       );
@@ -214,14 +214,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-id',
                 style: HttpParamStyles.DeepObject,
-                examples: [{ id: faker.random.word(), key: 'foo', value: { a: { aa: 1, ab: 2 } } }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: { a: { aa: 1, ab: 2 } } }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path?p-id%5Ba%5D%5Baa%5D=1&p-id%5Ba%5D%5Bab%5D=2')
       );
@@ -240,14 +240,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.DeepObject,
-                examples: [{ id: faker.random.word(), key: 'foo', value: exampleValue }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: exampleValue }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual(expected)
       );
@@ -262,14 +262,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.DeepObject,
-                examples: [{ id: faker.random.word(), key: 'foo', value: { a: null } }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: { a: null } }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path')
       );
@@ -284,14 +284,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.PipeDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: [1, 2, 3] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: [1, 2, 3] }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path?p=1%7C2%7C3')
       );
@@ -306,14 +306,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-id',
                 style: HttpParamStyles.PipeDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: [1, 2, 3] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: [1, 2, 3] }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path?p-id=1%7C2%7C3')
       );
@@ -328,14 +328,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p',
                 style: HttpParamStyles.SpaceDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: [1, 2, 3] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: [1, 2, 3] }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path?p=1%202%203')
       );
@@ -350,14 +350,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p-id',
                 style: HttpParamStyles.SpaceDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: [1, 2, 3] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: [1, 2, 3] }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path-path?p-id=1%202%203')
       );
@@ -372,14 +372,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q',
                 style: HttpParamStyles.PipeDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         e => expect(e.message).toEqual('Pipe delimited style is only applicable to array parameter')
       );
@@ -394,14 +394,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q',
                 style: HttpParamStyles.SpaceDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         e => expect(e.message).toEqual('Space delimited style is only applicable to array parameter')
       );
@@ -416,14 +416,14 @@ describe('createExamplePath()', () => {
           request: {
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'StartTime>',
                 style: HttpParamStyles.Form,
-                examples: [{ id: faker.random.word(), key: 'foo', value: '1985-10-25T03:33:00.613Z' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: '1985-10-25T03:33:00.613Z' }],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r => expect(r).toEqual('/path?StartTime%3E=1985-10-25T03%3A33%3A00.613Z')
       );
@@ -440,61 +440,61 @@ describe('createExamplePath()', () => {
           request: {
             path: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p1',
                 style: HttpParamStyles.Simple,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test1' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test1' }],
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p2',
                 style: HttpParamStyles.Label,
-                examples: [{ id: faker.random.word(), key: 'foo', value: ['test1', 'test2'] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: ['test1', 'test2'] }],
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'p3',
                 style: HttpParamStyles.Matrix,
-                examples: [{ id: faker.random.word(), key: 'foo', value: ['test1', 'test2'] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: ['test1', 'test2'] }],
               },
             ],
             query: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q1',
                 style: HttpParamStyles.Form,
-                examples: [{ id: faker.random.word(), key: 'foo', value: 'test1' }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test1' }],
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q2',
                 style: HttpParamStyles.SpaceDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: ['test1', 'test2'] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: ['test1', 'test2'] }],
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q3',
                 style: HttpParamStyles.PipeDelimited,
-                examples: [{ id: faker.random.word(), key: 'foo', value: ['test1', 'test2'] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: ['test1', 'test2'] }],
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q4',
                 style: HttpParamStyles.PipeDelimited,
                 explode: true,
-                examples: [{ id: faker.random.word(), key: 'foo', value: ['test1', 'test2'] }],
+                examples: [{ id: faker.string.alpha(), key: 'foo', value: ['test1', 'test2'] }],
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 name: 'q5',
                 style: HttpParamStyles.DeepObject,
                 examples: [
-                  { id: faker.random.word(), key: 'foo', value: { a: ['test1', 'test2'], b: { ba: 1, bb: 2 } } },
+                  { id: faker.string.alpha(), key: 'foo', value: { a: ['test1', 'test2'], b: { ba: 1, bb: 2 } } },
                 ],
               },
             ],
           },
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         }),
         r =>
           expect(r).toEqual(

--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -3,7 +3,7 @@ import { IHttpOperation } from '@stoplight/types';
 import fetch, { RequestInit } from 'node-fetch';
 import { createServer } from '../';
 import { ThenArg } from '../types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { Dictionary } from '@stoplight/types';
 import * as FormData from 'form-data';
 import { HttpParamStyles } from '@stoplight/types';
@@ -52,12 +52,12 @@ describe('body params validation', () => {
           path: '/json-body-no-request-content-type',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -72,10 +72,10 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: '',
                   schema: {
                     type: 'object',
@@ -107,12 +107,12 @@ describe('body params validation', () => {
           path: '/json-body-optional',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -127,11 +127,11 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               required: false,
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     type: 'object',
@@ -163,12 +163,12 @@ describe('body params validation', () => {
           path: '/json-body-required',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -183,11 +183,11 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               required: true,
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     type: 'object',
@@ -223,12 +223,12 @@ describe('body params validation', () => {
           path: '/json-body-property-required',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -243,10 +243,10 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     type: 'object',
@@ -279,12 +279,12 @@ describe('body params validation', () => {
           path: '/json-body-property-required-with-custom-415',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '415',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     type: 'object',
@@ -296,7 +296,7 @@ describe('body params validation', () => {
                   },
                   examples: [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       key: 'test',
                       value: { type: 'foo' },
                     },
@@ -309,10 +309,10 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     type: 'object',
@@ -345,12 +345,12 @@ describe('body params validation', () => {
           path: '/json-body-circular-property-required',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -365,10 +365,10 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     $ref: '#/__bundled__/schemas',
@@ -410,12 +410,12 @@ describe('body params validation', () => {
           path: '/empty-body',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -669,12 +669,12 @@ describe('body params validation', () => {
           path: '/path',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -689,10 +689,10 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/x-www-form-urlencoded',
                   schema: {
                     type: 'object',
@@ -727,12 +727,12 @@ describe('body params validation', () => {
           path: '/application-x-www-form-urlencoded-complex-request-body',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'text/plain',
                   schema: {
                     type: 'string',
@@ -747,10 +747,10 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/x-www-form-urlencoded',
                   schema: {
                     type: 'object',
@@ -803,12 +803,12 @@ describe('body params validation', () => {
           path: '/multipart-form-data-body-required',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: {
                     type: 'object',
@@ -820,7 +820,7 @@ describe('body params validation', () => {
                   },
                   examples: [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       key: 'test',
                       value: { type: 'foo' },
                     },
@@ -833,11 +833,11 @@ describe('body params validation', () => {
           servers: [],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               required: true,
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'multipart/form-data',
                   schema: {
                     type: 'object',

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -16,7 +16,7 @@
     "node": ">=18.20.1"
   },
   "dependencies": {
-    "@faker-js/faker": "^6.0.0",
+    "@faker-js/faker": "^8.4.1",
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-merge-allof": "0.7.8",
     "@stoplight/json-schema-sampler": "0.3.0",

--- a/packages/http/src/__tests__/fixtures/dynamic-generation.oas3.json
+++ b/packages/http/src/__tests__/fixtures/dynamic-generation.oas3.json
@@ -16,12 +16,12 @@
                   "properties": {
                     "name": {
                       "type": "string",
-                      "x-faker": "name.firstName"
+                      "x-faker": "person.firstName"
                     },
                     "surname": {
                       "type": "string",
                       "format": "string",
-                      "x-faker": "name.lastName"
+                      "x-faker": "person.lastName"
                     }
                   },
                   "required": ["name", "surname"]

--- a/packages/http/src/__tests__/fixtures/index.ts
+++ b/packages/http/src/__tests__/fixtures/index.ts
@@ -1,6 +1,6 @@
 import { IPrismInput } from '@stoplight/prism-core';
 import { DiagnosticSeverity, HttpParamStyles, IHttpOperation } from '@stoplight/types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { IHttpRequest, IHttpResponse } from '../../types';
 
 export const httpOperations: IHttpOperation[] = [
@@ -11,13 +11,13 @@ export const httpOperations: IHttpOperation[] = [
     request: {
       query: [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           required: false,
           name: 'name',
           style: HttpParamStyles.Form,
         },
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           required: true,
           name: 'completed',
           style: HttpParamStyles.Form,
@@ -26,11 +26,11 @@ export const httpOperations: IHttpOperation[] = [
     },
     responses: [
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '200',
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             schema: {
               type: 'array',
@@ -49,7 +49,7 @@ export const httpOperations: IHttpOperation[] = [
             },
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'application/json',
                 value: {
                   id: 1,
@@ -58,7 +58,7 @@ export const httpOperations: IHttpOperation[] = [
                 },
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'bear',
                 value: [
                   {
@@ -72,16 +72,16 @@ export const httpOperations: IHttpOperation[] = [
             encodings: [],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/xml',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'first',
                 value: '{ "root": "first" }',
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'second',
                 value: '{ "root": "second" }',
               },
@@ -89,16 +89,16 @@ export const httpOperations: IHttpOperation[] = [
             encodings: [],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'text/plain',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'text',
                 value: 'some text',
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'plain',
                 value: 'some plain',
               },
@@ -108,36 +108,36 @@ export const httpOperations: IHttpOperation[] = [
         ],
       },
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '201',
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'first',
                 value: '{ "root": "first" }',
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'second',
                 value: '{ "root": "second" }',
               },
             ],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/xml',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'first',
                 value: '<root>first</root>',
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'second',
                 value: '<root>second</root>',
               },
@@ -146,11 +146,11 @@ export const httpOperations: IHttpOperation[] = [
         ],
       },
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '422',
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             schema: {
               type: 'object',
@@ -163,7 +163,7 @@ export const httpOperations: IHttpOperation[] = [
             },
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'application/json',
                 value: {
                   message: 'error',
@@ -182,11 +182,11 @@ export const httpOperations: IHttpOperation[] = [
     request: {},
     responses: [
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '200',
         headers: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             name: 'x-todos-publish',
             style: HttpParamStyles.Simple,
             schema: { type: 'string', format: 'date-time' },
@@ -194,7 +194,7 @@ export const httpOperations: IHttpOperation[] = [
         ],
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             schema: {
               type: 'object',
@@ -212,11 +212,11 @@ export const httpOperations: IHttpOperation[] = [
             encodings: [],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/xml',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'xml',
                 value: '<todo><name>Shopping</name><completed>false</completed></todo>',
               },
@@ -226,12 +226,12 @@ export const httpOperations: IHttpOperation[] = [
         ],
       },
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '422',
         headers: [],
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             schema: {
               type: 'object',
@@ -253,10 +253,10 @@ export const httpOperations: IHttpOperation[] = [
     path: '/todos',
     request: {
       body: {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             schema: {
               type: 'object',
@@ -268,7 +268,7 @@ export const httpOperations: IHttpOperation[] = [
       },
       query: [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           name: 'overwrite',
           style: HttpParamStyles.Form,
           schema: { type: 'string', pattern: '^(yes|no)$' },
@@ -276,7 +276,7 @@ export const httpOperations: IHttpOperation[] = [
       ],
       headers: [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           name: 'x-todos-publish',
           style: HttpParamStyles.Simple,
           schema: { type: 'string', format: 'date-time' },
@@ -289,7 +289,7 @@ export const httpOperations: IHttpOperation[] = [
     },
     responses: [
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '200',
       },
     ],
@@ -302,16 +302,16 @@ export const httpOperations: IHttpOperation[] = [
     request: {},
     responses: [
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '200',
         headers: [],
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'application/json',
                 value: 'OK',
               },
@@ -320,16 +320,16 @@ export const httpOperations: IHttpOperation[] = [
         ],
       },
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '400',
         headers: [],
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             examples: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 key: 'application/json',
                 value: {
                   message: 'error',

--- a/packages/http/src/mocker/callback/__tests__/callbacks.spec.ts
+++ b/packages/http/src/mocker/callback/__tests__/callbacks.spec.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { runCallback } from '../callbacks';
 import { mapValues } from 'lodash';
 import { HttpParamStyles } from '@stoplight/types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 jest.mock('node-fetch');
 
@@ -35,19 +35,19 @@ describe('runCallback()', () => {
           id: '1',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
-              contents: [{ id: faker.random.word(), mediaType: 'application/json' }],
+              contents: [{ id: faker.string.alpha(), mediaType: 'application/json' }],
             },
           ],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
-                  examples: [{ id: faker.random.word(), key: 'e1', value: { about: 'something' } }],
+                  examples: [{ id: faker.string.alpha(), key: 'e1', value: { about: 'something' } }],
                 },
               ],
             },
@@ -95,11 +95,11 @@ describe('runCallback()', () => {
           id: '1',
           responses: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '200',
               headers: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'test',
                   style: HttpParamStyles.Simple,
                   deprecated: true,
@@ -108,7 +108,7 @@ describe('runCallback()', () => {
               ],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
                   schema: { type: 'object', properties: { test: { type: 'string', maxLength: 3 } } },
                 },
@@ -117,12 +117,12 @@ describe('runCallback()', () => {
           ],
           request: {
             body: {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: 'application/json',
-                  examples: [{ id: faker.random.word(), key: 'e1', value: { about: 'something' } }],
+                  examples: [{ id: faker.string.alpha(), key: 'e1', value: { about: 'something' } }],
                 },
               ],
             },
@@ -180,7 +180,7 @@ describe('runCallback()', () => {
           method: 'get',
           path: 'http://example.com/{$method}/{$statusCode}/{$response.body#/id}/{$request.header.content-type}',
           id: '1',
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         },
         request: {
           body: '',

--- a/packages/http/src/mocker/generator/JSONSchema.ts
+++ b/packages/http/src/mocker/generator/JSONSchema.ts
@@ -1,4 +1,4 @@
-import faker from '@faker-js/faker';
+import { faker } from '@faker-js/faker/locale/en';
 import { cloneDeep } from 'lodash';
 import { JSONSchema } from '../../types';
 

--- a/packages/http/src/mocker/generator/__tests__/HttpParamGenerator.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/HttpParamGenerator.spec.ts
@@ -1,13 +1,13 @@
 import { assertNone, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { generate, improveSchema } from '../HttpParamGenerator';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 describe('HttpParamGenerator', () => {
   describe('generate()', () => {
     describe('example is present', () => {
       it('uses static example', () => {
         assertSome(
-          generate({ id: faker.random.word(), examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }] }),
+          generate({ id: faker.string.alpha(), examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }] }),
           v => expect(v).toEqual('test')
         );
       });
@@ -17,9 +17,9 @@ describe('HttpParamGenerator', () => {
       it('prefers static example', () => {
         assertSome(
           generate({
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             schema: { type: 'string' },
-            examples: [{ id: faker.random.word(), key: 'foo', value: 'test' }],
+            examples: [{ id: faker.string.alpha(), key: 'foo', value: 'test' }],
           }),
           v => expect(v).toEqual('test')
         );
@@ -28,7 +28,7 @@ describe('HttpParamGenerator', () => {
 
     describe('schema is present', () => {
       it('generates example from schema', () => {
-        assertSome(generate({ id: faker.random.word(), schema: { type: 'string', format: 'email' } }), v =>
+        assertSome(generate({ id: faker.string.alpha(), schema: { type: 'string', format: 'email' } }), v =>
           expect(v).toEqual(expect.stringMatching(/@/))
         );
       });
@@ -36,7 +36,7 @@ describe('HttpParamGenerator', () => {
 
     describe('no schema and no examples', () => {
       it('returns none', () => {
-        assertNone(generate({ id: faker.random.word() }));
+        assertNone(generate({ id: faker.string.alpha() }));
       });
     });
   });

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -81,7 +81,7 @@ describe('JSONSchema generator', () => {
       const schema: JSONSchema & any = {
         type: 'object',
         properties: {
-          ip: { type: 'string', format: 'ip', 'x-faker': 'internet.ip' },
+          ip: { type: 'string', format: 'ip', 'x-faker': 'internet.ipv4' },
         },
         required: ['ip'],
       };
@@ -90,7 +90,6 @@ describe('JSONSchema generator', () => {
         assertRight(generate(operation, {}, schema), instance => {
           expect(instance).toHaveProperty('ip');
           const ip = get(instance, 'ip', '');
-
           expect(ipRegExp.test(ip)).toBeTruthy();
           expect(emailRegExp.test(ip)).toBeFalsy();
         });

--- a/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
+++ b/packages/http/src/mocker/generator/__tests__/JSONSchema.spec.ts
@@ -105,7 +105,7 @@ describe('JSONSchema generator', () => {
             meaning: {
               type: 'number',
               'x-faker': {
-                'datatype.number': {
+                'number.int': {
                   min: 42,
                   max: 42,
                 },

--- a/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/InternalHelpers.unit.ts
@@ -1,16 +1,16 @@
 import { assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { findBestHttpContentByMediaType } from '../InternalHelpers';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 describe('InternalHelpers', () => {
   describe('findBestHttpContentByMediaType()', () => {
     describe('with multiple content types for a response', () => {
       const availableResponses = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '200',
         contents: [
-          { id: faker.random.word(), mediaType: 'application/xml' },
-          { id: faker.random.word(), mediaType: 'application/json' },
+          { id: faker.string.alpha(), mediaType: 'application/xml' },
+          { id: faker.string.alpha(), mediaType: 'application/json' },
         ],
       };
 
@@ -28,7 +28,7 @@ describe('InternalHelpers', () => {
       it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType(
-            [{ id: faker.random.word(), mediaType: 'application/json; version=1' }],
+            [{ id: faker.string.alpha(), mediaType: 'application/json; version=1' }],
             ['application/json']
           )
         );
@@ -39,7 +39,7 @@ describe('InternalHelpers', () => {
       it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType(
-            [{ id: faker.random.word(), mediaType: 'application/json; version=1; q=0.6' }],
+            [{ id: faker.string.alpha(), mediaType: 'application/json; version=1; q=0.6' }],
             ['application/json']
           )
         );
@@ -50,9 +50,9 @@ describe('InternalHelpers', () => {
           assertSome(
             findBestHttpContentByMediaType(
               [
-                { id: faker.random.word(), mediaType: 'application/json; version=1; q=1' },
-                { id: faker.random.word(), mediaType: 'application/xml; version=1; q=0.6' },
-                { id: faker.random.word(), mediaType: 'application/vnd+json; version=1; q=0.5' },
+                { id: faker.string.alpha(), mediaType: 'application/json; version=1; q=1' },
+                { id: faker.string.alpha(), mediaType: 'application/xml; version=1; q=0.6' },
+                { id: faker.string.alpha(), mediaType: 'application/vnd+json; version=1; q=0.5' },
               ],
               ['application/json', 'application/xml']
             ),
@@ -66,7 +66,7 @@ describe('InternalHelpers', () => {
       it('should return an unparametrised version', () => {
         assertSome(
           findBestHttpContentByMediaType(
-            [{ id: faker.random.word(), mediaType: 'application/json' }],
+            [{ id: faker.string.alpha(), mediaType: 'application/json' }],
             ['application/json; version=1']
           )
         );

--- a/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
+++ b/packages/http/src/mocker/negotiator/__tests__/NegotiatorHelpers.spec.ts
@@ -6,7 +6,7 @@ import {
   INodeExample,
   INodeExternalExample,
 } from '@stoplight/types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import * as E from 'fp-ts/Either';
 import { left, right } from 'fp-ts/ReaderEither';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
@@ -29,10 +29,10 @@ const assertPayloadlessResponse = (actualResponse: E.Either<Error, IHttpNegotiat
 
 function anHttpOperation(givenHttpOperation?: IHttpOperation) {
   const httpOperation = givenHttpOperation || {
-    method: faker.random.word(),
+    method: faker.string.alpha(),
     path: faker.internet.url(),
-    responses: [{ id: faker.random.word(), code: '300' }],
-    id: faker.random.word(),
+    responses: [{ id: faker.string.alpha(), code: '300' }],
+    id: faker.string.alpha(),
     request: {},
   };
   return {
@@ -156,21 +156,21 @@ describe('NegotiatorHelpers', () => {
           httpOperation = anHttpOperation(httpOperation)
             .withResponses([
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 code: actualCode,
                 headers: [],
                 contents: [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     mediaType: actualMediaType + faker.random.word[0],
                   },
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     schema: { type: 'string' },
                     mediaType: actualMediaType,
                   },
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     schema: { type: 'number' },
                     mediaType: actualMediaType + faker.random.word[0],
                   },
@@ -194,18 +194,18 @@ describe('NegotiatorHelpers', () => {
           httpOperation = anHttpOperation(httpOperation)
             .withResponses([
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 code: actualCode,
                 headers: [],
                 contents: [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     mediaType: actualMediaType,
                     examples: [],
                     encodings: [],
                   },
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     mediaType: actualMediaType,
                     examples: [],
                     encodings: [],
@@ -230,16 +230,16 @@ describe('NegotiatorHelpers', () => {
         httpOperation = anHttpOperation(httpOperation)
           .withResponses([
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: '400',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: faker.system.mimeType(),
                   examples: [
-                    { id: faker.random.word(), key: faker.random.word(), value: '', externalValue: '' },
-                    { id: faker.random.word(), key: faker.random.word(), value: '', externalValue: '' },
+                    { id: faker.string.alpha(), key: faker.string.alpha(), value: '', externalValue: '' },
+                    { id: faker.string.alpha(), key: faker.string.alpha(), value: '', externalValue: '' },
                   ],
                   encodings: [],
                 },
@@ -256,16 +256,16 @@ describe('NegotiatorHelpers', () => {
         httpOperation = anHttpOperation(httpOperation)
           .withResponses([
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               code: 'default',
               headers: [],
               contents: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   mediaType: faker.system.mimeType(),
                   examples: [
-                    { id: faker.random.word(), key: faker.random.word(), value: '', externalValue: '' },
-                    { id: faker.random.word(), key: faker.random.word(), value: '', externalValue: '' },
+                    { id: faker.string.alpha(), key: faker.string.alpha(), value: '', externalValue: '' },
+                    { id: faker.string.alpha(), key: faker.string.alpha(), value: '', externalValue: '' },
                   ],
                   encodings: [],
                 },
@@ -351,9 +351,9 @@ describe('NegotiatorHelpers', () => {
     });
 
     it('given response defined should try to negotiate by that response', () => {
-      const code = faker.datatype.number();
+      const code = faker.number.int();
       const fakeResponse = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: code.toString(),
         contents: [],
         headers: [],
@@ -383,9 +383,9 @@ describe('NegotiatorHelpers', () => {
     });
 
     it('given response defined should fallback to default code on error', () => {
-      const code = faker.datatype.number();
+      const code = faker.number.int();
       const fakeResponse = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: code.toString(),
       };
       const desiredOptions = { dynamic: false };
@@ -415,7 +415,7 @@ describe('NegotiatorHelpers', () => {
     });
 
     it('given response not defined should fallback to default code', () => {
-      const code = faker.datatype.number();
+      const code = faker.number.int();
       const desiredOptions = { dynamic: false };
       httpOperation = anHttpOperation(httpOperation).instance();
 
@@ -429,7 +429,7 @@ describe('NegotiatorHelpers', () => {
     it('given only a generic 2XX response should negotiate that one', () => {
       const desiredOptions = { dynamic: false };
       const response = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '2xx',
         contents: [],
         headers: [],
@@ -453,7 +453,7 @@ describe('NegotiatorHelpers', () => {
     it('given two 2xx response should negotiate the lowest', () => {
       const desiredOptions = { dynamic: false };
       const response = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code: '200',
         contents: [],
         headers: [],
@@ -470,13 +470,13 @@ describe('NegotiatorHelpers', () => {
         .withResponses([
           response,
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '201',
             contents: [],
             headers: [],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '2xx',
             contents: [],
             headers: [],
@@ -507,18 +507,18 @@ describe('NegotiatorHelpers', () => {
         const desiredOptions = {
           mediaTypes: [faker.system.mimeType()],
           dynamic: faker.datatype.boolean(),
-          exampleKey: faker.random.word(),
+          exampleKey: faker.string.alpha(),
         };
 
         const contents: IMediaTypeContent = {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           mediaType: desiredOptions.mediaTypes[0],
           examples: [],
           encodings: [],
         };
 
         const httpResponseSchema: IHttpOperationResponse = {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           code: '200',
           contents: [contents],
           headers: [],
@@ -561,14 +561,14 @@ describe('NegotiatorHelpers', () => {
           };
 
           const contents: IMediaTypeContent[] = desiredOptions.mediaTypes.reverse().map(mediaType => ({
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType,
             encodings: [],
             examples: [],
           }));
 
           const httpResponseSchema: IHttpOperationResponse = {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '200',
             contents,
             headers: [],
@@ -590,14 +590,14 @@ describe('NegotiatorHelpers', () => {
           };
 
           const content: IMediaTypeContent = {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
             encodings: [],
             examples: [],
           };
 
           const httpResponseSchema: IHttpOperationResponse = {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '200',
             contents: [content],
             headers: [],
@@ -616,7 +616,7 @@ describe('NegotiatorHelpers', () => {
       describe('204 response', () => {
         it('returns an empty payload response when desired media type does not exist', () => {
           const httpResponseSchema: IHttpOperationResponse = {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '204',
             contents: [],
           };
@@ -638,7 +638,7 @@ describe('NegotiatorHelpers', () => {
 
       describe('the response exists, but there is no httpContent', () => {
         const httpResponseSchema: IHttpOperationResponse = {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           code: '200',
           contents: [],
         };
@@ -662,7 +662,7 @@ describe('NegotiatorHelpers', () => {
           const desiredOptions: NegotiationOptions = {
             mediaTypes: [faker.system.mimeType()],
             dynamic: faker.datatype.boolean(),
-            exampleKey: faker.random.word(),
+            exampleKey: faker.string.alpha(),
           };
 
           const actualResponse = helpers.negotiateOptionsBySpecificResponse(
@@ -683,11 +683,11 @@ describe('NegotiatorHelpers', () => {
           };
 
           const httpResponseSchema: IHttpOperationResponse = {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '200',
             contents: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 mediaType: 'text/plain',
               },
             ],
@@ -710,11 +710,11 @@ describe('NegotiatorHelpers', () => {
       it('should negotiate default media type', () => {
         const desiredOptions: NegotiationOptions = {
           dynamic: faker.datatype.boolean(),
-          exampleKey: faker.random.word(),
+          exampleKey: faker.string.alpha(),
         };
 
         const httpResponseSchema: IHttpOperationResponse = {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           code: '200',
           contents: [],
           headers: [],
@@ -759,22 +759,22 @@ describe('NegotiatorHelpers', () => {
         ['*/*', 'application/json'],
         ['application/json', 'application/xml'],
       ])('should return %s even when %s is available', (defaultMediaType, alternateMediaType) => {
-        const code = faker.random.word();
+        const code = faker.string.alpha();
         const partialOptions = {
           code,
           dynamic: faker.datatype.boolean(),
-          exampleKey: faker.random.word(),
+          exampleKey: faker.string.alpha(),
         };
 
         const contents: IMediaTypeContent[] = [alternateMediaType, defaultMediaType].map(mediaType => ({
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           mediaType,
           examples: [],
           encodings: [],
         }));
 
         const response: IHttpOperationResponse = {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           code,
           contents,
           headers: [],
@@ -807,10 +807,10 @@ describe('NegotiatorHelpers', () => {
     });
 
     describe('when no default response', () => {
-      const code = faker.random.word();
+      const code = faker.string.alpha();
       const partialOptions = { code: '200', dynamic: false };
       const response: IHttpOperationResponse = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code,
         contents: [],
         headers: [],
@@ -838,24 +838,24 @@ describe('NegotiatorHelpers', () => {
   });
 
   describe('when multiple responses', () => {
-    const code = faker.random.word();
+    const code = faker.string.alpha();
     const partialOptions = { code: '200', dynamic: false };
 
     describe('and json is among them', () => {
       const negotiationResult = helpers.negotiateDefaultMediaType(partialOptions, {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code,
         headers: [],
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'text/plain',
-            examples: [{ id: faker.random.word(), key: 'hey', value: {} }],
+            examples: [{ id: faker.string.alpha(), key: 'hey', value: {} }],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/json',
-            examples: [{ id: faker.random.word(), key: 'hey', value: {} }],
+            examples: [{ id: faker.string.alpha(), key: 'hey', value: {} }],
           },
         ],
       });
@@ -869,19 +869,19 @@ describe('NegotiatorHelpers', () => {
 
     describe('and json is not them', () => {
       const negotiationResult = helpers.negotiateDefaultMediaType(partialOptions, {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         code,
         headers: [],
         contents: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'application/xml',
-            examples: [{ id: faker.random.word(), key: 'hey', value: {} }],
+            examples: [{ id: faker.string.alpha(), key: 'hey', value: {} }],
           },
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             mediaType: 'text/plain',
-            examples: [{ id: faker.random.word(), key: 'hey', value: {} }],
+            examples: [{ id: faker.string.alpha(), key: 'hey', value: {} }],
           },
         ],
       });
@@ -898,20 +898,20 @@ describe('NegotiatorHelpers', () => {
 describe('negotiateByPartialOptionsAndHttpContent()', () => {
   describe('given exampleKey forced', () => {
     it('and example exists should return that example', () => {
-      const exampleKey = faker.random.word();
+      const exampleKey = faker.string.alpha();
       const partialOptions = {
         code: '200',
         exampleKey,
         dynamic: faker.datatype.boolean(),
       };
       const bodyExample: INodeExample = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         key: exampleKey,
         value: '',
       };
 
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [bodyExample],
         encodings: [],
@@ -931,14 +931,14 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
     });
 
     it('and example not exist should throw an error', () => {
-      const exampleKey = faker.random.word();
+      const exampleKey = faker.string.alpha();
       const partialOptions = {
         code: '200',
         exampleKey,
         dynamic: faker.datatype.boolean(),
       };
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [],
         encodings: [],
@@ -958,7 +958,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [],
         schema: { type: 'string' },
@@ -982,7 +982,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: true,
       };
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [],
         encodings: [],
@@ -1005,19 +1005,19 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         dynamic: false,
       };
       const bodyExample: INodeExample | INodeExternalExample = {
-        id: faker.random.word(),
-        key: faker.random.word(),
+        id: faker.string.alpha(),
+        key: faker.string.alpha(),
         value: '',
         externalValue: '',
       };
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [
           bodyExample,
           {
-            id: faker.random.word(),
-            key: faker.random.word(),
+            id: faker.string.alpha(),
+            key: faker.string.alpha(),
             value: '',
             externalValue: '',
           },
@@ -1043,7 +1043,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
         code: '200',
       };
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [],
         schema: { type: 'string' },
@@ -1068,7 +1068,7 @@ describe('negotiateByPartialOptionsAndHttpContent()', () => {
       };
 
       const httpContent: IMediaTypeContent = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: faker.system.mimeType(),
         examples: [],
         encodings: [],

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -1,4 +1,4 @@
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
 import { HttpMethod, IHttpOperation, IServer } from '@stoplight/types';
 import { isRight } from 'fp-ts/Either';
@@ -15,10 +15,10 @@ import { pickSetOfHttpMethods, pickOneHttpMethod, randomPath } from './utils';
 
 function createResource(method: string, path: string, servers: IServer[]): IHttpOperation {
   return {
-    id: faker.datatype.uuid(),
+    id: faker.string.uuid(),
     method,
     path,
-    responses: [{ id: faker.random.word(), code: '200' }],
+    responses: [{ id: faker.string.alpha(), code: '200' }],
     servers,
     security: [],
     request: { path: [], query: [], cookie: [], headers: [] },
@@ -92,7 +92,7 @@ describe('http router', () => {
             resources: [
               createResource(resourceMethod, randomPath(), [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   url,
                 },
               ]),
@@ -121,7 +121,7 @@ describe('http router', () => {
               resources: [
                 createResource(method, path, [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     url,
                   },
                 ]),
@@ -143,7 +143,7 @@ describe('http router', () => {
           const path = randomPath({ includeTemplates: false });
           const expectedResource = createResource(method, path, [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               url,
             },
           ]);
@@ -167,8 +167,8 @@ describe('http router', () => {
             assertLeft(
               route({
                 resources: [
-                  createResource(method, '/pet', [{ id: faker.random.word(), url: 'http://example.com/api' }]),
-                  createResource(method, '/owner', [{ id: faker.random.word(), url: 'http://stg.example.com/api/v2' }]),
+                  createResource(method, '/pet', [{ id: faker.string.alpha(), url: 'http://example.com/api' }]),
+                  createResource(method, '/owner', [{ id: faker.string.alpha(), url: 'http://stg.example.com/api/v2' }]),
                 ],
                 input: {
                   method,
@@ -187,7 +187,7 @@ describe('http router', () => {
           const path = randomPath({ includeTemplates: false });
           const expectedResource = createResource(method, path, [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               url,
               variables: {
                 host: {
@@ -217,7 +217,7 @@ describe('http router', () => {
           const path = '/{x}/b';
           const expectedResource = createResource(method, path, [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               url,
               variables: {
                 host: {
@@ -248,7 +248,7 @@ describe('http router', () => {
           const requestPath = '/a/x/c';
           const expectedResource = createResource(method, templatedPath, [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               url,
             },
           ]);
@@ -274,7 +274,7 @@ describe('http router', () => {
           const requestPath = '/a/y/b';
           const expectedResource = createResource(method, templatedPath, [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               url,
             },
           ]);
@@ -298,8 +298,8 @@ describe('http router', () => {
           const templatedPath = '/{x}/y';
           const concretePath = '/a/y';
           const url = 'concrete.com';
-          const resourceWithConcretePath = createResource(method, concretePath, [{ id: faker.random.word(), url }]);
-          const resourceWithTemplatedPath = createResource(method, templatedPath, [{ id: faker.random.word(), url }]);
+          const resourceWithConcretePath = createResource(method, concretePath, [{ id: faker.string.alpha(), url }]);
+          const resourceWithTemplatedPath = createResource(method, templatedPath, [{ id: faker.string.alpha(), url }]);
 
           assertRight(
             route({
@@ -320,8 +320,8 @@ describe('http router', () => {
           const templatedPathA = '/{x}/y';
           const templatedPathB = '/a/{z}';
           const url = 'concrete.com';
-          const firstResource = createResource(method, templatedPathA, [{ id: faker.random.word(), url }]);
-          const secondResource = createResource(method, templatedPathB, [{ id: faker.random.word(), url }]);
+          const firstResource = createResource(method, templatedPathA, [{ id: faker.string.alpha(), url }]);
+          const secondResource = createResource(method, templatedPathB, [{ id: faker.string.alpha(), url }]);
 
           assertRight(
             route({
@@ -342,12 +342,12 @@ describe('http router', () => {
           const path = '/';
           const url = 'concrete.com';
           const resourceWithConcreteMatch = createResource(method, path, [
-            { id: faker.random.word(), url },
-            { id: faker.random.word(), url: '{template}', variables: { template: { default: url, enum: [url] } } },
+            { id: faker.string.alpha(), url },
+            { id: faker.string.alpha(), url: '{template}', variables: { template: { default: url, enum: [url] } } },
           ]);
 
           const resourceWithTemplatedMatch = createResource(method, path, [
-            { id: faker.random.word(), url: '{template}', variables: { template: { default: url, enum: [url] } } },
+            { id: faker.string.alpha(), url: '{template}', variables: { template: { default: url, enum: [url] } } },
           ]);
 
           assertRight(
@@ -369,9 +369,9 @@ describe('http router', () => {
           const matchingPath = '/a/b/c';
           const nonMatchingPath = '/a/b/c/d';
           const url = 'concrete.com';
-          const resourceWithMatchingPath = createResource(method, matchingPath, [{ id: faker.random.word(), url }]);
+          const resourceWithMatchingPath = createResource(method, matchingPath, [{ id: faker.string.alpha(), url }]);
           const resourceWithNonMatchingPath = createResource(method, nonMatchingPath, [
-            { id: faker.random.word(), url },
+            { id: faker.string.alpha(), url },
           ]);
 
           assertRight(
@@ -392,7 +392,7 @@ describe('http router', () => {
         test('given empty baseUrl and concrete server it should match', () => {
           const path = randomPath({ includeTemplates: false });
           const url = 'concrete.com';
-          const expectedResource = createResource(method, path, [{ id: faker.random.word(), url }]);
+          const expectedResource = createResource(method, path, [{ id: faker.string.alpha(), url }]);
 
           assertRight(
             route({
@@ -415,7 +415,7 @@ describe('http router', () => {
 
           assertLeft(
             route({
-              resources: [createResource(method, path, [{ id: faker.random.word(), url }])],
+              resources: [createResource(method, path, [{ id: faker.string.alpha(), url }])],
               input: {
                 method,
                 url: {
@@ -431,7 +431,7 @@ describe('http router', () => {
         test('given empty baseUrl and empty server url it should match', () => {
           const path = randomPath({ includeTemplates: false });
           const url = '';
-          const expectedResource = createResource(method, path, [{ id: faker.random.word(), url }]);
+          const expectedResource = createResource(method, path, [{ id: faker.string.alpha(), url }]);
 
           assertRight(
             route({
@@ -451,7 +451,7 @@ describe('http router', () => {
         test('given no baseUrl and a server url it should ignore servers and match by path', () => {
           const path = randomPath({ includeTemplates: false });
           const expectedResource = createResource(method, path, [
-            { id: faker.random.word(), url: 'www.stoplight.io/v1' },
+            { id: faker.string.alpha(), url: 'www.stoplight.io/v1' },
           ]);
 
           assertRight(
@@ -495,7 +495,7 @@ describe('http router', () => {
 
           const expectedResource = createResource(method, path, [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               url,
             },
           ]);
@@ -544,7 +544,7 @@ describe('http router', () => {
 
         assertLeft(
           route({
-            resources: [createResource(method, path, [{ id: faker.random.word(), url }])],
+            resources: [createResource(method, path, [{ id: faker.string.alpha(), url }])],
             input: {
               method: 'post',
               url: {

--- a/packages/http/src/router/__tests__/matchBaseUrl.spec.ts
+++ b/packages/http/src/router/__tests__/matchBaseUrl.spec.ts
@@ -1,14 +1,14 @@
 import { convertTemplateToRegExp, matchBaseUrl } from '../matchBaseUrl';
 import { MatchType } from '../types';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 describe('matchServer.ts', () => {
   describe('matchServer()', () => {
     test('concrete server url fully matches request url', () => {
       const serverMatch = matchBaseUrl(
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           url: 'http://www.example.com/',
         },
         'http://www.example.com/'
@@ -19,29 +19,29 @@ describe('matchServer.ts', () => {
 
     test('concrete server url does not match request url', () => {
       assertRight(
-        matchBaseUrl({ id: faker.random.word(), url: 'http://www.example.com' }, 'http://www.example.com/'),
+        matchBaseUrl({ id: faker.string.alpha(), url: 'http://www.example.com' }, 'http://www.example.com/'),
         result => expect(result).toBe(MatchType.NOMATCH)
       );
 
       assertRight(
-        matchBaseUrl({ id: faker.random.word(), url: 'http://www.example.com' }, 'http://www.example'),
+        matchBaseUrl({ id: faker.string.alpha(), url: 'http://www.example.com' }, 'http://www.example'),
         result => expect(result).toBe(MatchType.NOMATCH)
       );
 
       assertRight(
-        matchBaseUrl({ id: faker.random.word(), url: 'http://www.example.com' }, 'http://www.google.com/'),
+        matchBaseUrl({ id: faker.string.alpha(), url: 'http://www.example.com' }, 'http://www.google.com/'),
         result => expect(result).toBe(MatchType.NOMATCH)
       );
 
       assertRight(
-        matchBaseUrl({ id: faker.random.word(), url: 'http://www.example.com:8081/v1' }, 'http://www.example.com/v1'),
+        matchBaseUrl({ id: faker.string.alpha(), url: 'http://www.example.com:8081/v1' }, 'http://www.example.com/v1'),
         result => expect(result).toBe(MatchType.NOMATCH)
       );
     });
 
     test('entirely templated server url to match request from enum', () => {
       const serverConfig = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         url: '{url}',
         variables: {
           url: {
@@ -69,7 +69,7 @@ describe('matchServer.ts', () => {
       assertRight(
         matchBaseUrl(
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             url: 'http://{host}/v1',
             variables: {
               host: { default: 'www.example.com' },
@@ -83,7 +83,7 @@ describe('matchServer.ts', () => {
 
     test('server url with templated enum host to match request url', () => {
       const serverConfig = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         url: 'http://{host}/v1',
         variables: {
           host: {
@@ -104,7 +104,7 @@ describe('matchServer.ts', () => {
 
     describe('a complex server template should match request url', () => {
       const serverConfig = {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         url: '{protocol}://{username}@{host}/{path}',
         variables: {
           protocol: {

--- a/packages/http/src/router/__tests__/matchPath.spec.ts
+++ b/packages/http/src/router/__tests__/matchPath.spec.ts
@@ -1,5 +1,5 @@
 import { matchPath } from '../matchPath';
-import faker from '@faker-js/faker';
+import { faker } from '@faker-js/faker/locale/en';
 import { MatchType } from '../types';
 import { randomPath } from './utils';
 import { assertRight } from '@stoplight/prism-core/src/__tests__/utils';
@@ -13,7 +13,7 @@ describe('matchPath()', () => {
   test('any concrete path with spaces should match an equal concrete path', () => {
     // e.g. /a b/c should match /a b/c
     const path = randomPath({
-      pathFragments: faker.datatype.number({ min: 2, max: 6 }),
+      pathFragments: faker.number.int({ min: 2, max: 6 }),
       includeTemplates: false,
       includeSpaces: true,
     });
@@ -24,7 +24,7 @@ describe('matchPath()', () => {
   test('any concrete path should match an equal concrete path', () => {
     // e.g. /a/b/c should match /a/b/c
     const path = randomPath({
-      pathFragments: faker.datatype.number({ min: 1, max: 6 }),
+      pathFragments: faker.number.int({ min: 1, max: 6 }),
       includeTemplates: false,
     });
 
@@ -34,7 +34,7 @@ describe('matchPath()', () => {
   test('any concrete path with colon should match an equal concrete path', () => {
     // e.g. /a/b:c should match /a/b:c
     const path = randomPath({
-      pathFragments: faker.datatype.number({ min: 2, max: 6 }),
+      pathFragments: faker.number.int({ min: 2, max: 6 }),
       includeTemplates: false,
       includeColon: true,
     });
@@ -47,12 +47,12 @@ describe('matchPath()', () => {
     // e.g. /a/b/c should not match /{a}/b
     const trailingSlash = faker.datatype.boolean();
     const requestPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
+      pathFragments: faker.number.int({ min: 4, max: 6 }),
       includeTemplates: false,
       trailingSlash,
     });
     const operationPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
+      pathFragments: faker.number.int({ min: 1, max: 3 }),
       trailingSlash,
     });
 
@@ -63,7 +63,7 @@ describe('matchPath()', () => {
     // e.g. /a/b:c should not match /a/b
     // e.g. /a/b:c should not match /{a}/b
     const requestPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 5, max: 7 }),
+      pathFragments: faker.number.int({ min: 5, max: 7 }),
       includeTemplates: false,
       includeColon: true,
     });
@@ -74,7 +74,7 @@ describe('matchPath()', () => {
   test('none request path with a colon should not match equivalent slash path', () => {
     // e.g. /a/b:c should not match /a/b/c
     const requestPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 5, max: 7 }),
+      pathFragments: faker.number.int({ min: 5, max: 7 }),
       includeTemplates: false,
       includeColon: true,
     });
@@ -87,11 +87,11 @@ describe('matchPath()', () => {
     // e.g. /a/b should not match /a/b/c
     // e.g. /a/b/ should not match /a/b/c
     const requestPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
+      pathFragments: faker.number.int({ min: 4, max: 6 }),
       includeTemplates: false,
     });
     const operationPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
+      pathFragments: faker.number.int({ min: 1, max: 3 }),
       includeTemplates: false,
     });
 
@@ -102,13 +102,13 @@ describe('matchPath()', () => {
     // e.g. /a/b:c should not match /a/b/c:d
     // e.g. /a/b:c should not match /{a}/b/c:d
     const requestPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 5, max: 7 }),
+      pathFragments: faker.number.int({ min: 5, max: 7 }),
       includeTemplates: false,
       includeColon: true,
     });
     const newPath = requestPath.split(':').shift();
     const lastWord = requestPath.split(':').pop();
-    const operationPath = [newPath, '/', lastWord, ':', faker.random.word()].join('');
+    const operationPath = [newPath, '/', lastWord, ':', faker.string.alpha()].join('');
 
     assertRight(matchPath(requestPath, operationPath), e => expect(e).toEqual(MatchType.NOMATCH));
   });
@@ -150,13 +150,13 @@ describe('matchPath()', () => {
     // e.g. `/a/b` should not match /{x}/{y}/{z}
     // e.g. `/a` should not match /{x}/{y}/{z}
     const requestPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 1, max: 3 }),
+      pathFragments: faker.number.int({ min: 1, max: 3 }),
       includeTemplates: false,
       trailingSlash: false,
     });
 
     const operationPath = randomPath({
-      pathFragments: faker.datatype.number({ min: 4, max: 6 }),
+      pathFragments: faker.number.int({ min: 4, max: 6 }),
       includeTemplates: true,
       trailingSlash: false,
     });

--- a/packages/http/src/router/__tests__/utils.ts
+++ b/packages/http/src/router/__tests__/utils.ts
@@ -1,5 +1,5 @@
 import { HttpMethod } from '@stoplight/types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { defaults } from 'lodash/fp';
 import { DeepNonNullable } from 'utility-types';
 
@@ -40,7 +40,7 @@ export function randomPath(opts: IRandomPathOptions = defaultRandomPathOptions):
   }
 
   const randomPathFragments = new Array(options.pathFragments).fill(0).map(() => {
-    const words = faker.random.words(options.includeSpaces ? 3 : 1);
+    const words = faker.word.words(options.includeSpaces ? 3 : 1);
     return options.includeTemplates && faker.datatype.boolean() ? `{${words}}` : words;
   });
 

--- a/packages/http/src/validator/__tests__/functional.spec.ts
+++ b/packages/http/src/validator/__tests__/functional.spec.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity, HttpParamStyles, IHttpOperation } from '@stoplight/
 import { httpInputs, httpOperations, httpOutputs } from '../../__tests__/fixtures';
 import { validateInput, validateOutput } from '../index';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 const BAD_INPUT = Object.assign({}, httpInputs[2], {
   body: { name: 'Shopping', completed: 'yes' },
@@ -37,14 +37,14 @@ describe('HttpValidator', () => {
                 path: '/todos',
                 responses: [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     code: '200',
                   },
                 ],
                 request: {
                   query: [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       name: 'updated_since',
                       schema: {
                         type: 'string',
@@ -81,14 +81,14 @@ describe('HttpValidator', () => {
         path: '/test',
         responses: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '200',
           },
         ],
         request: {
           query: [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               style: HttpParamStyles.Form,
               deprecated: true,
               name: 'productId',
@@ -148,7 +148,7 @@ describe('HttpValidator', () => {
               path: '/hey',
               responses: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   code: '200',
                 },
               ],
@@ -156,7 +156,7 @@ describe('HttpValidator', () => {
               request: {
                 headers: [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     name: 'API_KEY',
                     style: HttpParamStyles.Simple,
                     schema: {

--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -6,7 +6,7 @@ import * as validators from '../validators';
 import * as validator from '../';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import { ValidationContext } from '../validators/types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 const validate =
   (resourceExtension?: Partial<IHttpOperation>, inputExtension?: Partial<IHttpRequest>, length = 3) =>
@@ -18,7 +18,7 @@ const validate =
           path: '/',
           id: '1',
           request: {},
-          responses: [{ id: faker.random.word(), code: '200' }],
+          responses: [{ id: faker.string.alpha(), code: '200' }],
         },
         resourceExtension
       ),
@@ -52,7 +52,7 @@ describe('HttpValidator', () => {
         describe('request body is not required', () => {
           it(
             'does not try to validate the body',
-            validate({ request: { body: { id: faker.random.word(), required: false, contents: [] } } }, undefined, 0)
+            validate({ request: { body: { id: faker.string.alpha(), required: false, contents: [] } } }, undefined, 0)
           );
         });
 
@@ -64,8 +64,8 @@ describe('HttpValidator', () => {
                 method: 'get',
                 path: '/',
                 id: '1',
-                request: { body: { id: faker.random.word(), contents: [], required: true } },
-                responses: [{ id: faker.random.word(), code: '200' }],
+                request: { body: { id: faker.string.alpha(), contents: [], required: true } },
+                responses: [{ id: faker.string.alpha(), code: '200' }],
               },
               undefined,
               1
@@ -98,7 +98,7 @@ describe('HttpValidator', () => {
               {
                 request: {
                   query: [
-                    { id: faker.random.word(), style: HttpParamStyles.SpaceDelimited, name: 'hey', required: true },
+                    { id: faker.string.alpha(), style: HttpParamStyles.SpaceDelimited, name: 'hey', required: true },
                   ],
                 },
               },
@@ -125,11 +125,11 @@ describe('HttpValidator', () => {
                 id: '1',
                 request: {
                   path: [
-                    { id: faker.random.word(), name: 'a', style: HttpParamStyles.Simple },
-                    { id: faker.random.word(), name: 'b', style: HttpParamStyles.Matrix },
+                    { id: faker.string.alpha(), name: 'a', style: HttpParamStyles.Simple },
+                    { id: faker.string.alpha(), name: 'b', style: HttpParamStyles.Matrix },
                   ],
                 },
-                responses: [{ id: faker.random.word(), code: '200' }],
+                responses: [{ id: faker.string.alpha(), code: '200' }],
               },
               element: { method: 'get', url: { path: '/a/1/b/;b=2' } },
             });
@@ -159,11 +159,11 @@ describe('HttpValidator', () => {
                 id: '1',
                 request: {
                   path: [
-                    { id: faker.random.word(), name: 'a-id', style: HttpParamStyles.Simple },
-                    { id: faker.random.word(), name: 'b-id', style: HttpParamStyles.Matrix },
+                    { id: faker.string.alpha(), name: 'a-id', style: HttpParamStyles.Simple },
+                    { id: faker.string.alpha(), name: 'b-id', style: HttpParamStyles.Matrix },
                   ],
                 },
-                responses: [{ id: faker.random.word(), code: '200' }],
+                responses: [{ id: faker.string.alpha(), code: '200' }],
               },
               element: { method: 'get', url: { path: '/a-path/1/b/;b-id=2' } },
             });
@@ -197,11 +197,11 @@ describe('HttpValidator', () => {
               __bundled__: { OutputType: { type: 'string' } },
               responses: [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   code: '200',
                   contents: [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       mediaType: 'application/json',
                       schema: {
                         type: 'object',
@@ -247,7 +247,7 @@ describe('HttpValidator', () => {
                 path: '/',
                 id: '1',
                 request: {},
-                responses: [{ id: faker.random.word(), code: '200' }],
+                responses: [{ id: faker.string.alpha(), code: '200' }],
               },
               element: { statusCode: 200 },
             }),
@@ -277,9 +277,9 @@ describe('HttpValidator', () => {
                 request: {},
                 responses: [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     code: '200',
-                    contents: [{ id: faker.random.word(), mediaType: 'application/json' }],
+                    contents: [{ id: faker.string.alpha(), mediaType: 'application/json' }],
                   },
                 ],
               },
@@ -304,7 +304,7 @@ describe('HttpValidator', () => {
         path: '/',
         id: '1',
         request: {},
-        responses: [{ id: faker.random.word(), code: '200' }],
+        responses: [{ id: faker.string.alpha(), code: '200' }],
       };
 
       describe('when the desidered response is between 200 and 300', () => {
@@ -342,18 +342,18 @@ describe('HttpValidator', () => {
         request: {},
         responses: [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             code: '200',
             contents: [
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 mediaType: 'application/json',
                 schema: {
                   type: 'string',
                 },
               },
               {
-                id: faker.random.word(),
+                id: faker.string.alpha(),
                 mediaType: 'image/*',
                 schema: {
                   type: 'string',
@@ -411,7 +411,7 @@ describe('HttpValidator', () => {
 describe('validateMediaType()', () => {
   describe('when available content type does not have parameters', () => {
     const content: IMediaTypeContent = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       mediaType: 'application/vnd.archa.api+json',
     };
 

--- a/packages/http/src/validator/utils/__tests__/spec.spec.ts
+++ b/packages/http/src/validator/utils/__tests__/spec.spec.ts
@@ -1,6 +1,6 @@
 import { assertNone, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { findOperationResponse } from '../spec';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 describe('findOperationResponse()', () => {
   describe('when response for given code exists', () => {
@@ -8,10 +8,10 @@ describe('findOperationResponse()', () => {
       assertSome(
         findOperationResponse(
           [
-            { id: faker.random.word(), code: '2XX', contents: [], headers: [] },
-            { id: faker.random.word(), code: '20X', contents: [], headers: [] },
-            { id: faker.random.word(), code: 'default', contents: [], headers: [] },
-            { id: faker.random.word(), code: '1XX', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '2XX', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '20X', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: 'default', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '1XX', contents: [], headers: [] },
           ],
           200
         ),
@@ -25,9 +25,9 @@ describe('findOperationResponse()', () => {
       assertSome(
         findOperationResponse(
           [
-            { id: faker.random.word(), code: '2XX', contents: [], headers: [] },
-            { id: faker.random.word(), code: 'default', contents: [], headers: [] },
-            { id: faker.random.word(), code: '1XX', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '2XX', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: 'default', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '1XX', contents: [], headers: [] },
           ],
           422
         ),
@@ -41,8 +41,8 @@ describe('findOperationResponse()', () => {
       assertNone(
         findOperationResponse(
           [
-            { id: faker.random.word(), code: '2XX', contents: [], headers: [] },
-            { id: faker.random.word(), code: '1XX', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '2XX', contents: [], headers: [] },
+            { id: faker.string.alpha(), code: '1XX', contents: [], headers: [] },
           ],
           500
         )

--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -3,7 +3,7 @@ import { JSONSchema } from '../../..';
 import { validate, findContentByMediaTypeOrFirst, decodeUriEntities } from '../body';
 import { assertRight, assertLeft, assertSome } from '@stoplight/prism-core/src/__tests__/utils';
 import { ValidationContext } from '../types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 describe('validate()', () => {
   describe('content specs are missing', () => {
@@ -17,7 +17,7 @@ describe('validate()', () => {
       assertRight(
         validate(
           'test',
-          [{ id: faker.random.word(), mediaType: 'application/not-exists-son', examples: [], encodings: [] }],
+          [{ id: faker.string.alpha(), mediaType: 'application/not-exists-son', examples: [], encodings: [] }],
           ValidationContext.Input
         )
       );
@@ -29,7 +29,7 @@ describe('validate()', () => {
       assertRight(
         validate(
           'test',
-          [{ id: faker.random.word(), mediaType: 'application/not-exists-son', examples: [], encodings: [] }],
+          [{ id: faker.string.alpha(), mediaType: 'application/not-exists-son', examples: [], encodings: [] }],
           ValidationContext.Input,
           'application/json'
         )
@@ -43,7 +43,7 @@ describe('validate()', () => {
       assertLeft(
         validate(
           'test',
-          [{ id: faker.random.word(), mediaType: 'application/json', schema: mockSchema, examples: [], encodings: [] }],
+          [{ id: faker.string.alpha(), mediaType: 'application/json', schema: mockSchema, examples: [], encodings: [] }],
           ValidationContext.Input,
           'application/json'
         ),
@@ -62,7 +62,7 @@ describe('validate()', () => {
           encodeURI('key[a]=str'),
           [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               mediaType: 'application/x-www-form-urlencoded',
               encodings: [{ property: 'key', style: HttpParamStyles.DeepObject }],
               schema: {
@@ -92,7 +92,7 @@ describe('validate()', () => {
           encodeURI('key[a][ab]=str'),
           [
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               mediaType: 'application/x-www-form-urlencoded',
               encodings: [{ property: 'key', style: HttpParamStyles.DeepObject }],
               schema: {
@@ -131,7 +131,7 @@ describe('validate()', () => {
   describe('readOnly writeOnly parameters', () => {
     const specs: IMediaTypeContent[] = [
       {
-        id: faker.random.word(),
+        id: faker.string.alpha(),
         mediaType: 'application/json',
         schema: {
           type: 'object',
@@ -182,7 +182,7 @@ describe('validate()', () => {
       // Arrange
       const schemas: IMediaTypeContent[] = [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           mediaType: 'application/json',
           schema: {
             type: 'object',
@@ -212,7 +212,7 @@ describe('validate()', () => {
       // Arrange
       const schemas: IMediaTypeContent[] = [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           mediaType: 'application/json',
           schema: {
             type: 'object',
@@ -239,7 +239,7 @@ describe('validate()', () => {
       // Arrange
       const schemas: IMediaTypeContent[] = [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           mediaType: 'application/json',
           schema: {
             type: 'object',
@@ -268,7 +268,7 @@ describe('validate()', () => {
 describe('findContentByMediaTypeOrFirst()', () => {
   describe('when a spec has a content type', () => {
     const content: IMediaTypeContent = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       mediaType: 'application/x-www-form-urlencoded',
     };
 

--- a/packages/http/src/validator/validators/__tests__/headers.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/headers.spec.ts
@@ -3,7 +3,7 @@ import { validate } from '../headers';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import * as O from 'fp-ts/Option';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { ValidationContext } from '../types';
 
 describe('validate()', () => {
@@ -18,7 +18,7 @@ describe('validate()', () => {
           assertLeft(
             validate(
               {},
-              [{ id: faker.random.word(), name: 'aHeader', style: HttpParamStyles.Simple, required: true }],
+              [{ id: faker.string.alpha(), name: 'aHeader', style: HttpParamStyles.Simple, required: true }],
               ValidationContext.Input
             ),
             error =>
@@ -43,7 +43,7 @@ describe('validate()', () => {
                   { 'x-test-header': 'abc' },
                   [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       name: 'x-test-header',
                       style: HttpParamStyles.Simple,
                       schema: { type: 'string' },
@@ -66,7 +66,7 @@ describe('validate()', () => {
               { 'x-test-header': 'abc' },
               [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'x-test-header',
                   style: HttpParamStyles.Simple,
                 },
@@ -86,7 +86,7 @@ describe('validate()', () => {
               { 'x-test-header': 'abc' },
               [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'x-test-header',
                   deprecated: true,
                   style: HttpParamStyles.Simple,

--- a/packages/http/src/validator/validators/__tests__/path.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/path.spec.ts
@@ -3,7 +3,7 @@ import { validate } from '../path';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertLeft, assertRight } from '@stoplight/prism-core/src/__tests__/utils';
 import * as O from 'fp-ts/Option';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { ValidationContext } from '../types';
 
 describe('validate()', () => {
@@ -19,7 +19,7 @@ describe('validate()', () => {
           assertLeft(
             validate(
               {},
-              [{ id: faker.random.word(), name: 'aParam', style: HttpParamStyles.Simple, required: true }],
+              [{ id: faker.string.alpha(), name: 'aParam', style: HttpParamStyles.Simple, required: true }],
               ValidationContext.Input
             ),
             error =>
@@ -46,7 +46,7 @@ describe('validate()', () => {
                   { param: 'abc' },
                   [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       name: 'param',
                       style: HttpParamStyles.Simple,
                       schema: { type: 'string' },
@@ -69,7 +69,7 @@ describe('validate()', () => {
               { param: 'abc' },
               [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'param',
                   style: HttpParamStyles.Simple,
                 },
@@ -89,7 +89,7 @@ describe('validate()', () => {
               { param: 'abc' },
               [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'param',
                   deprecated: true,
                   style: HttpParamStyles.Simple,

--- a/packages/http/src/validator/validators/__tests__/query.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/query.spec.ts
@@ -3,7 +3,7 @@ import { validate } from '../query';
 import * as validateAgainstSchemaModule from '../utils';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import * as O from 'fp-ts/Option';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 import { ValidationContext } from '../types';
 
 describe('validate()', () => {
@@ -18,7 +18,7 @@ describe('validate()', () => {
           assertLeft(
             validate(
               {},
-              [{ id: faker.random.word(), name: 'aParam', style: HttpParamStyles.Form, required: true }],
+              [{ id: faker.string.alpha(), name: 'aParam', style: HttpParamStyles.Form, required: true }],
               ValidationContext.Input
             ),
             error => expect(error).toContainEqual(expect.objectContaining({ severity: DiagnosticSeverity.Error }))
@@ -37,7 +37,7 @@ describe('validate()', () => {
                   { param: 'abc' },
                   [
                     {
-                      id: faker.random.word(),
+                      id: faker.string.alpha(),
                       name: 'param',
                       style: HttpParamStyles.Form,
                       schema: { type: 'string' },
@@ -60,7 +60,7 @@ describe('validate()', () => {
               { param: 'abc' },
               [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'param',
                   style: HttpParamStyles.Form,
                 },
@@ -80,7 +80,7 @@ describe('validate()', () => {
               { param: 'abc' },
               [
                 {
-                  id: faker.random.word(),
+                  id: faker.string.alpha(),
                   name: 'param',
                   deprecated: true,
                   style: HttpParamStyles.Form,

--- a/packages/http/src/validator/validators/security/__tests__/security.spec.ts
+++ b/packages/http/src/validator/validators/security/__tests__/security.spec.ts
@@ -2,7 +2,7 @@ import { DiagnosticSeverity, HttpSecurityScheme } from '@stoplight/types';
 import { validateSecurity } from '../';
 import { assertRight, assertLeft } from '@stoplight/prism-core/src/__tests__/utils';
 import { IHttpRequest } from '../../../../types';
-import * as faker from '@faker-js/faker/locale/en';
+import { faker } from '@faker-js/faker/locale/en';
 
 const baseRequest: IHttpRequest = {
   method: 'get',
@@ -20,11 +20,11 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           scheme: 'basic',
           type: 'http',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
     ];
@@ -79,11 +79,11 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           scheme: 'digest',
           type: 'http',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
     ];
@@ -123,11 +123,11 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           scheme: 'bearer',
           type: 'http',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
     ];
@@ -164,11 +164,11 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           type: 'oauth2',
           flows: {},
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
     ];
@@ -205,11 +205,11 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           type: 'openIdConnect',
           openIdConnectUrl: 'https://google.it',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
     ];
@@ -252,19 +252,19 @@ describe('validateSecurity', () => {
               security: [
                 [
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     scheme: 'basic',
                     type: 'http',
                     key: 'sec',
-                    extensions: { 'x-test': faker.random.word() },
+                    extensions: { 'x-test': faker.string.alpha() },
                   },
                   {
-                    id: faker.random.word(),
+                    id: faker.string.alpha(),
                     in: 'header',
                     type: 'apiKey',
                     name: 'x-api-key',
                     key: 'sec',
-                    extensions: { 'x-test': faker.random.word() },
+                    extensions: { 'x-test': faker.string.alpha() },
                   },
                 ],
               ],
@@ -287,12 +287,12 @@ describe('validateSecurity', () => {
       const securityScheme: HttpSecurityScheme[][] = [
         [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             in: 'header',
             type: 'apiKey',
             name: 'x-api-key',
             key: 'sec',
-            extensions: { 'x-test': faker.random.word() },
+            extensions: { 'x-test': faker.string.alpha() },
           },
         ],
       ];
@@ -326,12 +326,12 @@ describe('validateSecurity', () => {
       const securityScheme: HttpSecurityScheme[][] = [
         [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             in: 'query',
             type: 'apiKey',
             name: 'key',
             key: 'sec',
-            extensions: { 'x-test': faker.random.word() },
+            extensions: { 'x-test': faker.string.alpha() },
           },
         ],
       ];
@@ -363,12 +363,12 @@ describe('validateSecurity', () => {
       const securityScheme: HttpSecurityScheme[][] = [
         [
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             in: 'cookie',
             type: 'apiKey',
             name: 'key',
             key: 'sec',
-            extensions: { 'x-test': faker.random.word() },
+            extensions: { 'x-test': faker.string.alpha() },
           },
         ],
       ];
@@ -401,11 +401,11 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           scheme: 'bearer',
           type: 'http',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
       [], // yeah that's how you do optional in OpenAPI
@@ -458,20 +458,20 @@ describe('validateSecurity', () => {
     const securityScheme: HttpSecurityScheme[][] = [
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           scheme: 'bearer',
           type: 'http',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
       [
         {
-          id: faker.random.word(),
+          id: faker.string.alpha(),
           scheme: 'basic',
           type: 'http',
           key: 'sec',
-          extensions: { 'x-test': faker.random.word() },
+          extensions: { 'x-test': faker.string.alpha() },
         },
       ],
     ];
@@ -521,7 +521,7 @@ describe('validateSecurity', () => {
 
   describe('AND relation between security schemes', () => {
     const headerScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       in: 'header' as const,
       type: 'apiKey' as const,
       name: 'x-api-key' as const,
@@ -535,11 +535,11 @@ describe('validateSecurity', () => {
           [
             headerScheme,
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               type: 'oauth2',
               flows: {},
               key: 'sec',
-              extensions: { 'x-test': faker.random.word() },
+              extensions: { 'x-test': faker.string.alpha() },
             },
           ],
         ];
@@ -581,11 +581,11 @@ describe('validateSecurity', () => {
           [
             headerScheme,
             {
-              id: faker.random.word(),
+              id: faker.string.alpha(),
               type: 'openIdConnect',
               openIdConnectUrl: 'https://google.it',
               key: 'sec',
-              extensions: { 'x-test': faker.random.word() },
+              extensions: { 'x-test': faker.string.alpha() },
             },
           ],
         ];
@@ -628,12 +628,12 @@ describe('validateSecurity', () => {
         [
           headerScheme,
           {
-            id: faker.random.word(),
+            id: faker.string.alpha(),
             in: 'query',
             type: 'apiKey',
             name: 'apiKey',
             key: 'sec',
-            extensions: { 'x-test': faker.random.word() },
+            extensions: { 'x-test': faker.string.alpha() },
           },
         ],
       ];
@@ -677,7 +677,7 @@ describe('validateSecurity', () => {
 
   describe('Mix of AND and OR security schemes', () => {
     const headerScheme: HttpSecurityScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       in: 'header' as const,
       type: 'apiKey' as const,
       name: 'x-api-key' as const,
@@ -686,7 +686,7 @@ describe('validateSecurity', () => {
     };
 
     const queryScheme: HttpSecurityScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       in: 'query' as const,
       type: 'apiKey' as const,
       name: 'x-api-key' as const,
@@ -695,7 +695,7 @@ describe('validateSecurity', () => {
     };
 
     const cookieScheme: HttpSecurityScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       in: 'cookie' as const,
       type: 'apiKey' as const,
       name: 'x-api-key' as const,
@@ -704,27 +704,27 @@ describe('validateSecurity', () => {
     };
 
     const bearerScheme: HttpSecurityScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       scheme: 'bearer',
       type: 'http',
       key: 'sec',
-      extensions: { 'x-test': faker.random.word() },
+      extensions: { 'x-test': faker.string.alpha() },
     };
 
     const oauth2Scheme: HttpSecurityScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       type: 'oauth2',
       flows: {},
       key: 'sec',
-      extensions: { 'x-test': faker.random.word() },
+      extensions: { 'x-test': faker.string.alpha() },
     };
 
     const openIdScheme: HttpSecurityScheme = {
-      id: faker.random.word(),
+      id: faker.string.alpha(),
       type: 'openIdConnect',
       openIdConnectUrl: 'https://google.it',
       key: 'sec',
-      extensions: { 'x-test': faker.random.word() },
+      extensions: { 'x-test': faker.string.alpha() },
     };
 
     const securityScheme: HttpSecurityScheme[][] = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,11 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz"
   integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
 
+"@babel/helper-validator-identifier@^7.24.7":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
+  integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
+
 "@babel/helper-validator-option@^7.22.15":
   version "7.22.15"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz"
@@ -174,6 +179,16 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     chalk "^2.4.2"
     js-tokens "^4.0.0"
+
+"@babel/highlight@^7.24.7":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.24.7.tgz#a05ab1df134b286558aae0ed41e6c5f731bf409d"
+  integrity sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.24.7"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.3":
   version "7.23.3"
@@ -337,15 +352,10 @@
   resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz"
   integrity sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==
 
-"@faker-js/faker@^6.0.0":
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz"
-  integrity sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==
-
-"@gar/promisify@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
-  integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
+"@faker-js/faker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
+  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -623,23 +633,13 @@
   resolved "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@lerna/child-process@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.npmjs.org/@lerna/child-process/-/child-process-7.1.5.tgz"
-  integrity sha512-YXmxzxXTP3u9HQpSXvK8qqoAm7VWQIFria3FVMQKkOSkWkph1TNnvt3Q1JvKT7/Jgd1HfTc3QrK09a2FND9+8A==
+"@lerna/create@8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@lerna/create/-/create-8.1.3.tgz#6cbdcc762fe5eb5dde24b34761c7bb61940fcb2a"
+  integrity sha512-JFvIYrlvR8Txa8h7VZx8VIQDltukEKOKaZL/muGO7Q/5aE2vjOKHsD/jkWYe/2uFy1xv37ubdx17O1UXQNadPg==
   dependencies:
-    chalk "^4.1.0"
-    execa "^5.0.0"
-    strong-log-transformer "^2.1.0"
-
-"@lerna/create@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.npmjs.org/@lerna/create/-/create-7.1.5.tgz"
-  integrity sha512-/CDI/cvXJbycgSDzWXzP7DBuJ10qL/uYEouFt3/mxi9+hSfM885fu6lbVPV7QOf8A0otXcTs7PN2dVyMrnWQeg==
-  dependencies:
-    "@lerna/child-process" "7.1.5"
-    "@npmcli/run-script" "6.0.2"
-    "@nx/devkit" ">=16.5.1 < 17"
+    "@npmcli/run-script" "7.0.2"
+    "@nx/devkit" ">=17.1.2 < 20"
     "@octokit/plugin-enterprise-rest" "6.0.1"
     "@octokit/rest" "19.0.11"
     byte-size "8.1.1"
@@ -662,12 +662,13 @@
     ini "^1.3.8"
     init-package-json "5.0.0"
     inquirer "^8.2.4"
+    is-ci "3.0.1"
     is-stream "2.0.0"
     js-yaml "4.1.0"
     libnpmpublish "7.3.0"
     load-json-file "6.2.0"
     lodash "^4.17.21"
-    make-dir "3.1.0"
+    make-dir "4.0.0"
     minimatch "3.0.5"
     multimatch "5.0.0"
     node-fetch "2.6.7"
@@ -675,12 +676,12 @@
     npm-packlist "5.1.1"
     npm-registry-fetch "^14.0.5"
     npmlog "^6.0.2"
-    nx ">=16.5.1 < 17"
+    nx ">=17.1.2 < 20"
     p-map "4.0.0"
     p-map-series "2.1.0"
     p-queue "6.6.2"
     p-reduce "^2.1.0"
-    pacote "^15.2.0"
+    pacote "^17.0.5"
     pify "5.0.0"
     read-cmd-shim "4.0.0"
     read-package-json "6.0.4"
@@ -691,7 +692,7 @@
     slash "^3.0.0"
     ssri "^9.0.1"
     strong-log-transformer "2.1.0"
-    tar "6.1.11"
+    tar "6.2.1"
     temp-dir "1.0.0"
     upath "2.0.1"
     uuid "^9.0.0"
@@ -699,8 +700,8 @@
     validate-npm-package-name "5.0.0"
     write-file-atomic "5.0.1"
     write-pkg "4.0.0"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
+    yargs "17.7.2"
+    yargs-parser "21.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -723,13 +724,16 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npmcli/fs@^2.1.0":
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz"
-  integrity sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==
+"@npmcli/agent@^2.0.0":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/agent/-/agent-2.2.2.tgz#967604918e62f620a648c7975461c9c9e74fc5d5"
+  integrity sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==
   dependencies:
-    "@gar/promisify" "^1.1.3"
-    semver "^7.3.5"
+    agent-base "^7.1.0"
+    http-proxy-agent "^7.0.0"
+    https-proxy-agent "^7.0.1"
+    lru-cache "^10.0.1"
+    socks-proxy-agent "^8.0.3"
 
 "@npmcli/fs@^3.1.0":
   version "3.1.0"
@@ -738,19 +742,19 @@
   dependencies:
     semver "^7.3.5"
 
-"@npmcli/git@^4.0.0":
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz"
-  integrity sha512-9hwoB3gStVfa0N31ymBmrX+GuDGdVA/QWShZVqE0HK2Af+7QGGrCTbZia/SW0ImUTjTne7SP91qxDmtXvDHRPQ==
+"@npmcli/git@^5.0.0":
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/@npmcli/git/-/git-5.0.7.tgz#7ff675e33b4dc0b0adb1f0c4aa302109efc06463"
+  integrity sha512-WaOVvto604d5IpdCRV2KjQu8PzkfE96d50CQGKgywXh2GxXmDeUO5EWcBC4V57uFyrNqx83+MewuJh3WTR3xPA==
   dependencies:
-    "@npmcli/promise-spawn" "^6.0.0"
-    lru-cache "^7.4.4"
-    npm-pick-manifest "^8.0.0"
-    proc-log "^3.0.0"
+    "@npmcli/promise-spawn" "^7.0.0"
+    lru-cache "^10.0.1"
+    npm-pick-manifest "^9.0.0"
+    proc-log "^4.0.0"
     promise-inflight "^1.0.1"
     promise-retry "^2.0.1"
     semver "^7.3.5"
-    which "^3.0.0"
+    which "^4.0.0"
 
 "@npmcli/installed-package-contents@^2.0.1":
   version "2.0.2"
@@ -760,114 +764,137 @@
     npm-bundled "^3.0.0"
     npm-normalize-package-bin "^3.0.0"
 
-"@npmcli/move-file@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz"
-  integrity sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==
-  dependencies:
-    mkdirp "^1.0.4"
-    rimraf "^3.0.2"
-
 "@npmcli/node-gyp@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-3.0.0.tgz"
   integrity sha512-gp8pRXC2oOxu0DUE1/M3bYtb1b3/DbJ5aM113+XJBgfXdussRAsX0YOrOhdd8WvnAR6auDBvJomGAkLKA5ydxA==
 
-"@npmcli/promise-spawn@^6.0.0", "@npmcli/promise-spawn@^6.0.1":
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-6.0.2.tgz"
-  integrity sha512-gGq0NJkIGSwdbUt4yhdF8ZrmkGKVz9vAdVzpOfnom+V8PLSmSOVhZwbNvZZS1EYcJN5hzzKBxmmVVAInM6HQLg==
+"@npmcli/package-json@^5.0.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/package-json/-/package-json-5.2.0.tgz#a1429d3111c10044c7efbfb0fce9f2c501f4cfad"
+  integrity sha512-qe/kiqqkW0AGtvBjL8TJKZk/eBBSpnJkUWvHdQ9jM2lKHXRYYJuyNpJPlJw3c8QjC2ow6NZYiLExhUaeJelbxQ==
   dependencies:
-    which "^3.0.0"
+    "@npmcli/git" "^5.0.0"
+    glob "^10.2.2"
+    hosted-git-info "^7.0.0"
+    json-parse-even-better-errors "^3.0.0"
+    normalize-package-data "^6.0.0"
+    proc-log "^4.0.0"
+    semver "^7.5.3"
 
-"@npmcli/run-script@6.0.2", "@npmcli/run-script@^6.0.0":
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/@npmcli/run-script/-/run-script-6.0.2.tgz"
-  integrity sha512-NCcr1uQo1k5U+SYlnIrbAh3cxy+OQT1VtqiAbxdymSlptbzBb62AjH2xXgjNCoP073hoa1CfCAcwoZ8k96C4nA==
+"@npmcli/promise-spawn@^7.0.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/promise-spawn/-/promise-spawn-7.0.2.tgz#1d53d34ffeb5d151bfa8ec661bcccda8bbdfd532"
+  integrity sha512-xhfYPXoV5Dy4UkY0D+v2KkwvnDfiA/8Mt3sWCGI/hM03NsYIH8ZaG6QzS9x7pje5vHZBZJ2v6VRFVTWACnqcmQ==
+  dependencies:
+    which "^4.0.0"
+
+"@npmcli/redact@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/redact/-/redact-1.1.0.tgz#78e53a6a34f013543a73827a07ebdc3a6f10454b"
+  integrity sha512-PfnWuOkQgu7gCbnSsAisaX7hKOdZ4wSAhAzH3/ph5dSGau52kCRrMMGbiSQLwyTZpgldkZ49b0brkOr1AzGBHQ==
+
+"@npmcli/run-script@7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-7.0.2.tgz#497e7f058799497889df65900c711312252276d3"
+  integrity sha512-Omu0rpA8WXvcGeY6DDzyRoY1i5DkCBkzyJ+m2u7PD6quzb0TvSqdIPOkTn8ZBOj7LbbcbMfZ3c5skwSu6m8y2w==
   dependencies:
     "@npmcli/node-gyp" "^3.0.0"
-    "@npmcli/promise-spawn" "^6.0.0"
-    node-gyp "^9.0.0"
+    "@npmcli/promise-spawn" "^7.0.0"
+    node-gyp "^10.0.0"
     read-package-json-fast "^3.0.0"
-    which "^3.0.0"
+    which "^4.0.0"
 
-"@nrwl/devkit@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.10.0.tgz"
-  integrity sha512-fRloARtsDQoQgQ7HKEy0RJiusg/HSygnmg4gX/0n/Z+SUS+4KoZzvHjXc6T5ZdEiSjvLypJ+HBM8dQzIcVACPQ==
+"@npmcli/run-script@^7.0.0":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-7.0.4.tgz#9f29aaf4bfcf57f7de2a9e28d1ef091d14b2e6eb"
+  integrity sha512-9ApYM/3+rBt9V80aYg6tZfzj3UWdiYyCt7gJUD1VJKvWF5nwKDSICXbYIQbspFTq6TOpbsEtIC0LArB8d9PFmg==
   dependencies:
-    "@nx/devkit" "16.10.0"
+    "@npmcli/node-gyp" "^3.0.0"
+    "@npmcli/package-json" "^5.0.0"
+    "@npmcli/promise-spawn" "^7.0.0"
+    node-gyp "^10.0.0"
+    which "^4.0.0"
 
-"@nrwl/tao@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.npmjs.org/@nrwl/tao/-/tao-16.10.0.tgz"
-  integrity sha512-QNAanpINbr+Pod6e1xNgFbzK1x5wmZl+jMocgiEFXZ67KHvmbD6MAQQr0MMz+GPhIu7EE4QCTLTyCEMlAG+K5Q==
+"@nrwl/devkit@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-19.2.0.tgz#24991625f08cfc8ef8a12bd330f902422f1af305"
+  integrity sha512-Ew5AJZkLXJwt15HjaIbHve8FOXmZ3HK8KPqTXqwKHX8jQW+fDUCaSXKe/lCZMNg0RvY+jMNecuC86uGdiIbLMg==
   dependencies:
-    nx "16.10.0"
+    "@nx/devkit" "19.2.0"
+
+"@nrwl/tao@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-19.2.0.tgz#c8a4416c3eab17e0c9bf88ec8706de9106d122fd"
+  integrity sha512-9AOwbY/E7OlLCFu+6jhJGUIs+qurE2/3Pldooe7cJPqQmSQeJuVZuL6A2xHtbSG7VsXTq5Yj8dVvK1KmT45SIA==
+  dependencies:
+    nx "19.2.0"
     tslib "^2.3.0"
 
-"@nx/devkit@16.10.0", "@nx/devkit@>=16.5.1 < 17":
-  version "16.10.0"
-  resolved "https://registry.npmjs.org/@nx/devkit/-/devkit-16.10.0.tgz"
-  integrity sha512-IvKQqRJFDDiaj33SPfGd3ckNHhHi6ceEoqCbAP4UuMXOPPVOX6H0KVk+9tknkPb48B7jWIw6/AgOeWkBxPRO5w==
+"@nx/devkit@19.2.0", "@nx/devkit@>=17.1.2 < 20":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/devkit/-/devkit-19.2.0.tgz#1b7adca4a3c396963db7429613000be10059b498"
+  integrity sha512-fK3zRUE2SLp9BUomFiyCuAX2E1yfWYE/hKimniscsvM34/u/xLZYVmmZ0/jfpGPbyaonXKZr2KTb7RimX/hyqg==
   dependencies:
-    "@nrwl/devkit" "16.10.0"
+    "@nrwl/devkit" "19.2.0"
     ejs "^3.1.7"
     enquirer "~2.3.6"
     ignore "^5.0.4"
-    semver "7.5.3"
+    minimatch "9.0.3"
+    semver "^7.5.3"
     tmp "~0.2.1"
     tslib "^2.3.0"
+    yargs-parser "21.1.1"
 
-"@nx/nx-darwin-arm64@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.10.0.tgz#0c73010cac7a502549483b12bad347da9014e6f1"
-  integrity sha512-YF+MIpeuwFkyvM5OwgY/rTNRpgVAI/YiR0yTYCZR+X3AAvP775IVlusNgQ3oedTBRUzyRnI4Tknj1WniENFsvQ==
+"@nx/nx-darwin-arm64@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-arm64/-/nx-darwin-arm64-19.2.0.tgz#eb5d6eddd1a397ef456a094cee7c726e186cc8bb"
+  integrity sha512-W+OpGyzr10oaycf4atPc5uH2wN1G6LJGHkWDN3LGSQhoDWuj13idFpjSy6rJ8WxtL8kIvPXq78GEi1yAADsakA==
 
-"@nx/nx-darwin-x64@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.10.0.tgz"
-  integrity sha512-ypi6YxwXgb0kg2ixKXE3pwf5myVNUgWf1CsV5OzVccCM8NzheMO51KDXTDmEpXdzUsfT0AkO1sk5GZeCjhVONg==
+"@nx/nx-darwin-x64@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-darwin-x64/-/nx-darwin-x64-19.2.0.tgz#54e951d35ee323a912510abda1079f9a132daebd"
+  integrity sha512-4l1BDn29R0ugf7ATcGcZGEwK0frZSCtiyXnX3JFq55dNS4Bv3FiZLew7JULjdumXEXr773bH326FQlocLVlcXg==
 
-"@nx/nx-freebsd-x64@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.10.0.tgz#c3ee6914256e69493fed9355b0d6661d0e86da44"
-  integrity sha512-UeEYFDmdbbDkTQamqvtU8ibgu5jQLgFF1ruNb/U4Ywvwutw2d4ruOMl2e0u9hiNja9NFFAnDbvzrDcMo7jYqYw==
+"@nx/nx-freebsd-x64@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-freebsd-x64/-/nx-freebsd-x64-19.2.0.tgz#96db8dcd1f9597b2fad3925ed465a279a284e54f"
+  integrity sha512-9zdwLRSkEg/H7bbIVWATn0H8QNgnHaTe23tciZPaBr95J6CXVJWWpC4wn9duURhvbscnqUSSSfKK1f+MSEDTbw==
 
-"@nx/nx-linux-arm-gnueabihf@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.10.0.tgz#a961eccbb38acb2da7fc125b29d1fead0b39152f"
-  integrity sha512-WV3XUC2DB6/+bz1sx+d1Ai9q2Cdr+kTZRN50SOkfmZUQyEBaF6DRYpx/a4ahhxH3ktpNfyY8Maa9OEYxGCBkQA==
+"@nx/nx-linux-arm-gnueabihf@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-19.2.0.tgz#1b144870fb91a416842e080e122373002f7b8752"
+  integrity sha512-KNVnqRPegJza3kU4q3pY8m0pT8OSQZnLGsDZti6morhXh2sE79f/zeevOrbhf8JnaJfQtyrXfGvjYAiL3+I8bw==
 
-"@nx/nx-linux-arm64-gnu@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.10.0.tgz#795f20072549d03822b5c4639ef438e473dbb541"
-  integrity sha512-aWIkOUw995V3ItfpAi5FuxQ+1e9EWLS1cjWM1jmeuo+5WtaKToJn5itgQOkvSlPz+HSLgM3VfXMvOFALNk125g==
+"@nx/nx-linux-arm64-gnu@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-19.2.0.tgz#a30e7a9e22b29c656e6f3e143627e8abbcd9b1a2"
+  integrity sha512-UXIl90l+cDecU17OOLlI+uzbjzQucnNu4Mee67EqE3TyfpSvuU1l3FWZ9sbE0effp8IwKpbL7Gt5KirJKtWzIA==
 
-"@nx/nx-linux-arm64-musl@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.10.0.tgz#f2428ee6dbe2b2c326e8973f76c97666def33607"
-  integrity sha512-uO6Gg+irqpVcCKMcEPIQcTFZ+tDI02AZkqkP7koQAjniLEappd8DnUBSQdcn53T086pHpdc264X/ZEpXFfrKWQ==
+"@nx/nx-linux-arm64-musl@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-19.2.0.tgz#2d78da4d90a21fe94f77932a5a146f388867de48"
+  integrity sha512-4Z8XO3WljS2GWOL2SQ1p8SRNn2Kn6FU1FWClh7KBzMtpzjsHdmOXenMP9UOGZ6gBnfBIknCEDjE3uJUHmuShGg==
 
-"@nx/nx-linux-x64-gnu@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz#d36c2bcf94d49eaa24e3880ddaf6f1f617de539b"
-  integrity sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==
+"@nx/nx-linux-x64-gnu@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-19.2.0.tgz#0c47e579c8ae7197c239ff11c86618cf5c2fca2b"
+  integrity sha512-EwAkZEp0KB99VEPTskW2feCpSKqWScKdRd6UaIM9Vmqqtb5hSk6yR6p0mprjytbDtFVoKQJMOFa35qe+2R8mKQ==
 
-"@nx/nx-linux-x64-musl@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.10.0.tgz#78bd2ab97a583b3d4ea3387b67fd7b136907493c"
-  integrity sha512-q8sINYLdIJxK/iUx9vRk5jWAWb/2O0PAbOJFwv4qkxBv4rLoN7y+otgCZ5v0xfx/zztFgk/oNY4lg5xYjIso2Q==
+"@nx/nx-linux-x64-musl@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-19.2.0.tgz#d8ec572e24fae27b02b01274d0da98f682c053d4"
+  integrity sha512-LbFcHe83YZUS/my/8nBxQ2i3JWakcXd7zbzZ0cSAQk6DuJVCUk8PLdgZzhrVcmT82Pv7H0fM/4jgEl+oHGoc/g==
 
-"@nx/nx-win32-arm64-msvc@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.10.0.tgz#ef20ec8d0c83d66e73e20df12d2c788b8f866396"
-  integrity sha512-moJkL9kcqxUdJSRpG7dET3UeLIciwrfP08mzBQ12ewo8K8FzxU8ZUsTIVVdNrwt01CXOdXoweGfdQLjJ4qTURA==
+"@nx/nx-win32-arm64-msvc@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-19.2.0.tgz#956139eddea37fbe067a963603be898715d2fe16"
+  integrity sha512-BxOveRfRCdhuCs2GWbsdzGsjtLC3N+MuUlVaXSWADksF6/QKuCHM/2Kq3RYkLVVtlls6NCBp410RSx/XsbSEug==
 
-"@nx/nx-win32-x64-msvc@16.10.0":
-  version "16.10.0"
-  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.10.0.tgz#7410a51d0f8be631eec9552f01b2e5946285927c"
-  integrity sha512-5iV2NKZnzxJwZZ4DM5JVbRG/nkhAbzEskKaLBB82PmYGKzaDHuMHP1lcPoD/rtYMlowZgNA/RQndfKvPBPwmXA==
+"@nx/nx-win32-x64-msvc@19.2.0":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-19.2.0.tgz#f101631a1a3a024174bcdf064c4c29877d4c8dde"
+  integrity sha512-QiDxtOHIiRka9Bz7tSpBvQgQPrX5grLhoz6miD6LX1WjO56bZIkEAVefGnMc3WZ1PacS1ZECtymHwUy+WpEqAQ==
 
 "@octokit/auth-token@^3.0.0":
   version "3.0.4"
@@ -985,14 +1012,6 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@parcel/watcher@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz"
-  integrity sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==
-  dependencies:
-    node-addon-api "^3.2.1"
-    node-gyp-build "^4.3.0"
-
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
@@ -1005,10 +1024,27 @@
   dependencies:
     "@sigstore/protobuf-specs" "^0.2.0"
 
+"@sigstore/bundle@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.3.2.tgz#ad4dbb95d665405fd4a7a02c8a073dbd01e4e95e"
+  integrity sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==
+  dependencies:
+    "@sigstore/protobuf-specs" "^0.3.2"
+
+"@sigstore/core@^1.0.0", "@sigstore/core@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@sigstore/core/-/core-1.1.0.tgz#5583d8f7ffe599fa0a89f2bf289301a5af262380"
+  integrity sha512-JzBqdVIyqm2FRQCulY6nbQzMpJJpSiJ8XXWMhtOX9eKgaXXpfNOF53lzQEjIydlStnd/eFtuC1dW4VYdD93oRg==
+
 "@sigstore/protobuf-specs@^0.2.0":
   version "0.2.1"
   resolved "https://registry.npmjs.org/@sigstore/protobuf-specs/-/protobuf-specs-0.2.1.tgz"
   integrity sha512-XTWVxnWJu+c1oCshMLwnKvz8ZQJJDVOlciMfgpJBQbThVjKTCG8dwyhgLngBD2KN0ap9F/gOV8rFDEx8uh7R2A==
+
+"@sigstore/protobuf-specs@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sigstore/protobuf-specs/-/protobuf-specs-0.3.2.tgz#5becf88e494a920f548d0163e2978f81b44b7d6f"
+  integrity sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw==
 
 "@sigstore/sign@^1.0.0":
   version "1.0.0"
@@ -1019,6 +1055,18 @@
     "@sigstore/protobuf-specs" "^0.2.0"
     make-fetch-happen "^11.0.1"
 
+"@sigstore/sign@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@sigstore/sign/-/sign-2.3.2.tgz#d3d01e56d03af96fd5c3a9b9897516b1233fc1c4"
+  integrity sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==
+  dependencies:
+    "@sigstore/bundle" "^2.3.2"
+    "@sigstore/core" "^1.0.0"
+    "@sigstore/protobuf-specs" "^0.3.2"
+    make-fetch-happen "^13.0.1"
+    proc-log "^4.2.0"
+    promise-retry "^2.0.1"
+
 "@sigstore/tuf@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@sigstore/tuf/-/tuf-1.0.3.tgz"
@@ -1026,6 +1074,23 @@
   dependencies:
     "@sigstore/protobuf-specs" "^0.2.0"
     tuf-js "^1.1.7"
+
+"@sigstore/tuf@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@sigstore/tuf/-/tuf-2.3.4.tgz#da1d2a20144f3b87c0172920cbc8dcc7851ca27c"
+  integrity sha512-44vtsveTPUpqhm9NCrbU8CWLe3Vck2HO1PNLw7RIajbB7xhtn5RBPm1VNSCMwqGYHhDsBJG8gDF0q4lgydsJvw==
+  dependencies:
+    "@sigstore/protobuf-specs" "^0.3.2"
+    tuf-js "^2.2.1"
+
+"@sigstore/verify@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@sigstore/verify/-/verify-1.2.1.tgz#c7e60241b432890dcb8bd8322427f6062ef819e1"
+  integrity sha512-8iKx79/F73DKbGfRf7+t4dqrc0bRr0thdPrxAtCKWRm/F0tG71i6O1rvlnScncJLLBZHn3h8M3c1BSUAb9yu8g==
+  dependencies:
+    "@sigstore/bundle" "^2.3.2"
+    "@sigstore/core" "^1.1.0"
+    "@sigstore/protobuf-specs" "^0.3.2"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -1176,6 +1241,11 @@
   resolved "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz"
   integrity sha512-QTnf++uxunWvG2z3UFNzAoQPHxnSXOwtaI3iJ+AohhV+5vONuArPjJE7aPXPVXfXJsqrVbZBu9b81AJoSd09IQ==
 
+"@tufjs/canonical-json@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-2.0.0.tgz#a52f61a3d7374833fca945b2549bc30a2dd40d0a"
+  integrity sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==
+
 "@tufjs/models@1.0.4":
   version "1.0.4"
   resolved "https://registry.npmjs.org/@tufjs/models/-/models-1.0.4.tgz"
@@ -1183,6 +1253,14 @@
   dependencies:
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
+
+"@tufjs/models@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tufjs/models/-/models-2.0.1.tgz#e429714e753b6c2469af3212e7f320a6973c2812"
+  integrity sha512-92F7/SFyufn4DXsha9+QfKnN03JGqtMFMXgSHbZOo8JG59WkTni7UzAouNQDf7AuP9OAMxVOPQcqG3sB7w+kkg==
+  dependencies:
+    "@tufjs/canonical-json" "2.0.0"
+    minimatch "^9.0.4"
 
 "@types/babel__core@^7.1.14":
   version "7.20.4"
@@ -1502,10 +1580,10 @@
     js-yaml "^3.10.0"
     tslib "^2.4.0"
 
-"@zkochan/js-yaml@0.0.6":
-  version "0.0.6"
-  resolved "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz"
-  integrity sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==
+"@zkochan/js-yaml@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@zkochan/js-yaml/-/js-yaml-0.0.7.tgz#4b0cb785220d7c28ce0ec4d0804deb5d821eae89"
+  integrity sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==
   dependencies:
     argparse "^2.0.1"
 
@@ -1517,10 +1595,10 @@ JSONStream@^1.3.5:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abbrev@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
-  integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -1563,6 +1641,13 @@ agent-base@6, agent-base@^6.0.2:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.0.2, agent-base@^7.1.0, agent-base@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.1.tgz#bdbded7dfb096b751a2a087eeeb9664725b2e317"
+  integrity sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==
+  dependencies:
+    debug "^4.3.4"
 
 agentkeepalive@^4.2.1:
   version "4.5.0"
@@ -1745,12 +1830,12 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-axios@^1.0.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
-  integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==
+axios@^1.6.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
   dependencies:
-    follow-redirects "^1.15.0"
+    follow-redirects "^1.15.6"
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
@@ -1937,30 +2022,6 @@ bytes@3.1.2:
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cacache@^16.1.0:
-  version "16.1.3"
-  resolved "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz"
-  integrity sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==
-  dependencies:
-    "@npmcli/fs" "^2.1.0"
-    "@npmcli/move-file" "^2.0.0"
-    chownr "^2.0.0"
-    fs-minipass "^2.1.0"
-    glob "^8.0.1"
-    infer-owner "^1.0.4"
-    lru-cache "^7.7.1"
-    minipass "^3.1.6"
-    minipass-collect "^1.0.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.4"
-    mkdirp "^1.0.4"
-    p-map "^4.0.0"
-    promise-inflight "^1.0.1"
-    rimraf "^3.0.2"
-    ssri "^9.0.0"
-    tar "^6.1.11"
-    unique-filename "^2.0.0"
-
 cacache@^17.0.0:
   version "17.1.4"
   resolved "https://registry.npmjs.org/cacache/-/cacache-17.1.4.tgz"
@@ -1972,6 +2033,24 @@ cacache@^17.0.0:
     lru-cache "^7.7.1"
     minipass "^7.0.3"
     minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    p-map "^4.0.0"
+    ssri "^10.0.0"
+    tar "^6.1.11"
+    unique-filename "^3.0.0"
+
+cacache@^18.0.0:
+  version "18.0.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-18.0.3.tgz#864e2c18414e1e141ae8763f31e46c2cb96d1b21"
+  integrity sha512-qXCd4rh6I07cnDqh8V48/94Tc/WSfj+o3Gn6NZ0aZovS255bUx8O13uKxRFd2eWG0xgsco7+YItQNPaa5E85hg==
+  dependencies:
+    "@npmcli/fs" "^3.1.0"
+    fs-minipass "^3.0.0"
+    glob "^10.2.2"
+    lru-cache "^10.0.1"
+    minipass "^7.0.3"
+    minipass-collect "^2.0.1"
     minipass-flush "^1.0.5"
     minipass-pipeline "^1.2.4"
     p-map "^4.0.0"
@@ -2300,10 +2379,10 @@ content-type@^1.0.4:
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
-conventional-changelog-angular@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz"
-  integrity sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==
+conventional-changelog-angular@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz#5eec8edbff15aa9b1680a8dcfbd53e2d7eb2ba7a"
+  integrity sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==
   dependencies:
     compare-func "^2.0.0"
 
@@ -3162,7 +3241,7 @@ fnv-plus@^1.3.1:
   resolved "https://registry.npmjs.org/fnv-plus/-/fnv-plus-1.3.1.tgz"
   integrity sha512-Gz1EvfOneuFfk4yG458dJ3TLJ7gV19q3OM/vVvvHf7eT02Hm1DleB4edsia6ahbKgAYxO9gvyQ1ioWZR+a00Yw==
 
-follow-redirects@^1.15.0:
+follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -3215,6 +3294,13 @@ fp-ts@^2.11.5:
   resolved "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.1.tgz"
   integrity sha512-by7U5W8dkIzcvDofUcO42yl9JbnHTEDBrzu3pt5fKT+Z4Oy85I21K80EYJYdjQGC2qum4Vo55Ag57iiIK4FYuA==
 
+front-matter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-4.0.2.tgz#b14e54dc745cfd7293484f3210d15ea4edd7f4d5"
+  integrity sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==
+  dependencies:
+    js-yaml "^3.13.1"
+
 fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
@@ -3229,7 +3315,7 @@ fs-extra@^11.1.0, fs-extra@^11.1.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-minipass@^2.0.0, fs-minipass@^2.1.0:
+fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz"
   integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
@@ -3412,18 +3498,6 @@ glob-parent@5.1.2, glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.1.4:
-  version "7.1.4"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^10.2.2:
   version "10.3.10"
   resolved "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz"
@@ -3434,6 +3508,17 @@ glob@^10.2.2:
     minimatch "^9.0.1"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
     path-scurry "^1.10.1"
+
+glob@^10.3.10:
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.1.tgz#0cfb01ab6a6b438177bfe6a58e2576f6efe909c2"
+  integrity sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    path-scurry "^1.11.1"
 
 glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
@@ -3611,6 +3696,13 @@ hosted-git-info@^6.0.0:
   dependencies:
     lru-cache "^7.5.1"
 
+hosted-git-info@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-7.0.2.tgz#9b751acac097757667f30114607ef7b661ff4f17"
+  integrity sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==
+  dependencies:
+    lru-cache "^10.0.1"
+
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
@@ -3626,7 +3718,7 @@ htmlparser2@^8.0.0:
     domutils "^3.0.1"
     entities "^4.4.0"
 
-http-cache-semantics@^4.1.0, http-cache-semantics@^4.1.1:
+http-cache-semantics@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
@@ -3651,6 +3743,14 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+http-proxy-agent@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
 http-reasons@0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz"
@@ -3667,6 +3767,14 @@ https-proxy-agent@^5.0.0:
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
+    debug "4"
+
+https-proxy-agent@^7.0.1:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
+  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
+  dependencies:
+    agent-base "^7.0.2"
     debug "4"
 
 human-signals@^1.1.1:
@@ -3717,10 +3825,10 @@ ignore-walk@^5.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-ignore-walk@^6.0.0:
-  version "6.0.3"
-  resolved "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.3.tgz"
-  integrity sha512-C7FfFoTA+bI10qfeydT8aZbvr91vAEU+2W5BZUlzPec47oNb07SsOfwYrtxuvOYdUApPP/Qlh4DtAO51Ekk2QA==
+ignore-walk@^6.0.4:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-6.0.5.tgz#ef8d61eab7da169078723d1f82833b36e200b0dd"
+  integrity sha512-VuuG0wCnjhnylG1ABXT3dAuIpTNDs/G8jlpmwXY03fXoXy/8ZK8/T+hMzt8L4WnrLCJgdybqgPagnF/f97cg3A==
   dependencies:
     minimatch "^9.0.0"
 
@@ -3759,11 +3867,6 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
-infer-owner@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz"
-  integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3830,6 +3933,14 @@ io-ts@^2.2.16:
   version "2.2.20"
   resolved "https://registry.npmjs.org/io-ts/-/io-ts-2.2.20.tgz"
   integrity sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==
+
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
+  dependencies:
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
 
 ip@^2.0.0:
   version "2.0.1"
@@ -4074,6 +4185,11 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isexe@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
+  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
+
 isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz"
@@ -4144,6 +4260,15 @@ jackspeak@^2.3.5:
   version "2.3.6"
   resolved "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz"
   integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+jackspeak@^3.1.2:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.0.tgz#a75763ff36ad778ede6a156d8ee8b124de445b4a"
+  integrity sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==
   dependencies:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
@@ -4542,6 +4667,11 @@ js-yaml@^3.10.0, js-yaml@^3.12.1, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz"
@@ -4676,15 +4806,14 @@ kleur@^3.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lerna@~7.1.5:
-  version "7.1.5"
-  resolved "https://registry.npmjs.org/lerna/-/lerna-7.1.5.tgz"
-  integrity sha512-5bvfmoIH4Czk5mdoLaRPYkM3M63Ei6+TOuXs3MgXmvqD8vs+vQpHuBVmiYFp5Mwsck3FkidJ+eTxfucltA2Lmw==
+lerna@~8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-8.1.3.tgz#9168804c99fbba49083e1f62de65a0ffefd6df22"
+  integrity sha512-Dg/r1dGnRCXKsOUC3lol7o6ggYTA6WWiPQzZJNKqyygn4fzYGuA3Dro2d5677pajaqFnFA72mdCjzSyF16Vi2Q==
   dependencies:
-    "@lerna/child-process" "7.1.5"
-    "@lerna/create" "7.1.5"
-    "@npmcli/run-script" "6.0.2"
-    "@nx/devkit" ">=16.5.1 < 17"
+    "@lerna/create" "8.1.3"
+    "@npmcli/run-script" "7.0.2"
+    "@nx/devkit" ">=17.1.2 < 20"
     "@octokit/plugin-enterprise-rest" "6.0.1"
     "@octokit/rest" "19.0.11"
     byte-size "8.1.1"
@@ -4692,7 +4821,7 @@ lerna@~7.1.5:
     clone-deep "4.0.1"
     cmd-shim "6.0.1"
     columnify "1.6.0"
-    conventional-changelog-angular "6.0.0"
+    conventional-changelog-angular "7.0.0"
     conventional-changelog-core "5.0.1"
     conventional-recommended-bump "7.0.1"
     cosmiconfig "^8.2.0"
@@ -4719,7 +4848,7 @@ lerna@~7.1.5:
     libnpmpublish "7.3.0"
     load-json-file "6.2.0"
     lodash "^4.17.21"
-    make-dir "3.1.0"
+    make-dir "4.0.0"
     minimatch "3.0.5"
     multimatch "5.0.0"
     node-fetch "2.6.7"
@@ -4727,14 +4856,14 @@ lerna@~7.1.5:
     npm-packlist "5.1.1"
     npm-registry-fetch "^14.0.5"
     npmlog "^6.0.2"
-    nx ">=16.5.1 < 17"
+    nx ">=17.1.2 < 20"
     p-map "4.0.0"
     p-map-series "2.1.0"
     p-pipe "3.1.0"
     p-queue "6.6.2"
     p-reduce "2.1.0"
     p-waterfall "2.1.1"
-    pacote "^15.2.0"
+    pacote "^17.0.5"
     pify "5.0.0"
     read-cmd-shim "4.0.0"
     read-package-json "6.0.4"
@@ -4745,7 +4874,7 @@ lerna@~7.1.5:
     slash "3.0.0"
     ssri "^9.0.1"
     strong-log-transformer "2.1.0"
-    tar "6.1.11"
+    tar "6.2.1"
     temp-dir "1.0.0"
     typescript ">=3 < 6"
     upath "2.0.1"
@@ -4754,8 +4883,8 @@ lerna@~7.1.5:
     validate-npm-package-name "5.0.0"
     write-file-atomic "5.0.1"
     write-pkg "4.0.0"
-    yargs "16.2.0"
-    yargs-parser "20.2.4"
+    yargs "17.7.2"
+    yargs-parser "21.1.1"
 
 leven@^3.1.0:
   version "3.1.0"
@@ -4925,6 +5054,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+lru-cache@^10.0.1, lru-cache@^10.2.0:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
+  integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz"
@@ -4939,7 +5073,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
+lru-cache@^7.5.1, lru-cache@^7.7.1:
   version "7.18.3"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
@@ -4951,12 +5085,12 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   dependencies:
     semver "^7.3.5"
 
-make-dir@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
-  integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+make-dir@4.0.0, make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
   dependencies:
-    semver "^6.0.0"
+    semver "^7.5.3"
 
 make-dir@^2.1.0:
   version "2.1.0"
@@ -4966,39 +5100,10 @@ make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz"
-  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
-  dependencies:
-    semver "^7.5.3"
-
 make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
-
-make-fetch-happen@^10.0.3:
-  version "10.2.1"
-  resolved "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz"
-  integrity sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==
-  dependencies:
-    agentkeepalive "^4.2.1"
-    cacache "^16.1.0"
-    http-cache-semantics "^4.1.0"
-    http-proxy-agent "^5.0.0"
-    https-proxy-agent "^5.0.0"
-    is-lambda "^1.0.1"
-    lru-cache "^7.7.1"
-    minipass "^3.1.6"
-    minipass-collect "^1.0.2"
-    minipass-fetch "^2.0.3"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.4"
-    negotiator "^0.6.3"
-    promise-retry "^2.0.1"
-    socks-proxy-agent "^7.0.0"
-    ssri "^9.0.0"
 
 make-fetch-happen@^11.0.0, make-fetch-happen@^11.0.1, make-fetch-happen@^11.1.1:
   version "11.1.1"
@@ -5019,6 +5124,24 @@ make-fetch-happen@^11.0.0, make-fetch-happen@^11.0.1, make-fetch-happen@^11.1.1:
     negotiator "^0.6.3"
     promise-retry "^2.0.1"
     socks-proxy-agent "^7.0.0"
+    ssri "^10.0.0"
+
+make-fetch-happen@^13.0.0, make-fetch-happen@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz#273ba2f78f45e1f3a6dca91cede87d9fa4821e36"
+  integrity sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==
+  dependencies:
+    "@npmcli/agent" "^2.0.0"
+    cacache "^18.0.0"
+    http-cache-semantics "^4.1.1"
+    is-lambda "^1.0.1"
+    minipass "^7.0.2"
+    minipass-fetch "^3.0.0"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.4"
+    negotiator "^0.6.3"
+    proc-log "^4.2.0"
+    promise-retry "^2.0.1"
     ssri "^10.0.0"
 
 makeerror@1.0.12:
@@ -5126,6 +5249,13 @@ minimatch@3.0.5:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@9.0.3, minimatch@^9.0.0, minimatch@^9.0.1:
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -5147,10 +5277,10 @@ minimatch@^8.0.2:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.0, minimatch@^9.0.1:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
-  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+minimatch@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -5180,16 +5310,12 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass-fetch@^2.0.3:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz"
-  integrity sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==
+minipass-collect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-2.0.1.tgz#1621bc77e12258a12c60d34e2276ec5c20680863"
+  integrity sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==
   dependencies:
-    minipass "^3.1.6"
-    minipass-sized "^1.0.3"
-    minizlib "^2.1.2"
-  optionalDependencies:
-    encoding "^0.1.13"
+    minipass "^7.0.3"
 
 minipass-fetch@^3.0.0:
   version "3.0.4"
@@ -5231,7 +5357,7 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^3.0.0, minipass@^3.1.1, minipass@^3.1.6:
+minipass@^3.0.0, minipass@^3.1.1:
   version "3.3.6"
   resolved "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz"
   integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
@@ -5253,6 +5379,11 @@ minipass@^5.0.0:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
 
+minipass@^7.0.2, minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
 minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz"
@@ -5268,7 +5399,7 @@ mkdirp@0.5.x:
   dependencies:
     minimist "^1.2.6"
 
-mkdirp@^1.0.3, mkdirp@^1.0.4:
+mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -5343,11 +5474,6 @@ node-abort-controller@^3.0.1:
   resolved "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz"
   integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
-node-addon-api@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz"
-  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
-
 node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
@@ -5362,27 +5488,21 @@ node-fetch@^2.6.1, node-fetch@^2.6.12, node-fetch@^2.6.5, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-gyp-build@^4.3.0:
-  version "4.6.1"
-  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz"
-  integrity sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==
-
-node-gyp@^9.0.0:
-  version "9.4.1"
-  resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz"
-  integrity sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==
+node-gyp@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-10.1.0.tgz#75e6f223f2acb4026866c26a2ead6aab75a8ca7e"
+  integrity sha512-B4J5M1cABxPc5PwfjhbV5hoy2DP9p8lFXASnEN6hugXOa61416tnTZ29x9sSwAd0o99XNIcpvDDy1swAExsVKA==
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
-    glob "^7.1.4"
+    glob "^10.3.10"
     graceful-fs "^4.2.6"
-    make-fetch-happen "^10.0.3"
-    nopt "^6.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
+    make-fetch-happen "^13.0.0"
+    nopt "^7.0.0"
+    proc-log "^3.0.0"
     semver "^7.3.5"
     tar "^6.1.2"
-    which "^2.0.2"
+    which "^4.0.0"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5399,12 +5519,12 @@ node-releases@^2.0.13:
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz"
   integrity sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==
 
-nopt@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz"
-  integrity sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==
+nopt@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
   dependencies:
-    abbrev "^1.0.0"
+    abbrev "^2.0.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -5432,6 +5552,16 @@ normalize-package-data@^5.0.0:
   integrity sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==
   dependencies:
     hosted-git-info "^6.0.0"
+    is-core-module "^2.8.1"
+    semver "^7.3.5"
+    validate-npm-package-license "^3.0.4"
+
+normalize-package-data@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-6.0.1.tgz#fa69e9452210f0fabf4d79ee08d0c2870c51ed88"
+  integrity sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==
+  dependencies:
+    hosted-git-info "^7.0.0"
     is-core-module "^2.8.1"
     semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
@@ -5491,6 +5621,16 @@ npm-package-arg@^10.0.0, npm-package-arg@^10.1.0:
     semver "^7.3.5"
     validate-npm-package-name "^5.0.0"
 
+npm-package-arg@^11.0.0:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-11.0.2.tgz#1ef8006c4a9e9204ddde403035f7ff7d718251ca"
+  integrity sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==
+  dependencies:
+    hosted-git-info "^7.0.0"
+    proc-log "^4.0.0"
+    semver "^7.3.5"
+    validate-npm-package-name "^5.0.0"
+
 npm-packlist@5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-5.1.1.tgz"
@@ -5501,24 +5641,24 @@ npm-packlist@5.1.1:
     npm-bundled "^1.1.2"
     npm-normalize-package-bin "^1.0.1"
 
-npm-packlist@^7.0.0:
-  version "7.0.4"
-  resolved "https://registry.npmjs.org/npm-packlist/-/npm-packlist-7.0.4.tgz"
-  integrity sha512-d6RGEuRrNS5/N84iglPivjaJPxhDbZmlbTwTDX2IbcRHG5bZCdtysYMhwiPvcF4GisXHGn7xsxv+GQ7T/02M5Q==
-  dependencies:
-    ignore-walk "^6.0.0"
-
-npm-pick-manifest@^8.0.0:
+npm-packlist@^8.0.0:
   version "8.0.2"
-  resolved "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz"
-  integrity sha512-1dKY+86/AIiq1tkKVD3l0WI+Gd3vkknVGAggsFeBkTvbhMQ1OND/LKkYv4JtXPKUJ8bOTCyLiqEg2P6QNdK+Gg==
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-8.0.2.tgz#5b8d1d906d96d21c85ebbeed2cf54147477c8478"
+  integrity sha512-shYrPFIS/JLP4oQmAwDyk5HcyysKW8/JLTEA32S0Z5TzvpaeeX2yMFfoK1fjEBnCBvVyIB/Jj/GBFdm0wsgzbA==
+  dependencies:
+    ignore-walk "^6.0.4"
+
+npm-pick-manifest@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-9.0.1.tgz#c90658bd726fe5bca9d2869f3e99359b8fcda046"
+  integrity sha512-Udm1f0l2nXb3wxDpKjfohwgdFUSV50UVwzEIpDXVsbDMXVIEF81a/i0UhuQbhrPMMmdiq3+YMFLFIRVLs3hxQw==
   dependencies:
     npm-install-checks "^6.0.0"
     npm-normalize-package-bin "^3.0.0"
-    npm-package-arg "^10.0.0"
+    npm-package-arg "^11.0.0"
     semver "^7.3.5"
 
-npm-registry-fetch@^14.0.0, npm-registry-fetch@^14.0.3, npm-registry-fetch@^14.0.5:
+npm-registry-fetch@^14.0.3, npm-registry-fetch@^14.0.5:
   version "14.0.5"
   resolved "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-14.0.5.tgz"
   integrity sha512-kIDMIo4aBm6xg7jOttupWZamsZRkAqMqwqqbVXnUqstY5+tapvv6bkH/qMR76jdgV+YljEUCyWx3hRYMrJiAgA==
@@ -5531,6 +5671,20 @@ npm-registry-fetch@^14.0.0, npm-registry-fetch@^14.0.3, npm-registry-fetch@^14.0
     npm-package-arg "^10.0.0"
     proc-log "^3.0.0"
 
+npm-registry-fetch@^16.0.0:
+  version "16.2.1"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-16.2.1.tgz#c367df2d770f915da069ff19fd31762f4bca3ef1"
+  integrity sha512-8l+7jxhim55S85fjiDGJ1rZXBWGtRLi1OSb4Z3BPLObPuIaeKRlPRiYMSHU4/81ck3t71Z+UwDDl47gcpmfQQA==
+  dependencies:
+    "@npmcli/redact" "^1.1.0"
+    make-fetch-happen "^13.0.0"
+    minipass "^7.0.2"
+    minipass-fetch "^3.0.0"
+    minipass-json-stream "^1.0.1"
+    minizlib "^2.1.2"
+    npm-package-arg "^11.0.0"
+    proc-log "^4.0.0"
+
 npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz"
@@ -5538,7 +5692,7 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^6.0.0, npmlog@^6.0.2:
+npmlog@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz"
   integrity sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==
@@ -5548,17 +5702,16 @@ npmlog@^6.0.0, npmlog@^6.0.2:
     gauge "^4.0.3"
     set-blocking "^2.0.0"
 
-nx@16.10.0, "nx@>=16.5.1 < 17":
-  version "16.10.0"
-  resolved "https://registry.npmjs.org/nx/-/nx-16.10.0.tgz"
-  integrity sha512-gZl4iCC0Hx0Qe1VWmO4Bkeul2nttuXdPpfnlcDKSACGu3ZIo+uySqwOF8yBAxSTIf8xe2JRhgzJN1aFkuezEBg==
+nx@19.2.0, "nx@>=17.1.2 < 20":
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-19.2.0.tgz#26bca73f7282994d4b24f36d3bc41c2884124cae"
+  integrity sha512-IewqV0eGOpp569TSjfQVIQODxkRYKSDTP0e0j20GKkMTvCAmdbJRYZxyTr6Aw6gSM7lEVgK/4yESRO5YidfV2Q==
   dependencies:
-    "@nrwl/tao" "16.10.0"
-    "@parcel/watcher" "2.0.4"
+    "@nrwl/tao" "19.2.0"
     "@yarnpkg/lockfile" "^1.1.0"
     "@yarnpkg/parsers" "3.0.0-rc.46"
-    "@zkochan/js-yaml" "0.0.6"
-    axios "^1.0.0"
+    "@zkochan/js-yaml" "0.0.7"
+    axios "^1.6.0"
     chalk "^4.1.0"
     cli-cursor "3.1.0"
     cli-spinners "2.6.1"
@@ -5568,38 +5721,37 @@ nx@16.10.0, "nx@>=16.5.1 < 17":
     enquirer "~2.3.6"
     figures "3.2.0"
     flat "^5.0.2"
+    front-matter "^4.0.2"
     fs-extra "^11.1.0"
-    glob "7.1.4"
     ignore "^5.0.4"
     jest-diff "^29.4.1"
-    js-yaml "4.1.0"
     jsonc-parser "3.2.0"
     lines-and-columns "~2.0.3"
-    minimatch "3.0.5"
+    minimatch "9.0.3"
     node-machine-id "1.1.12"
     npm-run-path "^4.0.1"
     open "^8.4.0"
-    semver "7.5.3"
+    ora "5.3.0"
+    semver "^7.5.3"
     string-width "^4.2.3"
     strong-log-transformer "^2.1.0"
     tar-stream "~2.2.0"
     tmp "~0.2.1"
     tsconfig-paths "^4.1.2"
     tslib "^2.3.0"
-    v8-compile-cache "2.3.0"
     yargs "^17.6.2"
     yargs-parser "21.1.1"
   optionalDependencies:
-    "@nx/nx-darwin-arm64" "16.10.0"
-    "@nx/nx-darwin-x64" "16.10.0"
-    "@nx/nx-freebsd-x64" "16.10.0"
-    "@nx/nx-linux-arm-gnueabihf" "16.10.0"
-    "@nx/nx-linux-arm64-gnu" "16.10.0"
-    "@nx/nx-linux-arm64-musl" "16.10.0"
-    "@nx/nx-linux-x64-gnu" "16.10.0"
-    "@nx/nx-linux-x64-musl" "16.10.0"
-    "@nx/nx-win32-arm64-msvc" "16.10.0"
-    "@nx/nx-win32-x64-msvc" "16.10.0"
+    "@nx/nx-darwin-arm64" "19.2.0"
+    "@nx/nx-darwin-x64" "19.2.0"
+    "@nx/nx-freebsd-x64" "19.2.0"
+    "@nx/nx-linux-arm-gnueabihf" "19.2.0"
+    "@nx/nx-linux-arm64-gnu" "19.2.0"
+    "@nx/nx-linux-arm64-musl" "19.2.0"
+    "@nx/nx-linux-x64-gnu" "19.2.0"
+    "@nx/nx-linux-x64-musl" "19.2.0"
+    "@nx/nx-win32-arm64-msvc" "19.2.0"
+    "@nx/nx-win32-x64-msvc" "19.2.0"
 
 object-inspect@^1.9.0:
   version "1.13.1"
@@ -5682,6 +5834,20 @@ optionator@^0.9.1:
     levn "^0.4.1"
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
+
+ora@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.3.0.tgz#fb832899d3a1372fe71c8b2c534bbfe74961bb6f"
+  integrity sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==
+  dependencies:
+    bl "^4.0.3"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    log-symbols "^4.0.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
 
 ora@^5.4.1:
   version "5.4.1"
@@ -5797,27 +5963,27 @@ p-waterfall@2.1.1:
   dependencies:
     p-reduce "^2.0.0"
 
-pacote@^15.2.0:
-  version "15.2.0"
-  resolved "https://registry.npmjs.org/pacote/-/pacote-15.2.0.tgz"
-  integrity sha512-rJVZeIwHTUta23sIZgEIM62WYwbmGbThdbnkt81ravBplQv+HjyroqnLRNH2+sLJHcGZmLRmhPwACqhfTcOmnA==
+pacote@^17.0.5:
+  version "17.0.7"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-17.0.7.tgz#14b59a9bf5e3442c891af86825b97b7d72f48fba"
+  integrity sha512-sgvnoUMlkv9xHwDUKjKQFXVyUi8dtJGKp3vg6sYy+TxbDic5RjZCHF3ygv0EJgNRZ2GfRONjlKPUfokJ9lDpwQ==
   dependencies:
-    "@npmcli/git" "^4.0.0"
+    "@npmcli/git" "^5.0.0"
     "@npmcli/installed-package-contents" "^2.0.1"
-    "@npmcli/promise-spawn" "^6.0.1"
-    "@npmcli/run-script" "^6.0.0"
-    cacache "^17.0.0"
+    "@npmcli/promise-spawn" "^7.0.0"
+    "@npmcli/run-script" "^7.0.0"
+    cacache "^18.0.0"
     fs-minipass "^3.0.0"
-    minipass "^5.0.0"
-    npm-package-arg "^10.0.0"
-    npm-packlist "^7.0.0"
-    npm-pick-manifest "^8.0.0"
-    npm-registry-fetch "^14.0.0"
-    proc-log "^3.0.0"
+    minipass "^7.0.2"
+    npm-package-arg "^11.0.0"
+    npm-packlist "^8.0.0"
+    npm-pick-manifest "^9.0.0"
+    npm-registry-fetch "^16.0.0"
+    proc-log "^4.0.0"
     promise-retry "^2.0.1"
-    read-package-json "^6.0.0"
+    read-package-json "^7.0.0"
     read-package-json-fast "^3.0.0"
-    sigstore "^1.3.0"
+    sigstore "^2.2.0"
     ssri "^10.0.0"
     tar "^6.1.11"
 
@@ -5908,6 +6074,14 @@ path-scurry@^1.10.1, path-scurry@^1.6.1:
   integrity sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==
   dependencies:
     lru-cache "^9.1.1 || ^10.0.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-type@^3.0.0:
@@ -6099,6 +6273,11 @@ proc-log@^3.0.0:
   resolved "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz"
   integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
 
+proc-log@^4.0.0, proc-log@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-4.2.0.tgz#b6f461e4026e75fdfe228b265e9f7a00779d7034"
+  integrity sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
@@ -6231,6 +6410,16 @@ read-package-json@6.0.4, read-package-json@^6.0.0:
     glob "^10.2.2"
     json-parse-even-better-errors "^3.0.0"
     normalize-package-data "^5.0.0"
+    npm-normalize-package-bin "^3.0.0"
+
+read-package-json@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-7.0.1.tgz#8b5f6aab97a796cfb436516ade24c011d10964a9"
+  integrity sha512-8PcDiZ8DXUjLf687Ol4BR8Bpm2umR7vhoZOzNRt+uxD9GpBh/K+CAAALVIiYFknmvlmyg7hM7BSNUXPaCCqd0Q==
+  dependencies:
+    glob "^10.2.2"
+    json-parse-even-better-errors "^3.0.0"
+    normalize-package-data "^6.0.0"
     npm-normalize-package-bin "^3.0.0"
 
 read-pkg-up@^3.0.0:
@@ -6487,13 +6676,6 @@ semver-compare@^1.0.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.5.3:
-  version "7.5.3"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz"
-  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
 semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
@@ -6501,7 +6683,7 @@ semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.2.1, semver@^7.3.2, semver
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -6582,7 +6764,7 @@ signale@^1.4.0:
     figures "^2.0.0"
     pkg-conf "^2.1.0"
 
-sigstore@^1.3.0, sigstore@^1.4.0:
+sigstore@^1.4.0:
   version "1.9.0"
   resolved "https://registry.npmjs.org/sigstore/-/sigstore-1.9.0.tgz"
   integrity sha512-0Zjz0oe37d08VeOtBIuB6cRriqXse2e8w+7yIy2XSXjshRKxbc2KkhXjL229jXSxEm7UbcjS76wcJDGQddVI9A==
@@ -6592,6 +6774,18 @@ sigstore@^1.3.0, sigstore@^1.4.0:
     "@sigstore/sign" "^1.0.0"
     "@sigstore/tuf" "^1.0.3"
     make-fetch-happen "^11.0.1"
+
+sigstore@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/sigstore/-/sigstore-2.3.1.tgz#0755dd2cc4820f2e922506da54d3d628e13bfa39"
+  integrity sha512-8G+/XDU8wNsJOQS5ysDVO0Etg9/2uA5gR9l4ZwijjlwxBcrU6RPfwi2+jJmbP+Ap1Hlp/nVAaEO4Fj22/SL2gQ==
+  dependencies:
+    "@sigstore/bundle" "^2.3.2"
+    "@sigstore/core" "^1.0.0"
+    "@sigstore/protobuf-specs" "^0.3.2"
+    "@sigstore/sign" "^2.3.2"
+    "@sigstore/tuf" "^2.3.4"
+    "@sigstore/verify" "^1.2.1"
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -6635,12 +6829,29 @@ socks-proxy-agent@^7.0.0:
     debug "^4.3.3"
     socks "^2.6.2"
 
+socks-proxy-agent@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz#6b2da3d77364fde6292e810b496cb70440b9b89d"
+  integrity sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==
+  dependencies:
+    agent-base "^7.1.1"
+    debug "^4.3.4"
+    socks "^2.7.1"
+
 socks@^2.6.2:
   version "2.7.1"
   resolved "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz"
   integrity sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==
   dependencies:
     ip "^2.0.0"
+    smart-buffer "^4.2.0"
+
+socks@^2.7.1:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.3.tgz#1ebd0f09c52ba95a09750afe3f3f9f724a800cb5"
+  integrity sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==
+  dependencies:
+    ip-address "^9.0.5"
     smart-buffer "^4.2.0"
 
 sonic-boom@^1.0.2:
@@ -6743,6 +6954,11 @@ split@^1.0.1:
   dependencies:
     through "2"
 
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
@@ -6755,7 +6971,7 @@ ssri@^10.0.0, ssri@^10.0.1:
   dependencies:
     minipass "^7.0.3"
 
-ssri@^9.0.0, ssri@^9.0.1:
+ssri@^9.0.1:
   version "9.0.1"
   resolved "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz"
   integrity sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==
@@ -6794,16 +7010,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6844,14 +7051,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6954,14 +7154,14 @@ tar-stream@~2.2.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@6.1.11:
-  version "6.1.11"
-  resolved "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz"
-  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+tar@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
+  integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"
-    minipass "^3.0.0"
+    minipass "^5.0.0"
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
@@ -7136,6 +7336,15 @@ tuf-js@^1.1.7:
     debug "^4.3.4"
     make-fetch-happen "^11.1.1"
 
+tuf-js@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tuf-js/-/tuf-js-2.2.1.tgz#fdd8794b644af1a75c7aaa2b197ddffeb2911b56"
+  integrity sha512-GwIJau9XaA8nLVbUXsN3IlFi7WmQ48gBUrl3FTkkL/XLu/POhBzfmX9hd33FNMX1qAsfl6ozO1iMmW9NC8YniA==
+  dependencies:
+    "@tufjs/models" "2.0.1"
+    debug "^4.3.4"
+    make-fetch-happen "^13.0.1"
+
 tv4@1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz"
@@ -7226,26 +7435,12 @@ undici-types@~5.26.4:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-unique-filename@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz"
-  integrity sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==
-  dependencies:
-    unique-slug "^3.0.0"
-
 unique-filename@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz"
   integrity sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==
   dependencies:
     unique-slug "^4.0.0"
-
-unique-slug@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz"
-  integrity sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==
-  dependencies:
-    imurmurhash "^0.1.4"
 
 unique-slug@^4.0.0:
   version "4.0.0"
@@ -7318,11 +7513,6 @@ uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
-
-v8-compile-cache@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz"
-  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"
@@ -7459,19 +7649,19 @@ which-typed-array@^1.1.2:
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
-which@^2.0.1, which@^2.0.2:
+which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
-which@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/which/-/which-3.0.1.tgz"
-  integrity sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==
+which@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
+  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
   dependencies:
-    isexe "^2.0.0"
+    isexe "^3.1.1"
 
 wide-align@^1.1.5:
   version "1.1.5"
@@ -7485,7 +7675,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7498,15 +7688,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -7604,11 +7785,6 @@ yaml@^1.10.0, yaml@^1.10.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
-  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
-
 yargs-parser@21.1.1, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
@@ -7619,20 +7795,7 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs@16.2.0, yargs@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
-  dependencies:
-    cliui "^7.0.2"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^20.2.2"
-
-yargs@^17.3.1, yargs@^17.6.2:
+yargs@17.7.2, yargs@^17.3.1, yargs@^17.6.2:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -7644,6 +7807,19 @@ yargs@^17.3.1, yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yn@3.1.1:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,10 @@
   resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-5.5.3.tgz"
   integrity sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==
 
-"@faker-js/faker@^6.0.0":
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/@faker-js/faker/-/faker-6.3.1.tgz"
-  integrity sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==
+"@faker-js/faker@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.4.1.tgz#5d5e8aee8fce48f5e189bf730ebd1f758f491451"
+  integrity sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==
 
 "@gar/promisify@^1.1.3":
   version "1.1.3"
@@ -6786,16 +6786,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6836,14 +6827,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7477,7 +7461,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7490,15 +7474,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# [WIP] feat: Update faker version 8.

**Summary**

I have upgraded my faker version to 8.1.4.
Because of many deprecations.

For example, I currently use the “image.avatar” method at work.
But it is a broken link (timedout) with the current v6 system.
(e.g. https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/934.jpg)

- I referred to this article for the migration to faker v7.
  - https://v7.fakerjs.dev/guide/upgrading.html
- For migration to faker v8, I referred to this article
  - https://fakerjs.dev/guide/upgrading

The reason for the “WIP”  is that I have finished replacing the original code, but not the documentation.

I would like your approval to proceed as is!

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A