### PR TITLE
fix: style validation function error

### DIFF
--- a/packages/http/src/validator/deserializers/style/label.ts
+++ b/packages/http/src/validator/deserializers/style/label.ts
@@ -9,11 +9,11 @@ export function deserializeLabelStyle(
 ): unknown {
   const type = schema ? schema.type : 'undefined';
 
-  if (!parameters[name].startsWith('.')) {
+  if (!parameters[name].toString().startsWith('.')) {
     throw new Error('Label serialization style requires parameter to be prefixed with "."');
   }
 
-  const value = parameters[name].substr(1);
+  const value = parameters[name].toString().subString(1);
 
   if (type === 'array') {
     return deserializeArray(value, explode);

--- a/packages/http/src/validator/deserializers/style/label.ts
+++ b/packages/http/src/validator/deserializers/style/label.ts
@@ -13,7 +13,7 @@ export function deserializeLabelStyle(
     throw new Error('Label serialization style requires parameter to be prefixed with "."');
   }
 
-  const value = parameters[name].toString().subString(1);
+  const value = parameters[name].toString().substring(1);
 
   if (type === 'array') {
     return deserializeArray(value, explode);

--- a/packages/http/src/validator/deserializers/style/matrix.ts
+++ b/packages/http/src/validator/deserializers/style/matrix.ts
@@ -11,11 +11,11 @@ export function deserializeMatrixStyle(
 ): unknown {
   const type = schema ? schema.type : 'undefined';
 
-  if (!parameters[name].startsWith(';')) {
+  if (!parameters[name].toString().startsWith(';')) {
     throw new Error('Matrix serialization style requires parameter to be prefixed with ";"');
   }
 
-  const value = parameters[name].substr(1);
+  const value = parameters[name].subString(1);
 
   if (type === 'array') {
     return explode ? deserializeImplodeArray(name, value) : deserializeArray(name, value);
@@ -28,11 +28,11 @@ export function deserializeMatrixStyle(
 
 function deserializePrimitive(name: string, value: string) {
   const prefix = name + '=';
-  if (!value.startsWith(prefix)) {
+  if (!value.toLowerCase().startsWith(prefix)) {
     throw new Error('Matrix serialization style requires parameter to be prefixed with name');
   }
 
-  return value.substr(prefix.length);
+  return value.subString(prefix.length);
 }
 
 function deserializeArray(name: string, value: string) {

--- a/packages/http/src/validator/deserializers/style/matrix.ts
+++ b/packages/http/src/validator/deserializers/style/matrix.ts
@@ -15,7 +15,7 @@ export function deserializeMatrixStyle(
     throw new Error('Matrix serialization style requires parameter to be prefixed with ";"');
   }
 
-  const value = parameters[name].subString(1);
+  const value = parameters[name].substring(1);
 
   if (type === 'array') {
     return explode ? deserializeImplodeArray(name, value) : deserializeArray(name, value);
@@ -32,7 +32,7 @@ function deserializePrimitive(name: string, value: string) {
     throw new Error('Matrix serialization style requires parameter to be prefixed with name');
   }
 
-  return value.subString(prefix.length);
+  return value.substring(prefix.length);
 }
 
 function deserializeArray(name: string, value: string) {

--- a/packages/http/src/validator/deserializers/style/simple.ts
+++ b/packages/http/src/validator/deserializers/style/simple.ts
@@ -8,7 +8,7 @@ export function deserializeSimpleStyle(
   explode?: boolean
 ): unknown {
   const type = schema ? schema.type : 'undefined';
-  const value = parameters[name];
+  const value = parameters[name].toString();
 
   if (type === 'array') {
     return deserializeArray(value);

--- a/packages/http/src/validator/deserializers/style/simple.ts
+++ b/packages/http/src/validator/deserializers/style/simple.ts
@@ -8,7 +8,7 @@ export function deserializeSimpleStyle(
   explode?: boolean
 ): unknown {
   const type = schema ? schema.type : 'undefined';
-  const value = parameters[name].toString();
+  const value = parameters[name] == undefined ? parameters[name] : parameters[name].toString();
 
   if (type === 'array') {
     return deserializeArray(value);


### PR DESCRIPTION
Addresses #2710

**Summary**

Currently there is a bug that prevents the validation with the styles. This bug happens because it is invoking a method from a string when the object is not a string. To fix that, it is applied a .toString() to the object before the other methods are call.

Also, there is a second bug. This one affects the style Matrix. When the field has some uppercase letter (like camelCase), the name of the field from the OpenAPI is totally in lowercase. This name of the field is compared with the name of the field in the request, which is not applied this lowercase to all of its letters, meaning that even if is written, for example, nameId in the OpenAPI and it is sent nameId in the request, it always fail due comparing nameid to nameId. To fix that, it is applied a lowercase also to request field name. Ideally, the solution would be to not lowercase the field name from the OpenAPI, but my knowledge of the system is not so deep to implement that solution.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] Passing
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [x] I reported errors and followed the error reporting guidelines
  - [ ] N/A
