### PR TITLE
fix(Docker): use tini to handle kernel signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN if [ $(uname -m) != "aarch64" ]; then node-prune; fi
 ###############################################################
 FROM node:18-alpine
 
+# https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
+RUN apk add --no-cache tini
+
 WORKDIR /usr/src/prism
 ARG BUILD_TYPE=development
 ENV NODE_ENV production
@@ -68,4 +71,4 @@ fi
 
 EXPOSE 4010
 
-ENTRYPOINT [ "node", "dist/index.js" ]
+ENTRYPOINT [ "/sbin/tini", "--", "node", "dist/index.js" ]


### PR DESCRIPTION
**Summary**

Use [tini](https://github.com/krallin/tini) to handle kernel signals for Node.js, per https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals

For example, this aids shutting down. In a Docker compose setup Docker will send SIGINT and wait ten seconds for the container to stop. Without tini, prism does not get the signal and the 10s timeout forces stopping. With tini, prism closes in under a second.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A
