### PR TITLE
fix: ignore explicit zero-length JSON request bodies

### DIFF
--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -54,6 +54,35 @@ describe('HttpValidator', () => {
             'does not try to validate the body',
             validate({ request: { body: { id: faker.word.sample(), required: false, contents: [] } } }, undefined, 0)
           );
+
+          it('does not try to validate an explicit zero-length JSON body', () => {
+            const validationResult = validator.validateInput({
+              resource: {
+                method: 'delete',
+                path: '/',
+                id: '1',
+                request: {
+                  body: {
+                    id: faker.word.sample(),
+                    required: false,
+                    contents: [{ id: faker.word.sample(), mediaType: 'application/json' }],
+                  },
+                },
+                responses: [{ id: faker.word.sample(), code: '204' }],
+              },
+              element: {
+                method: 'delete',
+                url: { path: '/', query: {} },
+                headers: {
+                  'content-type': 'application/json',
+                  'content-length': '0',
+                },
+                body: '',
+              },
+            });
+
+            assertRight(validationResult);
+          });
         });
 
         describe('request body is required', () => {

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -86,7 +86,7 @@ const validateInputBody = (
       const contentLength = parseInt(headers.get('content-length')) || 0;
       if (contentLength === 0) {
         // generously allow this content type if there isn't a body actually provided
-        return E.right([requestBody, body, mediaType, multipartBoundary] as const);
+        return E.right([requestBody, O.none as O.Option<unknown>, mediaType, multipartBoundary] as const);
       }
 
       let errorMessage = 'No supported content types, but request included a non-empty body';


### PR DESCRIPTION
## Summary

- Treat requests with `Content-Length: 0` as having no request body before body schema validation
- Add a regression test for `Content-Type: application/json` plus `Content-Length: 0` with an explicit empty string body

Fixes #1745.

## Verification

- RED: `npm test -- packages/http/src/validator/__tests__/index.spec.ts --runInBand --no-watchman` failed with `Right expected, got a Left`
- GREEN: `npm test -- packages/http/src/validator/__tests__/index.spec.ts --runInBand --no-watchman` passed: 19 tests passed, and the `posttest` lint hook completed
- `git diff --check`

AI-assisted disclosure: I used AI assistance to inspect the issue, add the regression test, and prepare this patch. I reviewed the final diff before submitting.
