### PR TITLE
chore(deps-dev): bump json-schema-faker from 0.5.6 to 0.5.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "fp-ts": "^2.11.5",
-    "json-schema-faker": "0.5.6",
+    "json-schema-faker": "0.5.8",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.5",
     "pino": "^6.13.3",


### PR DESCRIPTION
Addresses #[[2611](https://github.com/stoplightio/prism/issues/2611)]

**Summary**

`json-schema-faker@0.5.8` includes the patched version of `jsonpath-plus` against https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A