### PR TITLE
fixed prism-cli build issue

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
     "@stoplight/json": "3.21.7",
     "@stoplight/json-schema-ref-parser": "9.2.7",
     "@stoplight/prism-core": "^5.8.0",
-    "@stoplight/prism-http": "5.12.1",
+    "@stoplight/prism-http": "5.12.0",
     "@stoplight/prism-http-server": "^5.12.1",
     "@stoplight/types": "^14.1.0",
     "chalk": "^4.1.2",

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@stoplight/prism-core": "^5.8.0",
-    "@stoplight/prism-http": "^5.12.1",
+    "@stoplight/prism-http": "^5.12.0",
     "@stoplight/types": "^14.1.0",
     "fast-xml-parser": "^4.2.0",
     "fp-ts": "^2.11.5",


### PR DESCRIPTION
Addresses :- prism-cli requests prism-http@5.12.1 but this version doesn't exist

**Summary**

prism-cli requests prism-http@5.12.1 but this version doesn't exist so change package.json

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.
