### PR TITLE
fixed prism-cli build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "tsconfig-paths": "^4.1.0",
     "ttypescript": "^1.5.15",
     "type-is": "^1.6.18",
-    "typescript": "4.9.3",
-    "jsonrepair": "^3.12.0"
+    "typescript": "4.9.3"
   },
   "lint-staged": {
     "**/packages/**/*.ts": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,8 @@
     "tslib": "^2.3.1",
     "uri-template-lite": "^22.9.0",
     "urijs": "^1.19.11",
-    "yargs": "^16.2.0"
+    "yargs": "^16.2.0",
+    "jsonrepair": "^3.12.0"
   },
   "engines": {
     "node": ">=18.20.1"


### PR DESCRIPTION

 [STOP-2386](https://smartbear.atlassian.net/browse/STOP-2386)

Summary

Issue logged while running prism-cli.

Current Behavior
The customer has raised an issue that the prism-cli is not build properly and getting the below error
`Error: Cannot find module 'jsonrepair'`

Tests

Tested the changes by running the `yarn build` command and run successfully. 

 N/A
Event Tracking
 I added event tracking and followed the event tracking guidelines
 N/A
Error Reporting
 I reported errors and followed the error reporting guidelines
 N/A