### PR TITLE
refactor(docker): AS casing match FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as compiler
+FROM node:18 AS compiler
 
 WORKDIR /usr/src/prism
 
@@ -8,7 +8,7 @@ COPY packages/ /usr/src/prism/packages/
 RUN yarn && yarn build
 
 ###############################################################
-FROM node:18 as dependencies
+FROM node:18 AS dependencies
 
 WORKDIR /usr/src/prism/
 


### PR DESCRIPTION
**Summary**

Avoid a minor warning from Docker when building.

> While Dockerfile keywords can be either uppercase or lowercase, mixing case styles is not recommended for readability.

https://docs.docker.com/reference/build-checks/from-as-casing/

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

```
$ docker build .
...
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                               0.1s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 11)                                              0.1s
...

$ docker version
Client: Docker Engine - Community
 Version:           27.2.1
...

Server: Docker Engine - Community
 Engine:
  Version:          27.2.1
...
```
