### PR TITLE
Quality: basicAuth rejects valid credentials when password contains colons

### DIFF
--- a/packages/http/src/validator/validators/security/handlers/basicAuth.ts
+++ b/packages/http/src/validator/validators/security/handlers/basicAuth.ts
@@ -17,7 +17,7 @@ function checkHeader(authorizationHeader: string) {
 function isBasicToken(token: string) {
   const tokenParts = Buffer.from(token, 'base64').toString().split(':');
 
-  return tokenParts.length === 2;
+  return tokenParts.length >= 2;
 }
 
 export const httpBasic = (input: Pick<IHttpRequest, 'headers' | 'url'>) => {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`isBasicToken` splits the decoded base64 string by `:` and checks `tokenParts.length === 2`. Per RFC 7617, the Basic auth format is `userid:password`, where the password itself may contain colon characters. A user with password `p@ss:word` decodes to `user:p@ss:word`, which splits into 3 parts and is incorrectly rejected as invalid. This silently denies authentication for any user whose password contains a colon — a character many password generators include.


**Severity**: `high`
**File**: `packages/http/src/validator/validators/security/handlers/basicAuth.ts`

### Solution
Change `tokenParts.length === 2` to `tokenParts.length >= 2`:


### Changes
- `packages/http/src/validator/validators/security/handlers/basicAuth.ts` (modified)

Addresses #[ISSUE_NUMBER]

**Summary**

Replace this with something that explains what this PR is for and why it matters.

**Checklist**

- The basics
  - [ ] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [ ] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [ ] N/A

**Screenshots**

If applicable, add screenshots or gifs to help demonstrate the changes. If not applicable, remove this screenshots
section before creating the PR.

**Additional context**

Add any other context about the pull request here. Remove this section if there is no additional context.

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #2814