### PR TITLE
feat(http-server): add TLS and mTLS termination

### DIFF
--- a/packages/cli/src/commands/mock.ts
+++ b/packages/cli/src/commands/mock.ts
@@ -43,8 +43,32 @@ const mockCommand: CommandModule = {
       }),
   handler: async parsedArgs => {
     parsedArgs.jsonSchemaFakerFillProperties = parsedArgs['json-schema-faker-fillProperties'];
-    const { multiprocess, dynamic, port, host, cors, document, errors, verboseLevel, ignoreExamples, seed, jsonSchemaFakerFillProperties } =
-      parsedArgs as unknown as CreateMockServerOptions;
+    parsedArgs.tlsKey = parsedArgs['tls-key'];
+    parsedArgs.tlsCert = parsedArgs['tls-cert'];
+    parsedArgs.tlsPassphrase = parsedArgs['tls-passphrase'];
+    parsedArgs.tlsCa = parsedArgs['tls-ca'];
+    parsedArgs.tlsForwardClientCert = parsedArgs['tls-forward-client-cert'];
+    parsedArgs.tlsHttp2 = parsedArgs['tls-http2'];
+    const {
+      multiprocess,
+      dynamic,
+      port,
+      host,
+      cors,
+      document,
+      errors,
+      verboseLevel,
+      ignoreExamples,
+      seed,
+      jsonSchemaFakerFillProperties,
+      tlsKey,
+      tlsCert,
+      tlsPassphrase,
+      tlsCa,
+      mtls,
+      tlsForwardClientCert,
+      tlsHttp2,
+    } = parsedArgs as unknown as CreateMockServerOptions;
 
     const createPrism = multiprocess ? createMultiProcessPrism : createSingleProcessPrism;
     const options = {
@@ -59,6 +83,13 @@ const mockCommand: CommandModule = {
       ignoreExamples,
       seed,
       jsonSchemaFakerFillProperties,
+      tlsKey,
+      tlsCert,
+      tlsPassphrase,
+      tlsCa,
+      mtls,
+      tlsForwardClientCert,
+      tlsHttp2,
     };
 
     await runPrismAndSetupWatcher(createPrism, options);

--- a/packages/cli/src/commands/proxy.ts
+++ b/packages/cli/src/commands/proxy.ts
@@ -39,6 +39,12 @@ const proxyCommand: CommandModule = {
       }),
   handler: async parsedArgs => {
     parsedArgs.validateRequest = parsedArgs['validate-request'];
+    parsedArgs.tlsKey = parsedArgs['tls-key'];
+    parsedArgs.tlsCert = parsedArgs['tls-cert'];
+    parsedArgs.tlsPassphrase = parsedArgs['tls-passphrase'];
+    parsedArgs.tlsCa = parsedArgs['tls-ca'];
+    parsedArgs.tlsForwardClientCert = parsedArgs['tls-forward-client-cert'];
+    parsedArgs.tlsHttp2 = parsedArgs['tls-http2'];
     const p: CreateProxyServerOptions = pick(
       parsedArgs as unknown as CreateProxyServerOptions,
       'dynamic',
@@ -54,7 +60,14 @@ const proxyCommand: CommandModule = {
       'ignoreExamples',
       'seed',
       'upstreamProxy',
-      'jsonSchemaFakerFillProperties'
+      'jsonSchemaFakerFillProperties',
+      'tlsKey',
+      'tlsCert',
+      'tlsPassphrase',
+      'tlsCa',
+      'mtls',
+      'tlsForwardClientCert',
+      'tlsHttp2'
     );
 
     const createPrism = p.multiprocess ? createMultiProcessPrism : createSingleProcessPrism;

--- a/packages/cli/src/commands/sharedOptions.ts
+++ b/packages/cli/src/commands/sharedOptions.ts
@@ -48,6 +48,46 @@ const sharedOptions: Dictionary<Options> = {
     // custom levels like "success" and "start" are set to the same severity value as "info"
     choices: Object.keys(pino.levels.values).concat('silent'),
   },
+
+  'tls-key': {
+    description: 'Path to a PEM private key. Enables HTTPS (TLS termination) when set with --tls-cert.',
+    string: true,
+  },
+
+  'tls-cert': {
+    description: 'Path to a PEM server certificate (may include the chain). Required with --tls-key.',
+    string: true,
+  },
+
+  'tls-passphrase': {
+    description: 'Passphrase for an encrypted --tls-key.',
+    string: true,
+  },
+
+  'tls-ca': {
+    description: 'Path to a PEM CA bundle used to verify client certificates. Enables mTLS.',
+    string: true,
+  },
+
+  mtls: {
+    description:
+      'Require and verify a client certificate (mTLS); connections without a valid client cert are rejected. Requires --tls-ca.',
+    boolean: true,
+    default: false,
+  },
+
+  'tls-forward-client-cert': {
+    description:
+      'Inject the verified client certificate identity (subject, SAN, fingerprint) as x-client-cert-* request headers.',
+    boolean: true,
+    default: false,
+  },
+
+  'tls-http2': {
+    description: 'Serve over HTTP/2 (with HTTPS/1.1 fallback) instead of HTTPS/1.1. Requires --tls-key/--tls-cert.',
+    boolean: true,
+    default: false,
+  },
 };
 
 export default sharedOptions;

--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@stoplight/prism-core';
 import { IHttpConfig, IHttpRequest } from '@stoplight/prism-http';
-import { createServer as createHttpServer } from '@stoplight/prism-http-server';
+import { createServer as createHttpServer, ITlsOptions } from '@stoplight/prism-http-server';
+import * as fs from 'fs';
 import * as chalk from 'chalk';
 import cluster from 'node:cluster';
 import * as E from 'fp-ts/Either';
@@ -104,6 +105,7 @@ async function createPrismServerWithLogger(options: CreateBaseServerOptions, log
     cors: options.cors,
     config,
     components: { logger: logInstance.child({ name: 'HTTP SERVER' }) },
+    tls: buildTlsOptions(options),
   });
 
   const address = await server.listen(options.port, options.host);
@@ -153,6 +155,41 @@ function isProxyServerOptions(options: CreateBaseServerOptions): options is Crea
   return 'upstream' in options;
 }
 
