### PR TITLE
fix(ci): run yarn build before publishing npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Install dependencies
         run: yarn --frozen-lockfile
 
+      - name: Build
+        run: yarn build
+
       - name: Version bump & GitHub release
         run: |
           git config user.email "swagger-bot@smartbear.com"


### PR DESCRIPTION
## Summary

- The `release` job was calling `lerna publish from-package` without first running `yarn build`
- All packages have `"files": ["/dist"]` in their `package.json`, so publishing without a build results in empty npm packages (missing `dist/`)
- The `validate` job does build, but runs on a separate runner — its artifacts are not shared with the `release` job

## Root cause

Each GitHub Actions job gets a fresh runner. The build output from the `validate` job is discarded after that job completes, so the `release` job must build independently before publishing.

## Fix

Add `yarn build` to the `release` job, immediately after `yarn --frozen-lockfile` and before the version bump / publish steps.

Fixes #2782

🤖 Generated with [Claude Code](https://claude.com/claude-code)