### PR TITLE
✨ Quality: Add dynamic and json-schema-faker-fillProperties to shared options

### DIFF
--- a/packages/cli/src/commands/sharedOptions.ts
+++ b/packages/cli/src/commands/sharedOptions.ts
@@ -48,6 +48,18 @@ const sharedOptions: Dictionary<Options> = {
     // custom levels like "success" and "start" are set to the same severity value as "info"
     choices: Object.keys(pino.levels.values).concat('silent'),
   },
+
+  dynamic: {
+    description: 'Enables dynamic mode, generating responses based on the OpenAPI schema.',
+    boolean: true,
+    default: false,
+  },
+
+  'json-schema-faker-fillProperties': {
+    description: 'Number of properties to generate in dynamic mode (0 for all properties).',
+    number: true,
+    default: 0,
+  },
 };
 
 export default sharedOptions;


### PR DESCRIPTION
## ✨ Code Quality

### Problem
Currently these options are only available in the mock command. To enable dynamic mode in proxy, we need to move these options to the shared options file so both mock and proxy commands can use them.

**Severity**: `high`
**File**: `packages/cli/src/commands/sharedOptions.ts`

### Solution
Add two new option definitions:

### Changes
- `packages/cli/src/commands/sharedOptions.ts` (modified)

Addresses #[ISSUE_NUMBER]

**Summary**

Replace this with something that explains what this PR is for and why it matters.

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2529