### PR TITLE
fix: prefer exact response media type schema

### DIFF
--- a/packages/http/src/validator/validators/__tests__/body.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/body.spec.ts
@@ -53,6 +53,40 @@ describe('validate()', () => {
           )
       );
     });
+
+    it('selects an exact response media type before a wildcard match', () => {
+      const specs: IMediaTypeContent[] = [
+        {
+          id: faker.word.sample(),
+          mediaType: 'application/*+json',
+          schema: {
+            type: 'object',
+            required: ['v2Only'],
+            properties: {
+              version: { type: 'string' },
+              v2Only: { type: 'boolean' },
+            },
+          },
+          examples: [],
+          encodings: [],
+        },
+        {
+          id: faker.word.sample(),
+          mediaType: 'application/vnd.stuff.v1+json',
+          schema: {
+            type: 'object',
+            required: ['version'],
+            properties: {
+              version: { type: 'string' },
+            },
+          },
+          examples: [],
+          encodings: [],
+        },
+      ];
+
+      assertRight(validate({ version: 'v1' }, specs, ValidationContext.Output, 'application/vnd.stuff.v1+json'));
+    });
   });
 
   describe('body is form-urlencoded with deep object style', () => {

--- a/packages/http/src/validator/validators/body.ts
+++ b/packages/http/src/validator/validators/body.ts
@@ -19,6 +19,7 @@ import * as mergeAllOf from '@stoplight/json-schema-merge-allof';
 import { stripReadOnlyProperties, stripWriteOnlyProperties } from '../../utils/filterRequiredProperties';
 import { JSONSchema7 } from 'json-schema';
 import { wildcardMediaTypeMatch } from '../utils/wildcardMediaTypeMatch';
+import { parse as parseContentType } from 'content-type';
 
 export function deserializeFormBody(
   schema: JSONSchema,
@@ -156,10 +157,24 @@ export function decodeUriEntities(target: Dictionary<string>, mediaType: string)
 export function findContentByMediaTypeOrFirst(specs: IMediaTypeContent[], mediaType: string) {
   return pipe(
     specs,
-    A.findFirst(spec => wildcardMediaTypeMatch(mediaType, spec.mediaType)),
+    A.findFirst(spec => mediaTypesMatchExactly(mediaType, spec.mediaType)),
+    O.alt(() =>
+      pipe(
+        specs,
+        A.findFirst(spec => wildcardMediaTypeMatch(mediaType, spec.mediaType))
+      )
+    ),
     O.alt(() => A.head(specs)),
     O.map(content => ({ mediaType, content }))
   );
+}
+
+function mediaTypesMatchExactly(mediaTypeA: string, mediaTypeB: string): boolean {
+  try {
+    return parseContentType(mediaTypeA).type.toLowerCase() === parseContentType(mediaTypeB).type.toLowerCase();
+  } catch {
+    return false;
+  }
 }
 
 function deserializeAndValidate(


### PR DESCRIPTION
## Summary

- prefer an exact response media type match before wildcard media type matches during body schema selection
- add a regression test for vendor JSON response content where a wildcard schema appears first

Closes #2509.

## Test

- `npm test -- packages/http/src/validator/validators/__tests__/body.spec.ts --runInBand --no-watchman`
