### PR TITLE
feat: Print validation results even when --errors flag is passed

### DIFF
--- a/docs/guides/06-errors.md
+++ b/docs/guides/06-errors.md
@@ -194,7 +194,7 @@ curl http://localhost:4010/todos -H "accept: application/json"`
 
 **Returned Status Code: `500`**
 
-**Explanation:** This error occurs when you're run Prism with the `--errors` flag and the request or the response has at least one violation marked as an error.
+**Explanation:** This error occurs when you've run Prism with the `--errors` flag and the request or the response has at least one violation marked as an error.
 
 **Message #2: response.body Request body must match exactly one schema in oneOf**
 

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -121,21 +121,11 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
 
         if (inputOutputValidationErrors.length > 0) {
           addViolationHeader(reply, inputOutputValidationErrors);
-
-          const errorViolations = outputValidationErrors.filter(
-            v => v.severity === DiagnosticSeverity[DiagnosticSeverity.Error]
-          );
-
-          if (opts.config.errors && errorViolations.length > 0) {
-            return IOE.left(
-              ProblemJsonError.fromTemplate(
-                VIOLATIONS,
-                'Your request/response is not valid and the --errors flag is set, so Prism is generating this error for you.',
-                { validation: errorViolations }
-              )
-            );
-          }
         }
+
+        const errorViolations = outputValidationErrors.filter(
+          v => v.severity === DiagnosticSeverity[DiagnosticSeverity.Error]
+        );
 
         inputOutputValidationErrors.forEach(validation => {
           const message = `Violation: ${validation.location.join('.') || ''} ${validation.message}`;
@@ -147,6 +137,16 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
             components.logger.info({ name: 'VALIDATOR' }, message);
           }
         });
+
+        if (opts.config.errors && errorViolations.length > 0) {
+          return IOE.left(
+            ProblemJsonError.fromTemplate(
+              VIOLATIONS,
+              'Your request/response is not valid and the --errors flag is set, so Prism is generating this error for you.',
+              { validation: errorViolations }
+            )
+          );
+        }
 
         return IOE.fromEither(
           E.tryCatch(() => {


### PR DESCRIPTION
**Summary**

My team wants to integrate the Prism proxy into our CI pipeline, without having to modify all our existing e2e tests to print out the validation errors in case of failure.

This PR changes the behaviour of the `--errors` flag so that in addition to returning validation errors in the response body (the existing behaviour), the validation failures are also printed in the prism proxy output (similar to the current behaviour **without** the `--errors` flag).

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A (I'm open to adding a test, but the change didn't affect any existing tests)
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

Proxy output with `--errors` before change:

![2024-11-15_13-59](https://github.com/user-attachments/assets/acb08f05-88e4-4a68-8225-a1bb8bfeff77)

Proxy output with `--errors` after change:

![2024-11-15_13-58](https://github.com/user-attachments/assets/c30e7be4-8fc5-44aa-9bd1-08ab733d5cd2)
