### PR TITLE
fix: mock issue resolve for similar templated requests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-ref-parser": "9.2.7",
     "@stoplight/prism-core": "^5.8.0",
-    "@stoplight/prism-http": "^5.8.2",
+    "@stoplight/prism-http": "^5.8.3",
     "@stoplight/prism-http-server": "^5.8.2",
     "@stoplight/types": "^14.1.0",
     "chalk": "^4.1.2",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@stoplight/prism-core": "^5.8.0",
-    "@stoplight/prism-http": "^5.8.2",
+    "@stoplight/prism-http": "^5.8.3",
     "@stoplight/types": "^14.1.0",
     "fast-xml-parser": "^4.2.0",
     "fp-ts": "^2.11.5",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/prism-http",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/http/src/router/__tests__/index.spec.ts
+++ b/packages/http/src/router/__tests__/index.spec.ts
@@ -316,7 +316,7 @@ describe('http router', () => {
           );
         });
 
-        test('given a concrete servers and templated paths should match first resource', () => {
+        test('given a concrete servers and templated paths should match second resource', () => {
           const templatedPathA = '/{x}/y';
           const templatedPathB = '/a/{z}';
           const url = 'concrete.com';
@@ -334,7 +334,7 @@ describe('http router', () => {
                 },
               },
             }),
-            resource => expect(resource).toBe(firstResource)
+            resource => expect(resource).toBe(secondResource)
           );
         });
 

--- a/packages/http/src/router/index.ts
+++ b/packages/http/src/router/index.ts
@@ -2,6 +2,7 @@ import { IPrismComponents } from '@stoplight/prism-core';
 import { IHttpOperation, IServer } from '@stoplight/types';
 import * as E from 'fp-ts/Either';
 import * as A from 'fp-ts/Array';
+import * as O from 'fp-ts/Ord';
 import { pipe } from 'fp-ts/function';
 import { IHttpConfig, IHttpRequest, ProblemJsonError } from '../types';
 import {
@@ -14,16 +15,42 @@ import {
 import { matchBaseUrl } from './matchBaseUrl';
 import { matchPath } from './matchPath';
 import { IMatch, MatchType } from './types';
+import { isTemplated } from './matchPath';
+
+// matching score is calcualated for resources based upon their match with given request
+// matchScore is introduced to sort the resources in case we get multiple matches for given request.
+const calculateMatchScore = (endpoint: string, request: string) => {
+  const endpointParts = endpoint.split('/');
+  const requestParts = request.split('/');
+  let score = 0;
+  for (let i = 0; i < endpointParts.length; i++) {
+    if (endpointParts[i] === requestParts[i]) {
+      score++;
+    } else if (isTemplated(endpointParts[i])) {
+      score += 0.5;
+    } else {
+      break;
+    }
+  }
+  return score;
+};
+
+
+//sort endpoints based on match score
+const sortEndpointsByMatch = (endpoints:IHttpOperation[], request: string) => {
+  return A.sort(O.contramap((endpoint: IHttpOperation) => calculateMatchScore(endpoint.path, request))(O.ordNumber))(endpoints).reverse();
+};
 
 const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig>['route'] = ({ resources, input }) => {
   const { path: requestPath, baseUrl: requestBaseUrl } = input.url;
+  const sortedResources = sortEndpointsByMatch(resources, requestPath);
 
   if (!requestPath.startsWith('/')) {
     return E.left(new Error(`The request path '${requestPath}' must start with a slash.`));
   }
 
   return pipe(
-    resources,
+    sortedResources,
     E.fromPredicate(A.isNonEmpty, () =>
       ProblemJsonError.fromTemplate(
         NO_RESOURCE_PROVIDED_ERROR,
@@ -101,7 +128,7 @@ const route: IPrismComponents<IHttpOperation, IHttpRequest, unknown, IHttpConfig
       }
 
       if (requestBaseUrl) {
-        if (resources.every(resource => !resource.servers || resource.servers.length === 0)) {
+        if (sortedResources.every(resource => !resource.servers || resource.servers.length === 0)) {
           return E.left(
             ProblemJsonError.fromTemplate(
               NO_SERVER_CONFIGURATION_PROVIDED_ERROR,

--- a/packages/http/src/router/matchPath.ts
+++ b/packages/http/src/router/matchPath.ts
@@ -9,7 +9,7 @@ function fragmentize(path: string): string[] {
   return path.split('/').slice(1).map(decodePathFragment);
 }
 
-function isTemplated(pathFragment: string) {
+export function isTemplated(pathFragment: string) {
   return /{(.+)}/.test(pathFragment);
 }
 


### PR DESCRIPTION
Addresses STOP-448

**Summary**

We observe that the issue is occurring in mock server when OAS is having similar templated requests as below example. Request was getting mapped with wrong endpoint and mock server was returning 400 error code.
 
Consider following API endpoints defined in project spec. 
1.	[https://stoplight-local.com:8443/mocks/seeded-enterprise/mock/174/{initgPtyIdOrgId}/payments/{paymentId}](https://stoplight-local.com:8443/mocks/seeded-enterprise/mock/174/%7BinitgPtyIdOrgId%7D/payments/%7BpaymentId%7D)
2.	[https://stoplight-local.com:8443/mocks/seeded-enterprise/mock/174/{initgPtyIdOrgId}/payments/search](https://stoplight-local.com:8443/mocks/seeded-enterprise/mock/174/%7BinitgPtyIdOrgId%7D/payments/search)
 
we can find two paths here - 
1. /{initgPtyIdOrgId}/payments/{paymentId}
2. /{initgPtyIdOrgId}/payments/search
 
If we call search Api from mock server our request will be encoded to "/SMARTBEAR/payments/search". here "SMARTBEAR" is initgPtyIdOrgId. And if call is made to payment API, request will be encoded to - SMARTBEAR/payments/paytm123. Here SMARTBEAR is initgPtyIdOrgId and paytm123 is paymentId. But if you compare the both requests looks similar.
 
There is matchPath function in prism-http which is handling request and endpoint mapping functionality and for above scenario it is returning two endpoint objects for search API. Ideally it should return single object array. And make-payment API is placed before search Api in spec, make-Api object will be the first item in array and matchPath is using first item from array to call mock Api.
 
To solve this, I created the sorting function in http-spec where all these endpoints will be sorted on the basis their match with request path. In case we get multiple matched endpoints for any request, this sorting will make sure that first endpoint in array is close match to request.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
