### PR TITLE
Fix for https://github.com/advisories/GHSA-hw8r-x6gr-5gjp

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "resolutions": {
     "sanitize-html": "2.12.1",
-    "jsonpath-plus":"10.2.0"
+    "jsonpath-plus":"10.3.0"
   },
   "devDependencies": {
     "@stoplight/types": "^14.1.0",


### PR DESCRIPTION

**Summary**

Upgrading the jsonpath-plus to 10.3.0 to fix the vulnerability issue https://security.snyk.io/vuln/SNYK-JS-JSONPATHPLUS-7945884 

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Before:**

![image](https://github.com/user-attachments/assets/1e4b3032-9bca-4df8-ae12-0c22ef2ab022)

**After:**

![image](https://github.com/user-attachments/assets/b3f5fd27-43e2-4336-807e-df7210e285ee)
