### PR TITLE
✨ Quality: Add disableRemock configuration option to proxy config types

### DIFF
--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -18,7 +18,7 @@ export interface IHttpOperationConfig {
 }
 
 export type IHttpMockConfig = Overwrite<IPrismMockConfig, { mock: IHttpOperationConfig }>;
-export type IHttpProxyConfig = Overwrite<IPrismProxyConfig, { mock: IHttpOperationConfig }>;
+export type IHttpProxyConfig = Overwrite<IPrismProxyConfig, { mock: IHttpOperationConfig; disableRemock?: boolean }>;
 
 export type IHttpConfig = IHttpProxyConfig | IHttpMockConfig;
 


### PR DESCRIPTION
## ✨ Code Quality

### Problem
Add a new boolean configuration option `disableRemock` to the IHttpProxyConfig interface that allows users to disable the automatic remock feature when upstream server returns 501.

**Severity**: `high`
**File**: `packages/http/src/types.ts`

### Solution
Add `disableRemock?: boolean;` to the IHttpProxyConfig interface. This should be optional with a default value of false (remock enabled by default for backward compatibility). The type should be added alongside other proxy-specific configuration options.

### Changes
- `packages/http/src/types.ts` (modified)

Addresses #[ISSUE_NUMBER]

**Summary**

Replace this with something that explains what this PR is for and why it matters.

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2553