### PR TITLE
fix(http): skip transport-level headers in mock response generation

### DIFF
--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -1,5 +1,5 @@
 import { createLogger, IPrismInput } from '@stoplight/prism-core';
-import { IHttpOperation, INodeExample, DiagnosticSeverity } from '@stoplight/types';
+import { IHttpOperation, INodeExample, DiagnosticSeverity, HttpParamStyles } from '@stoplight/types';
 import { right } from 'fp-ts/ReaderEither';
 import * as E from 'fp-ts/Either';
 import { flatMap } from 'lodash';
@@ -673,6 +673,78 @@ describe('mocker', () => {
         assertRight(mockResult, result => {
           expect(result.body).toHaveProperty('name');
           expect(result.body).toHaveProperty('surname');
+        });
+      });
+    });
+
+    describe('transport-level headers', () => {
+      it('does not include Content-Encoding in mocked response headers', () => {
+        jest.spyOn(helpers, 'negotiateOptionsForValidRequest').mockReturnValue(
+          right({
+            code: '200',
+            mediaType: 'application/json',
+            bodyExample: { id: 'test', key: 'test', value: { message: 'ok' } },
+            headers: [
+              {
+                id: 'Content-Encoding',
+                name: 'Content-Encoding',
+                style: HttpParamStyles.Simple,
+                schema: { type: 'string' as const, enum: ['gzip', 'deflate', 'br'] },
+              },
+              {
+                id: 'X-Request-Id',
+                name: 'X-Request-Id',
+                style: HttpParamStyles.Simple,
+                schema: { type: 'string' as const },
+              },
+            ],
+          })
+        );
+
+        const mockResult = mock({
+          config: { dynamic: false },
+          resource: mockResource,
+          input: mockInput,
+        })(logger);
+
+        assertRight(mockResult, result => {
+          expect(result.headers).not.toHaveProperty('Content-Encoding');
+          expect(result.headers).toHaveProperty('X-Request-Id');
+        });
+      });
+
+      it('does not include Transfer-Encoding or Content-Length in mocked response headers', () => {
+        jest.spyOn(helpers, 'negotiateOptionsForValidRequest').mockReturnValue(
+          right({
+            code: '200',
+            mediaType: 'application/json',
+            bodyExample: { id: 'test', key: 'test', value: { message: 'ok' } },
+            headers: [
+              {
+                id: 'Transfer-Encoding',
+                name: 'Transfer-Encoding',
+                style: HttpParamStyles.Simple,
+                schema: { type: 'string' as const, enum: ['chunked'] },
+              },
+              {
+                id: 'Content-Length',
+                name: 'Content-Length',
+                style: HttpParamStyles.Simple,
+                schema: { type: 'integer' as const },
+              },
+            ],
+          })
+        );
+
+        const mockResult = mock({
+          config: { dynamic: false },
+          resource: mockResource,
+          input: mockInput,
+        })(logger);
+
+        assertRight(mockResult, result => {
+          expect(result.headers).not.toHaveProperty('Transfer-Encoding');
+          expect(result.headers).not.toHaveProperty('Content-Length');
         });
       });
     });

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -359,10 +359,18 @@ function isINodeExample(nodeExample: ContentExample | undefined): nodeExample is
   return !!nodeExample && 'value' in nodeExample;
 }
 
+const TRANSPORT_HEADERS = new Set([
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'content-md5',
+]);
+
 function computeMockedHeaders(headers: IHttpHeaderParam[], payloadGenerator: PayloadGenerator) {
+  const filteredHeaders = headers.filter(h => !TRANSPORT_HEADERS.has(h.name.toLowerCase()));
   return eitherRecordSequence(
     mapValues(
-      keyBy(headers, h => h.name),
+      keyBy(filteredHeaders, h => h.name),
       header => {
         if (header.schema) {
           if (header.examples && header.examples.length > 0) {


### PR DESCRIPTION
## Summary

When an OpenAPI spec defines transport-level headers like `Content-Encoding` as response headers, Prism's `computeMockedHeaders` generates values from the schema (e.g. picking `gzip` from an enum) but doesn't actually compress the response body. This causes HTTP clients to fail with decompression errors like `zlib.error: Error -3 while decompressing data`.

The root cause is that `computeMockedHeaders` treats every spec-defined header equally — including transport-level headers whose values must be derived from the actual response, not generated from the spec schema.

## Fix

Added a `TRANSPORT_HEADERS` set containing `content-encoding`, `content-length`, `transfer-encoding`, and `content-md5`. These are filtered out before header generation in `computeMockedHeaders`.

These headers describe transport behavior the mock server doesn't implement, so generating values for them is actively harmful.

## Changes

- `packages/http/src/mocker/index.ts` — filter transport-level headers before mock generation
- `packages/http/src/mocker/__tests__/HttpMocker.spec.ts` — added tests verifying Content-Encoding, Transfer-Encoding, and Content-Length are excluded from mocked responses while application headers like X-Request-Id are preserved

Fixes #2787

Made with [Cursor](https://cursor.com)