### PR TITLE
fix: handle invalid request content types

### DIFF
--- a/packages/http/src/validator/__tests__/index.spec.ts
+++ b/packages/http/src/validator/__tests__/index.spec.ts
@@ -73,6 +73,42 @@ describe('HttpValidator', () => {
           );
         });
       });
+
+      describe('content-type header is invalid', () => {
+        it('returns an unsupported media type diagnostic', () => {
+          assertLeft(
+            validator.validateInput({
+              resource: {
+                method: 'post',
+                path: '/',
+                id: '1',
+                request: {
+                  body: {
+                    id: faker.word.sample(),
+                    required: true,
+                    contents: [{ id: faker.word.sample(), mediaType: 'application/json' }],
+                  },
+                },
+                responses: [{ id: faker.word.sample(), code: '200' }],
+              },
+              element: {
+                method: 'post',
+                url: { path: '/', query: {} },
+                headers: { 'content-type': 'undefined', 'content-length': '2' },
+                body: '{}',
+              },
+            }),
+            error =>
+              expect(error).toEqual([
+                {
+                  message: 'Invalid content type: undefined',
+                  code: 415,
+                  severity: DiagnosticSeverity.Error,
+                },
+              ])
+          );
+        });
+      });
     });
 
     describe('headers validation in enabled', () => {

--- a/packages/http/src/validator/index.ts
+++ b/packages/http/src/validator/index.ts
@@ -79,9 +79,21 @@ const validateInputBody = (
     E.map(b => [...b, caseless(headers || {})] as const),
     E.chain(([requestBody, body, headers]) => {
       const contentTypeHeader = headers.get('content-type');
-      const [multipartBoundary, mediaType] = contentTypeHeader
-        ? parseMIMEHeader(contentTypeHeader)
-        : [undefined, undefined];
+      let multipartBoundary: string | undefined;
+      let mediaType: string | undefined;
+      if (contentTypeHeader) {
+        try {
+          [multipartBoundary, mediaType] = parseMIMEHeader(contentTypeHeader);
+        } catch {
+          return E.left<NonEmptyArray<IPrismDiagnostic>>([
+            {
+              message: `Invalid content type: ${contentTypeHeader}`,
+              code: 415,
+              severity: DiagnosticSeverity.Error,
+            },
+          ]);
+        }
+      }
 
       const contentLength = parseInt(headers.get('content-length')) || 0;
       if (contentLength === 0) {


### PR DESCRIPTION
## Summary
- return a normal 415 validation diagnostic when request Content-Type cannot be parsed
- add a regression test for Content-Type: undefined so validation does not throw before building diagnostics

Fixes #2605.

## Verification
- npm test -- packages/http/src/validator/__tests__/index.spec.ts --runInBand --no-watchman
  - includes posttest lint: npm run lint