### PR TITLE
docs: fix petstore example URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For more installation options, see our [installation documentation](./docs/getti
 Prism can help you create a fake "mock" based off an OpenAPI document, which helps people see how your API will work before you even have it built. Run it locally with the `prism mock` command to run your API on a HTTP server you can interact with.
 
 ```bash
-prism mock https://raw.githack.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
+prism mock https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/_archive_/schemas/v3.0/pass/petstore-expanded.yaml
 ```
 
 Learn more about [how the mock server works](docs/guides/01-mocking.md).

--- a/docs/getting-started/03-cli.md
+++ b/docs/getting-started/03-cli.md
@@ -7,7 +7,7 @@ Prism CLI has two commands: `mock` and `proxy`.
 [Mocking](../guides/01-mocking.md) is available through the CLI mock command.
 
 ```bash
-prism mock https://raw.githack.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore-expanded.yaml
+prism mock https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/_archive_/schemas/v3.0/pass/petstore-expanded.yaml
 ✔  success   Prism is listening on http://127.0.0.1:4010
 ●  note      GET        http://127.0.0.1:4010/pets
 ●  note      POST       http://127.0.0.1:4010/pets


### PR DESCRIPTION
Addresses #2717

**Summary**

Updates the Prism mock examples in the README and CLI getting-started guide to use the current archived OpenAPI Specification petstore-expanded YAML URL. The previous raw.githack URL no longer resolves successfully, while the replacement URL returns the same petstore-expanded example with the documented `/pets` paths.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Additional context**

Verification performed:

- `git diff --check`
- `curl -I -L https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/_archive_/schemas/v3.0/pass/petstore-expanded.yaml` returns HTTP 200
- Confirmed the replacement document still exposes `/pets` paths used in the CLI docs output