### PR TITLE
chore: Fix 'fast-xml-parser' vulnerability

### DIFF
--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -22,7 +22,7 @@
     "@stoplight/prism-core": "^5.8.0",
     "@stoplight/prism-http": "^5.8.4",
     "@stoplight/types": "^14.1.0",
-    "fast-xml-parser": "^4.2.0",
+    "fast-xml-parser": "^4.4.1",
     "fp-ts": "^2.11.5",
     "io-ts": "^2.2.16",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Addresses #2580

**Summary**

Fixes the 'fast-xml-parser' vulnerability. https://github.com/advisories/GHSA-mpg4-rc92-vx8v

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

N/A

**Additional context**

N/A
