### PR TITLE
docs: bump Docker examples to Prism 5

### DIFF
--- a/docs/getting-started/01-installation.md
+++ b/docs/getting-started/01-installation.md
@@ -23,19 +23,19 @@ curl -L https://raw.githack.com/stoplightio/prism/master/install | sh
 Prism is available as a Docker image. You should specify the major version you'd like to use as a tag:
 
 ```bash
-docker run --init -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 api.oas2.yml
+docker run --init -p 4010:4010 stoplight/prism:5 mock -h 0.0.0.0 api.oas2.yml
 ```
 
 If the document you want to mock is on your computer, you'll need to mount the directory where the file resides as a volume:
 
 ```bash
-docker run --init --rm -v $(pwd):/tmp -p 4010:4010 stoplight/prism:4 mock -h 0.0.0.0 "/tmp/file.yaml"
+docker run --init --rm -v $(pwd):/tmp -p 4010:4010 stoplight/prism:5 mock -h 0.0.0.0 "/tmp/file.yaml"
 ```
 
 If you want to start the proxy server, you can run a command like this:
 
 ```bash
-docker run --init --rm -d -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:4 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
+docker run --init --rm -d -p 4010:4010 -v $(pwd):/tmp -P stoplight/prism:5 proxy -h 0.0.0.0 "/tmp/file.yml" http://host.docker.internal:8080 --errors
 ```
 
 ## Docker Compose
@@ -47,7 +47,7 @@ Alternatively, you may wish to use prism as part of a docker compose file to aid
 version: '3.9'
 services:
   prism:
-    image: stoplight/prism:4
+    image: stoplight/prism:5
     command: 'mock -h 0.0.0.0 /tmp/api.oas3.yml'
     volumes:
       - ./api.oas3.yml:/tmp/api.oas3.yml:ro

--- a/docs/guides/08-multiple-documents.md
+++ b/docs/guides/08-multiple-documents.md
@@ -21,12 +21,12 @@ services:
       - prism_1
       - prism_2
   prism_1:
-    image: stoplight/prism:4
+    image: stoplight/prism:5
     command: >
       mock -p 4010 --host 0.0.0.0
       https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/yaml/petstore.yaml
   prism_2:
-    image: stoplight/prism:4
+    image: stoplight/prism:5
     command: >
       mock -p 4010 --host 0.0.0.0
       https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
@@ -87,7 +87,7 @@ Under `services`, you can add:
 
 ```yaml
 prism_3:
-  image: stoplight/prism:4
+  image: stoplight/prism:5
   command: >
     mock -p 4010 --host 0.0.0.0
     https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml

--- a/docs/guides/10-nginx-tls-proxy.md
+++ b/docs/guides/10-nginx-tls-proxy.md
@@ -27,7 +27,7 @@ Extending the basic `docker-compose.yml` from the installation guide to include 
 version: '3.9'
 services:
   prism:
-    image: stoplight/prism:4
+    image: stoplight/prism:5
     command: 'mock -h 0.0.0.0 /tmp/api.oas3.yml'
     volumes:
       - ./api.oas3.yml:/tmp/api.oas3.yml:ro


### PR DESCRIPTION
Addresses #2697

**Summary**

Updates Docker image examples from `stoplight/prism:4` to `stoplight/prism:5` in the installation docs and related Docker guide examples. The repository version is currently 5.x, so these examples now point at the current major release while preserving the docs guidance to pin a major version.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [ ] Added or updated
  - [x] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Additional context**

Verification performed:

- `git diff --check`
- Confirmed no `stoplight/prism:4` references remain in `docs` or `README.md`
- Confirmed `version.txt` reports Prism `5.15.1`