### PR TITLE
fix(http): skip Content-Encoding mock header

### DIFF
--- a/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
+++ b/packages/http/src/mocker/__tests__/HttpMocker.spec.ts
@@ -1,5 +1,5 @@
 import { createLogger, IPrismInput } from '@stoplight/prism-core';
-import { IHttpOperation, INodeExample, DiagnosticSeverity } from '@stoplight/types';
+import { IHttpOperation, INodeExample, DiagnosticSeverity, HttpParamStyles } from '@stoplight/types';
 import { right } from 'fp-ts/ReaderEither';
 import * as E from 'fp-ts/Either';
 import { flatMap } from 'lodash';
@@ -150,6 +150,41 @@ describe('mocker', () => {
         })(logger);
 
         assertRight(mockResult, result => expect(result).toMatchSnapshot());
+      });
+
+      it('does not include generated Content-Encoding headers in mock responses', () => {
+        jest.spyOn(helpers, 'negotiateOptionsForValidRequest').mockReturnValue(
+          right({
+            code: '202',
+            mediaType: 'application/json',
+            bodyExample: mockResource.responses[0].contents![0].examples![0],
+            headers: [
+              {
+                id: 'content-encoding',
+                name: 'Content-Encoding',
+                style: HttpParamStyles.Simple,
+                schema: { type: 'string', enum: ['gzip'] },
+              },
+              {
+                id: 'x-mocked-header',
+                name: 'x-mocked-header',
+                style: HttpParamStyles.Simple,
+                schema: { type: 'string', enum: ['mocked'] },
+              },
+            ],
+          })
+        );
+
+        const mockResult = mock({
+          config: { dynamic: false },
+          resource: mockResource,
+          input: mockInput,
+        })(logger);
+
+        assertRight(mockResult, result => {
+          expect(result.headers).toHaveProperty('x-mocked-header', 'mocked');
+          expect(result.headers).not.toHaveProperty('Content-Encoding');
+        });
       });
 
       it('returns dynamic example', () => {

--- a/packages/http/src/mocker/index.ts
+++ b/packages/http/src/mocker/index.ts
@@ -19,7 +19,7 @@ import { sequenceT } from 'fp-ts/Apply';
 import * as R from 'fp-ts/Reader';
 import * as O from 'fp-ts/Option';
 import * as RE from 'fp-ts/ReaderEither';
-import { get, groupBy, isNumber, isString, keyBy, mapValues, partial, pick } from 'lodash';
+import { get, groupBy, isNumber, isString, keyBy, mapValues, pick } from 'lodash';
 import { Logger } from 'pino';
 import { is } from 'type-is';
 import {
@@ -52,6 +52,7 @@ export { resetGenerator as resetJSONSchemaGenerator } from './generator/JSONSche
 
 const eitherRecordSequence = Record.sequence(E.Applicative);
 const eitherSequence = sequenceT(E.Apply);
+const mockedHeaderDenylist = new Set(['content-encoding']);
 
 const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpMockConfig>['mock'] = ({
   resource,
@@ -61,8 +62,8 @@ const mock: IPrismComponents<IHttpOperation, IHttpRequest, IHttpResponse, IHttpM
   function createPayloadGenerator(config: IHttpOperationConfig, resource: IHttpOperation): PayloadGenerator {
     return (source: JSONSchema) => {
       return config.dynamic
-      ? generate(resource, resource['__bundled__'], source, config.seed)
-      : generateStatic(resource, source);
+        ? generate(resource, resource['__bundled__'], source, config.seed)
+        : generateStatic(resource, source);
     };
   }
   const payloadGenerator = createPayloadGenerator(config, resource);
@@ -163,7 +164,7 @@ function parseBodyIfUrlEncoded(request: IHttpRequest, resource: IHttpOperation) 
     mediaType === 'multipart/form-data'
       ? parseMultipartFormDataParams(requestBody, multipartBoundary)
       : splitUriParams(requestBody),
-    E.getOrElse<IPrismDiagnostic[], Dictionary<string>>(() => ({} as Dictionary<string>))
+    E.getOrElse<IPrismDiagnostic[], Dictionary<string>>(() => ({}) as Dictionary<string>)
   );
 
   if (specs.length < 1) {
@@ -362,7 +363,10 @@ function isINodeExample(nodeExample: ContentExample | undefined): nodeExample is
 function computeMockedHeaders(headers: IHttpHeaderParam[], payloadGenerator: PayloadGenerator) {
   return eitherRecordSequence(
     mapValues(
-      keyBy(headers, h => h.name),
+      keyBy(
+        headers.filter(header => !mockedHeaderDenylist.has(header.name.toLowerCase())),
+        h => h.name
+      ),
       header => {
         if (header.schema) {
           if (header.examples && header.examples.length > 0) {


### PR DESCRIPTION
Addresses #2787

**Summary**

Prism currently generates response headers declared in an OpenAPI spec even when those headers imply transport behavior the mock response does not perform. In particular, a generated `Content-Encoding: gzip` header makes clients try to decompress an uncompressed mock body.

This change skips generated `Content-Encoding` response headers in the HTTP mocker while preserving ordinary mocked headers. It also adds a regression test that keeps a normal generated header and verifies `Content-Encoding` is omitted.

**Checklist**

- The basics
  - [x] I tested these changes manually in my local or dev environment
- Tests
  - [x] Added or updated
  - [ ] N/A
- Event Tracking
  - [ ] I added event tracking and followed the event tracking guidelines
  - [x] N/A
- Error Reporting
  - [ ] I reported errors and followed the error reporting guidelines
  - [x] N/A

**Additional context**

Verified with:

```bash
npm test -- packages/http/src/mocker/__tests__/HttpMocker.spec.ts --runInBand --no-watchman
```

The test command also ran the repository `posttest` lint step successfully.