### PR TITLE
feat: Validate request option in Mock mode

### DIFF
--- a/packages/cli/src/commands/__tests__/commands.spec.ts
+++ b/packages/cli/src/commands/__tests__/commands.spec.ts
@@ -87,3 +87,11 @@ test(`starts proxy server with default validate-request option to be overriden`,
     expect.objectContaining({ validateRequest: false, host: '0.0.0.0' })
   );
 });
+
+test(`starts mock server with default validate-request option to be overriden`, () => {
+  parser.parse(`mock /path/to -m -h 0.0.0.0 --validate-request=false`);
+
+  expect(createMultiProcessPrism).toHaveBeenLastCalledWith(
+    expect.objectContaining({ validateRequest: false, host: '0.0.0.0' })
+  );
+});

--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -43,7 +43,8 @@ const mockCommand: CommandModule = {
       }),
   handler: async parsedArgs => {
     parsedArgs.jsonSchemaFakerFillProperties = parsedArgs['json-schema-faker-fillProperties'];
-    const { multiprocess, dynamic, port, host, cors, document, errors, verboseLevel, ignoreExamples, seed, jsonSchemaFakerFillProperties } =
+    parsedArgs.validateRequest = parsedArgs['validate-request'];
+    const { multiprocess, dynamic, port, host, cors, document, errors, verboseLevel, ignoreExamples, seed, jsonSchemaFakerFillProperties, validateRequest } =
       parsedArgs as unknown as CreateMockServerOptions;
 
     const createPrism = multiprocess ? createMultiProcessPrism : createSingleProcessPrism;
@@ -59,6 +60,7 @@ const mockCommand: CommandModule = {
       ignoreExamples,
       seed,
       jsonSchemaFakerFillProperties,
+      validateRequest,
     };
 
     await runPrismAndSetupWatcher(createPrism, options);

--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -26,11 +26,6 @@ const proxyCommand: CommandModule = {
       })
       .options({
         ...sharedOptions,
-        'validate-request': {
-          description: 'Validate incoming HTTP requests.',
-          boolean: true,
-          default: true,
-        },
         'upstream-proxy': {
           description:
             'If an http proxy is required to reach upstream, formatted as "{protocol}://[{user}[:{password}]@]{host}[:{port}]". eg "http://myUser:myPassword@proxy.example.com:1234"',

--- a/packages/cli/src/commands/sharedOptions.ts
+++ b/packages/cli/src/commands/sharedOptions.ts
@@ -39,6 +39,12 @@ const sharedOptions: Dictionary<Options> = {
     default: false,
   },
 
+  'validate-request': {
+    description: 'Validate incoming HTTP requests.',
+    boolean: true,
+    default: true,
+  },
+
   verboseLevel: {
     alias: 'v',
     description: 'Turns on verbose logging.',

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -81,7 +81,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     throw new Error('No operations found in the current file.');
   }
 
-  const validateRequest = isProxyServerOptions(options) ? options.validateRequest : true;
+  const validateRequest = options.validateRequest !== undefined ? options.validateRequest : true;
   const shared = {
     validateRequest,
     validateResponse: true,

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -168,6 +168,7 @@ type CreateBaseServerOptions = {
   ignoreExamples: boolean;
   seed: string;
   jsonSchemaFakerFillProperties: boolean;
+  validateRequest?: boolean;
 };
 
 export interface CreateProxyServerOptions extends CreateBaseServerOptions {


### PR DESCRIPTION
Addresses #2695 

**Summary**

Replace this with something that explains what this PR is for and why it matters.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**

BEFORE

`yarn cli mock ../../examples/museum.openapi.yaml`

![IMG 2025-04-22 at 11 03 47@2x](https://github.com/user-attachments/assets/16033788-f558-4d10-9b51-fac6c738f3ee)

![IMG 2025-04-22 at 11 01 34@2x](https://github.com/user-attachments/assets/4038e996-7ffa-4055-b3e8-689e3d8dfce6)


AFTER

`yarn cli mock ../../examples/museum.openapi.yaml --validate-request=false`

![IMG 2025-04-22 at 11 03 13@2x](https://github.com/user-attachments/assets/a8dff1ed-7396-4fab-be93-1ae6b29db54b)

![IMG 2025-04-22 at 11 02 38@2x](https://github.com/user-attachments/assets/0a845e69-34b4-4bcf-aff8-79b268042a77)
