### PR TITLE
fix(cli): restore cluster namespace import to fix startup regression

### DIFF
--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -2,7 +2,7 @@ import { createLogger } from '@stoplight/prism-core';
 import { IHttpConfig, IHttpRequest } from '@stoplight/prism-http';
 import { createServer as createHttpServer } from '@stoplight/prism-http-server';
 import * as chalk from 'chalk';
-import cluster from 'node:cluster';
+import * as clusterNS from 'node:cluster';
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import * as pino from 'pino';
@@ -32,6 +32,15 @@ const cliSpecificLoggerOptions: pino.LoggerOptions = {
     level: level => ({ level }),
   },
 };
+
+// The namespace import is required for correct runtime behavior: under `module: commonjs`
+// and `esModuleInterop: false`, a default import (`import cluster from 'node:cluster'`)
+// compiles to `cluster.default.isPrimary`, but `cluster.default` is `undefined` at runtime
+// because the cluster module has no default export. The namespace import compiles to
+// `cluster.isPrimary`, which works because the module IS the singleton Cluster instance.
+// The cast restores the Cluster type, which @types/node 24+ only exposes via the default
+// export of "node:cluster".
+const cluster = clusterNS as unknown as typeof import('node:cluster').default;
 
 const createMultiProcessPrism: CreatePrism = async options => {
   if (cluster.isPrimary) {


### PR DESCRIPTION
## Problem

PR #2763 reports that Prism 5.15+ fails to start in any mode (mock, proxy, etc.):

```
TypeError: Cannot read properties of undefined (reading 'isPrimary')
    at createMultiProcessPrism (packages/cli/dist/util/createServer.js:29:32)
```

## Root cause

PR #2752 (Node 18 → 24 bump) changed the cluster import style from
namespace to default:

```diff
-import * as cluster from 'cluster';
+import cluster from 'node:cluster';
```

Under `module: commonjs` + `esModuleInterop: false`, the default import
compiles to `node_cluster_1.default.isPrimary`, but `node_cluster_1.default`
is `undefined` at runtime because the cluster module has no default export.
The namespace import compiles to `cluster.isPrimary`, which works because
the module IS the singleton Cluster instance.

## Fix

Restore the namespace import with a type cast to satisfy the Cluster type
from `@types/node` 24+ (which only exposes the Cluster interface via the
default export). The cast is erased at compile time; runtime behavior is
identical to a plain namespace import.

```ts
import * as clusterNS from 'node:cluster';
const cluster = clusterNS as unknown as typeof import('node:cluster').default;
```

## Verification

```js
cluster.isPrimary === true            // was undefined before fix
typeof cluster.setupPrimary === 'function'
typeof cluster.fork       === 'function'
```

Pre-existing TypeScript errors in `paths.ts`, `forwarder/index.ts`, and
`validator/index.ts` (unrelated to this fix) remain unchanged.

Fixes #2763