### PR TITLE
fix(deps): bump uuid from 8.3.2 to 11.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13809,7 +13809,7 @@
         "mime-types": "2.1.35",
         "postman-url-encoder": "3.0.5",
         "semver": "7.6.3",
-        "uuid": "8.3.2"
+        "uuid": "11.1.1"
       },
       "engines": {
         "node": ">=10"
@@ -16031,9 +16031,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "prism",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "workspaces": [


### PR DESCRIPTION
## Summary

- Updates `uuid` from `8.3.2` to `11.1.1` in `package-lock.json`
- Fixes [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq): missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided (CVSS 7.5, moderate)
- `uuid@11.1.1` is the minimum safe version that still ships a CommonJS build, required by `postman-collection`'s `require('uuid')` call (`uuid@14` is ESM-only and breaks it)

## Test plan

- [x] `npm test` passes
- [x] `npm audit` shows no uuid vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)