### PR TITLE
fix(ci): use version tag instead of branch ref when publishing CLI binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,4 +228,6 @@ jobs:
         run: go install github.com/tcnksm/ghr@latest
 
       - name: Publish Release artifacts on GitHub
-        run: ghr -t ${{ github.token }} -u ${{ github.actor }} -r ${{ github.repository }} -c ${{ github.sha }} ${{ github.ref }} ./cli-binaries
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          ghr -t ${{ github.token }} -u ${{ github.actor }} -r ${{ github.repository }} -c $(git rev-list -n 1 $TAG) $TAG ./cli-binaries


### PR DESCRIPTION
## Summary

- `ghr` was being called with `${{ github.ref }}` (`refs/heads/master`) as the release tag in the **Build & publish CLI binaries** job
- Lerna creates the GitHub release under a semver tag (e.g. `v5.15.11`), so `ghr` failed with `release is not found` (exit code 11)
- Fix: resolve the tag via `git describe --tags --abbrev=0` after checkout and use `git rev-list -n 1 $TAG` for the correct commitish

## Test plan

- [ ] Trigger a release workflow and confirm the **Build & publish CLI binaries** job passes
- [ ] Verify CLI binaries are attached to the correct GitHub release tag

Fixes failed run: https://github.com/stoplightio/prism/actions/runs/26869475559/job/79241795766

🤖 Generated with [Claude Code](https://claude.com/claude-code)