### PR TITLE
change code owners to prism engineers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @stoplightio/prism-owners
+*       @stoplightio/prism-engineers


### PR DESCRIPTION
change code owners to stoplightio/prism-engineers as requested by Łukasz Matuszek