+function readPemFile(label: string, filePath: string): Buffer {
+  try {
+    return fs.readFileSync(filePath);
+  } catch (e) {
+    throw new Error(`Unable to read ${label} from "${filePath}": ${(e as Error).message}`);
+  }
+}
+
+function buildTlsOptions(options: CreateBaseServerOptions): ITlsOptions | undefined {
+  if (!options.tlsKey && !options.tlsCert && !options.tlsCa && !options.mtls && !options.tlsHttp2) {
+    return undefined;
+  }
+
+  if (!options.tlsKey || !options.tlsCert) {
+    throw new Error('TLS requires both --tls-key and --tls-cert.');
+  }
+
+  if (options.mtls && !options.tlsCa) {
+    throw new Error('--mtls requires --tls-ca to verify client certificates.');
+  }
+
+  const ca = options.tlsCa ? readPemFile('TLS CA bundle', options.tlsCa) : undefined;
+
+  return {
+    key: readPemFile('TLS key', options.tlsKey),
+    cert: readPemFile('TLS certificate', options.tlsCert),
+    passphrase: options.tlsPassphrase,
+    ca,
+    requestCert: options.mtls || !!ca,
+    rejectUnauthorized: options.mtls,
+    forwardClientCertHeaders: options.tlsForwardClientCert,
+    http2: options.tlsHttp2,
+  };
+}
+
 /**
  * @property {boolean} jsonSchemaFakerFillProperties - Used to override the default json-schema-faker extension value
  */
