### PR TITLE
fix(deserializer): handle array value from uri-template-lite in simple style path params

### DIFF
--- a/packages/http/src/validator/deserializers/style/simple.ts
+++ b/packages/http/src/validator/deserializers/style/simple.ts
@@ -11,7 +11,7 @@ export function deserializeSimpleStyle(
   const value = parameters[name];
 
   if (type === 'array') {
-    return deserializeArray(value);
+    return deserializeArray(value as string | string[]);
   } else if (type === 'object') {
     return explode ? deserializeImplodeObject(value) : deserializeObject(value);
   } else {
@@ -19,7 +19,8 @@ export function deserializeSimpleStyle(
   }
 }
 
-function deserializeArray(value: string) {
+function deserializeArray(value: string | string[]) {
+  if (Array.isArray(value)) return value;
   return value === '' ? [] : value.split(',');
 }
 


### PR DESCRIPTION
`uri-template-lite` returns `string[]` (not `string`) when it parses a comma-separated path param — e.g. matching `/codes/123,456` against `/codes/{codeIds}` yields `{ codeIds: ["123","456"] }`. `deserializeArray` assumed a plain string and crashed with `TypeError: value.split is not a function` (reported in #2710).

The fix adds an `Array.isArray` guard: if the value is already a parsed array, return it directly; otherwise split as before.