### PR TITLE
chore: changing codeowners to team of smartbears

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @stoplightio/bear-claws
+*       @stoplightio/prism-owners


### PR DESCRIPTION
updates code owners to the [Prism Owners](https://github.com/orgs/stoplightio/teams/prism-owners) team that is full of smartbear people.