@@ -168,6 +205,13 @@ type CreateBaseServerOptions = {
   ignoreExamples: boolean;
   seed: string;
   jsonSchemaFakerFillProperties: boolean;
+  tlsKey?: string;
+  tlsCert?: string;
+  tlsPassphrase?: string;
+  tlsCa?: string;
+  mtls?: boolean;
+  tlsForwardClientCert?: boolean;
+  tlsHttp2?: boolean;
 };
 
 export interface CreateProxyServerOptions extends CreateBaseServerOptions {

--- a/packages/http-server/src/__tests__/tls.spec.ts
+++ b/packages/http-server/src/__tests__/tls.spec.ts
@@ -1,0 +1,106 @@
+import { createLogger } from '@stoplight/prism-core';
+import { getHttpOperationsFromSpec } from '@stoplight/prism-http';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { resolve } from 'path';
+import fetch from 'node-fetch';
+import { Agent } from 'https';
+import { createServer } from '../';
+import { ITlsOptions, ThenArg } from '../types';
+
+const logger = createLogger('TEST', { enabled: false });
+const specPath = resolve(__dirname, 'fixtures', 'petstore.no-auth.oas3.yaml');
+
+let certDir: string;
+let caCert: Buffer;
+
+// Generate a CA, a server cert (SAN localhost/127.0.0.1) and a client cert, all via openssl.
+beforeAll(() => {
+  certDir = mkdtempSync(join(tmpdir(), 'prism-tls-'));
+  const f = (name: string) => join(certDir, name);
+  const run = (args: string[]) => execFileSync('openssl', args, { stdio: 'ignore' });
+
+  writeFileSync(f('san.ext'), 'subjectAltName=DNS:localhost,IP:127.0.0.1');
+
+  run(['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-keyout', f('ca.key'), '-out', f('ca.crt'), '-days', '1', '-subj', '/CN=Test CA']);
+  run(['req', '-newkey', 'rsa:2048', '-nodes', '-keyout', f('server.key'), '-out', f('server.csr'), '-subj', '/CN=localhost']);
+  run(['x509', '-req', '-in', f('server.csr'), '-CA', f('ca.crt'), '-CAkey', f('ca.key'), '-CAcreateserial', '-out', f('server.crt'), '-days', '1', '-extfile', f('san.ext')]);
+  run(['req', '-newkey', 'rsa:2048', '-nodes', '-keyout', f('client.key'), '-out', f('client.csr'), '-subj', '/CN=test-client']);
+  run(['x509', '-req', '-in', f('client.csr'), '-CA', f('ca.crt'), '-CAkey', f('ca.key'), '-CAcreateserial', '-out', f('client.crt'), '-days', '1']);
+
+  caCert = readFileSync(f('ca.crt'));
+}, 30000);
+
+afterAll(() => {
+  if (certDir) rmSync(certDir, { recursive: true, force: true });
+});
+
+async function instantiate(tls: ITlsOptions, port: number) {
+  const operations = await getHttpOperationsFromSpec(specPath);
+  const server = createServer(operations, {
+    components: { logger },
+    config: {
+      checkSecurity: true,
+      validateRequest: true,
+      validateResponse: true,
+      errors: false,
+      mock: { dynamic: false },
+      upstreamProxy: undefined,
+      isProxy: false,
+    },
+    cors: true,
+    tls,
+  });
+  const address = await server.listen(port, '127.0.0.1');
+  return { close: server.close.bind(server), address };
+}
+
+const f = (name: string) => join(certDir, name);
+
+describe('TLS termination', () => {
+  let server: ThenArg<ReturnType<typeof instantiate>>;
+
+  afterEach(() => server && server.close());
+
+  it('serves over HTTPS and reports an https:// address', async () => {
+    server = await instantiate({ key: readFileSync(f('server.key')), cert: readFileSync(f('server.crt')) }, 30441);
+
+    expect(server.address).toMatch(/^https:\/\//);
+
+    const res = await fetch(`${server.address}/no_auth/pets?name=fido`, {
+      agent: new Agent({ ca: caCert }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('mTLS termination', () => {
+  let server: ThenArg<ReturnType<typeof instantiate>>;
+
+  afterEach(() => server && server.close());
+
+  it('rejects a request without a client certificate', async () => {
+    server = await instantiate(
+      { key: readFileSync(f('server.key')), cert: readFileSync(f('server.crt')), ca: caCert, requestCert: true, rejectUnauthorized: true },
+      30442
+    );
+
+    await expect(
+      fetch(`${server.address}/no_auth/pets?name=fido`, { agent: new Agent({ ca: caCert }) })
+    ).rejects.toThrow();
+  });
+
+  it('accepts a request with a valid client certificate', async () => {
+    server = await instantiate(
+      { key: readFileSync(f('server.key')), cert: readFileSync(f('server.crt')), ca: caCert, requestCert: true, rejectUnauthorized: true },
+      30443
+    );
+
+    const res = await fetch(`${server.address}/no_auth/pets?name=fido`, {
+      agent: new Agent({ ca: caCert, cert: readFileSync(f('client.crt')), key: readFileSync(f('client.key')) }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/http-server/src/index.ts
+++ b/packages/http-server/src/index.ts
@@ -1,1 +1,2 @@
 export { createServer } from './server';
+export { ITlsOptions, IPrismHttpServerOpts } from './types';

--- a/packages/http-server/src/server.ts
+++ b/packages/http-server/src/server.ts
@@ -7,12 +7,15 @@ import {
   IHttpConfig,
 } from '@stoplight/prism-http';
 import { DiagnosticSeverity, HttpMethod, IHttpOperation, Dictionary } from '@stoplight/types';
-import { IncomingMessage, ServerResponse, IncomingHttpHeaders } from 'http';
+import { IncomingMessage, ServerResponse, IncomingHttpHeaders, Server as HttpServer } from 'http';
+import { createServer as createHttpsServer } from 'https';
+import { createSecureServer as createHttp2SecureServer } from 'http2';
+import { TLSSocket, PeerCertificate } from 'tls';
 import { AddressInfo } from 'net';
-import { IPrismHttpServer, IPrismHttpServerOpts } from './types';
+import { IPrismHttpServer, IPrismHttpServerOpts, ITlsOptions } from './types';
 import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { MicriHandler } from 'micri';
-import micri, { Router, json, send, text } from 'micri';
+import micri, { Router, json, send, text, run as micriRun } from 'micri';
 import * as typeIs from 'type-is';
 import { getHttpConfigFromRequest } from './getHttpConfigFromRequest';
 import { serialize } from './serialize';
@@ -31,10 +34,11 @@ function searchParamsToNameValues(searchParams: URLSearchParams): IHttpNameValue
   return params;
 }
 
-function addressInfoToString(addressInfo: AddressInfo | string | null) {
+function addressInfoToString(addressInfo: AddressInfo | string | null, secure: boolean) {
   if (!addressInfo) return '';
   if (typeof addressInfo === 'string') return addressInfo;
-  return `http://${addressInfo.address}:${addressInfo.port}`;
+  const scheme = secure ? 'https' : 'http';
+  return `${scheme}://${addressInfo.address}:${addressInfo.port}`;
 }
 
 type ValidationError = {
@@ -76,6 +80,24 @@ function parseRequestBody(request: IncomingMessage) {
   } else {
     return text(request, { limit: '10mb' });
   }
+}
+
+function sha256Fingerprint(cert: PeerCertificate): string | undefined {
+  return cert.fingerprint256 ? cert.fingerprint256.replace(/:/g, '').toLowerCase() : undefined;
+}
+
+function injectClientCertHeaders(request: IncomingMessage): void {
+  const socket = request.socket;
+  if (!(socket instanceof TLSSocket)) return;
+
+  const cert = socket.getPeerCertificate();
+  if (!cert || Object.keys(cert).length === 0) return;
+
+  request.headers['x-client-cert-verified'] = String(socket.authorized === true);
+  if (cert.subject && cert.subject.CN) request.headers['x-client-cert-subject'] = cert.subject.CN;
+  if (cert.subjectaltname) request.headers['x-client-cert-san'] = cert.subjectaltname;
+  const fingerprint = sha256Fingerprint(cert);
+  if (fingerprint) request.headers['x-client-cert-fingerprint'] = fingerprint;
 }
 
 export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServerOpts): IPrismHttpServer => {
@@ -194,38 +216,38 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
     res.setHeader('Access-Control-Expose-Headers', incomingHeaders['access-control-expose-headers'] || '*');
   }
 
-  const server = micri(
-    Router.router(
-      Router.on.options(
-        () => opts.cors,
-        (req: IncomingMessage, res: ServerResponse) => {
-          setCommonCORSHeaders(req.headers, res);
+  const routerHandler = Router.router(
+    Router.on.options(
+      () => opts.cors,
+      (req: IncomingMessage, res: ServerResponse) => {
+        setCommonCORSHeaders(req.headers, res);
 
-          if (!!req.headers['origin'] && !!req.headers['access-control-request-method']) {
-            // This is a preflight request, so we'll respond with the appropriate CORS response
-            res.setHeader(
-              'Access-Control-Allow-Methods',
-              req.headers['access-control-request-method'] || 'GET,DELETE,HEAD,PATCH,POST,PUT,OPTIONS'
-            );
+        if (!!req.headers['origin'] && !!req.headers['access-control-request-method']) {
+          // This is a preflight request, so we'll respond with the appropriate CORS response
+          res.setHeader(
+            'Access-Control-Allow-Methods',
+            req.headers['access-control-request-method'] || 'GET,DELETE,HEAD,PATCH,POST,PUT,OPTIONS'
+          );
 
-            res.setHeader('Vary', 'origin');
+          res.setHeader('Vary', 'origin');
 
-            // This should not be required since we're responding with a 204, which has no content by definition. However
-            // Safari does not really understand that and throws a Network Error. Explicit is better than implicit.
-            res.setHeader('Content-Length', '0');
-            return send(res, 204);
-          }
-
-          return handler(req, res);
+          // This should not be required since we're responding with a 204, which has no content by definition. However
+          // Safari does not really understand that and throws a Network Error. Explicit is better than implicit.
+          res.setHeader('Content-Length', '0');
+          return send(res, 204);
         }
-      ),
-      Router.otherwise((req, res, options) => {
-        if (opts.cors) setCommonCORSHeaders(req.headers, res);
 
-        return handler(req, res, options);
-      })
-    )
+        return handler(req, res);
+      }
+    ),
+    Router.otherwise((req, res, options) => {
+      if (opts.cors) setCommonCORSHeaders(req.headers, res);
+
+      return handler(req, res, options);
+    })
   );
+
+  const server = createUnderlyingServer(opts.tls, routerHandler);
 
   const prism = createInstance(config, components);
 
@@ -256,11 +278,38 @@ export const createServer = (operations: IHttpOperation[], opts: IPrismHttpServe
         server.once('error', e => reject(e.message));
         server.listen(port, ...args, (err: unknown) => {
           if (err) return reject(err);
-          return resolve(addressInfoToString(server.address()));
+          return resolve(addressInfoToString(server.address(), !!opts.tls));
         });
       }),
   };
 };
+
+function createUnderlyingServer(tls: ITlsOptions | undefined, routerHandler: MicriHandler): HttpServer {
+  if (!tls) {
+    return micri(routerHandler);
+  }
+
+  const tlsServerOptions = {
+    key: tls.key,
+    cert: tls.cert,
+    passphrase: tls.passphrase,
+    ca: tls.ca,
+    requestCert: tls.requestCert ?? !!tls.ca,
+    rejectUnauthorized: tls.rejectUnauthorized ?? !!tls.ca,
+  };
+
+  const bridge = (req: IncomingMessage, res: ServerResponse) => {
+    if (tls.forwardClientCertHeaders) injectClientCertHeaders(req);
+    return micriRun(req, res, routerHandler);
+  };
+
+  if (tls.http2) {
+    // ALPN negotiates h2/http1.1; allowHTTP1 keeps HTTPS/1.1 clients working.
+    return createHttp2SecureServer({ ...tlsServerOptions, allowHTTP1: true }, bridge as never) as unknown as HttpServer;
+  }
+
+  return createHttpsServer(tlsServerOptions, bridge);
+}
 
 const createErrorObjectWithPrefix = (locationPrefix: string) => (detail: IPrismDiagnostic) => ({
   location: [locationPrefix].concat(detail.path || []),

--- a/packages/http-server/src/types.ts
+++ b/packages/http-server/src/types.ts
@@ -1,10 +1,22 @@
 import { IHttpConfig, PickRequired, PrismHttpComponents, PrismHttpInstance } from '@stoplight/prism-http';
 import { Logger } from 'pino';
 
+export interface ITlsOptions {
+  key: Buffer | string;
+  cert: Buffer | string;
+  passphrase?: string;
+  ca?: Buffer | string;
+  requestCert?: boolean;
+  rejectUnauthorized?: boolean;
+  forwardClientCertHeaders?: boolean;
+  http2?: boolean;
+}
+
 export interface IPrismHttpServerOpts {
   components: PickRequired<Partial<PrismHttpComponents>, 'logger'>;
   config: IHttpConfig;
   cors: boolean;
+  tls?: ITlsOptions;
 }
 
 export interface IPrismHttpServer {


### PR DESCRIPTION
## Summary

Adds **TLS termination** (serve HTTPS) and **mTLS termination** (require/verify client certificates) to the Prism HTTP server, for both `mock` and `proxy`. It is fully opt-in: with no TLS flags, Prism serves plain HTTP exactly as before.

Lets Prism stand in for an API that is fronted by TLS/mTLS — e.g. mock or contract-test a service that requires HTTPS or client certs, without putting a real TLS gateway in front.

## How it works

Prism's server framework (`micri`) only creates plain `http` servers, so the TLS path is built on Node's built-in modules instead:

- TLS/mTLS uses `https.createServer(tlsOptions, handler)` (and `http2.createSecureServer` for `--tls-http2`).
- Micri is still used for **all request handling** — the same router/handler runs requests via Micri's `run()` in the TLS path, so routing, CORS, and the mock/validate/proxy pipeline are unchanged.
- Node's `tls` layer performs the handshake and client-certificate verification; Prism just passes the options through.
- No changes to `@stoplight/prism-core` or `@stoplight/prism-http` — TLS is purely a server-transport concern.

## Flags (available on both `mock` and `proxy`)

| Flag | Purpose |
| ---- | ------- |
| `--tls-key <path>` | PEM private key. Enables HTTPS with `--tls-cert`. |
| `--tls-cert <path>` | PEM server certificate (may include chain). |
| `--tls-passphrase <str>` | Passphrase for an encrypted key. |
| `--tls-ca <path>` | PEM CA bundle to verify client certs → enables mTLS. |
| `--mtls` | Require + reject on failed client-cert verification (needs `--tls-ca`). |
| `--tls-forward-client-cert` | Inject verified client identity as `x-client-cert-subject` / `-san` / `-fingerprint` / `-verified` request headers. |
| `--tls-http2` | Serve HTTP/2 over TLS, with HTTPS/1.1 fallback (ALPN). |

The CLI reads the PEM files (clear errors on missing/unreadable files) and validates flag combinations (e.g. `--mtls` requires `--tls-ca`; TLS requires both key and cert). When TLS is active, the reported listen address switches to `https://`.

```bash
# TLS termination
prism mock api.oas.yaml --tls-key server.key --tls-cert server.crt

# mTLS termination + forward client identity
prism mock api.oas.yaml \
  --tls-key server.key --tls-cert server.crt \
  --tls-ca ca.crt --mtls --tls-forward-client-cert
```

## Testing

- Added unit tests (`packages/http-server/src/__tests__/tls.spec.ts`) using openssl-generated certs: TLS serves HTTPS (200); mTLS rejects a request with no client cert and accepts one with a valid client cert.
- Manually validated end to end: HTTPS 200 + plain-HTTP-to-TLS-port rejected; mTLS reject/accept; `x-client-cert-*` headers injected; HTTP/2 (`proto=2`) with HTTPS/1.1 fallback.

**Checklist**
- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
- Event Tracking
  - [x] N/A
- Error Reporting
  - [x] N/A
