### PR TITLE
fix: When the log level is set to debug, output queries

### DIFF
--- a/packages/http-server/src/__tests__/body-params-validation.spec.ts
+++ b/packages/http-server/src/__tests__/body-params-validation.spec.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '@stoplight/prism-core';
 import { IHttpOperation } from '@stoplight/types';
-import fetch, { RequestInit } from 'node-fetch';
+import fetch, { FetchError, RequestInit } from 'node-fetch';
 import { createServer } from '../';
 import { ThenArg } from '../types';
 import * as faker from '@faker-js/faker/locale/en';
@@ -37,7 +37,18 @@ async function instantiatePrism(operations: IHttpOperation[]) {
 describe('body params validation', () => {
   let server: ThenArg<ReturnType<typeof instantiatePrism>>;
 
-  afterEach(() => server.close());
+  afterEach(async () => {
+    await server.close();
+
+    while (true) {
+      try {
+        await makeRequest('/');
+      } catch (err) {
+        if ((err instanceof FetchError) && (err as any).code === 'ECONNREFUSED') break;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+    }
+  });
 
   function makeRequest(url: string, init?: RequestInit) {
     return fetch(new URL(url, server.address), init);

--- a/packages/http/src/forwarder/index.ts
+++ b/packages/http/src/forwarder/index.ts
@@ -121,7 +121,7 @@ export function serializeBody(body: unknown): E.Either<Error, string | undefined
 function logForwardRequest({ logger, url, request }: { logger: Logger; url: string; request: IHttpRequest }) {
   const prefix = `${chalk.grey('> ')}`;
   logger.info(`${prefix}Forwarding "${request.method}" request to ${url}...`);
-  logRequest({ logger, prefix, ...pick(request, 'body', 'headers') });
+  logRequest({ logger, prefix, ...pick(request, 'body', 'headers', 'url') });
 }
 
 function forwardResponseLogger(logger: Logger) {

--- a/packages/http/src/mocker/callback/callbacks.ts
+++ b/packages/http/src/mocker/callback/callbacks.ts
@@ -63,7 +63,7 @@ function logCallbackRequest({
 }) {
   const prefix = `${chalk.blueBright(callbackName + ':')} ${chalk.grey('> ')}`;
   logger.info(`${prefix}Executing "${requestData.method}" callback to ${url}...`);
-  logRequest({ logger, prefix, ...pick(requestData, 'body', 'headers') });
+  logRequest({ logger, prefix, ...pick(requestData, 'body', 'headers', 'url') });
 }
 
 function callbackResponseLogger({ logger, callbackName }: { logger: Logger; callbackName: string }) {

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -69,7 +69,7 @@ const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpM
 
   return pipe(
     withLogger(logger => {
-      logRequest({ logger, prefix: `${chalk.grey('< ')}`, ...pick(input.data, 'body', 'headers') });
+      logRequest({ logger, prefix: `${chalk.grey('< ')}`, ...pick(input.data, 'body', 'headers', 'url') });
 
       // setting default values
       const acceptMediaType = input.data.headers && caseless(input.data.headers).get('accept');

--- a/packages/http/src/utils/__tests__/logger.spec.ts
+++ b/packages/http/src/utils/__tests__/logger.spec.ts
@@ -1,5 +1,5 @@
 import { DiagnosticSeverity } from '@stoplight/types';
-import { logBody, logHeaders, logRequest, logResponse, violationLogger } from '../logger';
+import { logBody, logHeaders, logQuery, logRequest, logResponse, violationLogger } from '../logger';
 
   const logger: any = {
     error: jest.fn(),
@@ -91,16 +91,38 @@ import { logBody, logHeaders, logRequest, logResponse, violationLogger } from '.
       });
     });
   });
+
+  describe('logQuery()', () => {
+    beforeEach(() => jest.clearAllMocks());
+  
+    describe('when query supplied', () => {
+      it('logs with debug level', () => {
+        logQuery({ logger, query: { a: 'a', b: ['b1', 'b2'] } });
+        expect(logger.debug).toHaveBeenNthCalledWith(1, expect.stringContaining('Query'));
+        expect(logger.debug).toHaveBeenNthCalledWith(2, expect.stringContaining('a: a'));
+        expect(logger.debug).toHaveBeenNthCalledWith(3, expect.stringContaining('b: ["b1","b2"]'));
+      });
+    });
+  
+    describe('when query not supplied', () => {
+      it('logs nothing', () => {
+        logQuery({ logger , query: {} });
+        expect(logger.debug).not.toHaveBeenCalled();
+      });
+    });
+  });
   
   describe('logRequest()', () => {
     beforeEach(() => jest.clearAllMocks());
   
     describe('when both body and headers are supplied', () => {
       it('logs', () => {
-        logRequest({ logger, prefix: 'The ', body: 'of an American', headers: { the: 'Pogues' } });
+        logRequest({ logger, prefix: 'The ', body: 'of an American', headers: { the: 'Pogues' }, url: { path: '/', query: { q: 'search' } } });
         expect(logger.debug).toHaveBeenNthCalledWith(1, expect.stringMatching(/The .*Headers:/));
         expect(logger.debug).toHaveBeenNthCalledWith(2, expect.stringContaining('the: Pogues'));
         expect(logger.debug).toHaveBeenNthCalledWith(3, expect.stringMatching(/The .*Body:.* of an American/));
+        expect(logger.debug).toHaveBeenNthCalledWith(4, expect.stringMatching(/The .*Query:/));
+        expect(logger.debug).toHaveBeenNthCalledWith(5, expect.stringContaining('q: search'));
       });
     });
   

--- a/packages/http/src/utils/logger.ts
+++ b/packages/http/src/utils/logger.ts
@@ -7,7 +7,7 @@ import { pipe } from 'fp-ts/lib/function';
 import * as Option from 'fp-ts/lib/Option';
 import * as chalk from 'chalk';
 
-import { IHttpRequest, IHttpResponse } from '../types';
+import { IHttpNameValues, IHttpRequest, IHttpResponse, IHttpUrl } from '../types';
 import { serializeBody } from '../forwarder';
 
 export const violationLogger = withLogger(logger => {
@@ -26,6 +26,7 @@ export const violationLogger = withLogger(logger => {
 
 type HeadersInput = RequestInit['headers'] | Response['headers'] | IHttpRequest['headers'] | IHttpResponse['headers'];
 type BodyInput = RequestInit['body'] | Response['body'] | IHttpRequest['body'] | IHttpResponse['body'];
+type UrlInput = IHttpUrl;
 
 export function logHeaders({
   logger,
@@ -60,16 +61,32 @@ export function logBody({ logger, prefix = '', body }: { logger: Logger; prefix?
   );
 }
 
+export function logQuery({ logger, prefix = '', query }: { logger: Logger; prefix?: string; query: IHttpNameValues }) {
+  pipe(
+    Option.fromNullable(query),
+    Option.filter(q => Object.keys(q).length > 0),
+    Option.map(query => {
+      logger.debug(`${prefix}${chalk.grey('Query:')}`);
+      Object.entries(query).forEach(([name, value]) => {
+        const out = Array.isArray(value) ? JSON.stringify(value) : value;
+        logger.debug(`${prefix}\t${name}: ${out}`);
+      });
+    })
+  );
+}
+
 export function logRequest({
   logger,
   prefix = '',
   headers,
   body,
+  url,  
 }: {
   logger: Logger;
   prefix?: string;
   body?: BodyInput;
   headers?: HeadersInput;
+  url?: UrlInput;
 }) {
   pipe(
     Option.fromNullable(headers),
@@ -89,6 +106,17 @@ export function logRequest({
         logger,
         prefix,
         body,
+      })
+    )
+  );
+
+  pipe(
+    Option.fromNullable(url?.query), 
+    Option.map(query => 
+      logQuery({
+        logger,
+        prefix,
+        query,
       })
     )
   );


### PR DESCRIPTION
Addresses #2351

**Summary**

Replace this with something that explains what this PR is for and why it matters.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Screenshots**
<img width="1259" height="385" alt="ss" src="https://github.com/user-attachments/assets/6f1d1a78-bb03-4adf-9a90-4ba43eec70e8" />

**Additional context**

I also fixed the test code that was failing with `yarn test` in its pre-revised state. f3366751a896e4f93d0b764221f9329ed415b4f4  
Is it just my environment?  
  
I'm not familiar with Node.js and this is my first PR, so I apologize in advance for any shortcomings.