### PR TITLE
fix: resolve schema validation bug where errors were swallowed

### DIFF
--- a/packages/http/src/validator/validators/__tests__/utils.spec.ts
+++ b/packages/http/src/validator/validators/__tests__/utils.spec.ts
@@ -51,23 +51,41 @@ describe('convertAjvErrors()', () => {
     it('converts properly', () => {
       expect(
         convertAjvErrors(
-          [Object.assign({}, errorObjectFixture, {
-            params: { unevaluatedProperty: 'd' },
-            keyword: 'unevaluatedProperties',
-            message: 'must NOT have unevaluated propertes',
-          })],
+          [
+            Object.assign({}, errorObjectFixture, {
+              params: { unevaluatedProperty: 'd' },
+              keyword: 'unevaluatedProperties',
+              message: 'must NOT have unevaluated propertes',
+            }),
+          ],
           DiagnosticSeverity.Error,
           ValidationContext.Input
         )[0]
       ).toHaveProperty('message', "Request parameter a.b must NOT have unevaluated propertes: 'd'");
     });
-   });
+  });
 });
 
 describe('validateAgainstSchema()', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(convertAjvErrorsModule, 'convertAjvErrors');
+  });
+
+  describe('when schema is invalid', () => {
+    it('returns an error with severity Error', () => {
+      assertSome(
+        validateAgainstSchema('test', { type: 'obj' } as unknown as JSONSchema7, true, ValidationContext.Input, 'pfx'),
+        error => {
+          expect(error).toContainEqual(
+            expect.objectContaining({
+              message: expect.stringContaining('Prism encountered an error processing the schema'),
+              severity: DiagnosticSeverity.Error,
+            })
+          );
+        }
+      );
+    });
   });
 
   describe('has no validation errors', () => {

--- a/packages/http/src/validator/validators/utils.ts
+++ b/packages/http/src/validator/validators/utils.ts
@@ -1,5 +1,6 @@
 import { IPrismDiagnostic } from '@stoplight/prism-core';
 import { DiagnosticSeverity } from '@stoplight/types';
+import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
 import { pipe } from 'fp-ts/function';
 import { NonEmptyArray, fromArray, map } from 'fp-ts/NonEmptyArray';
@@ -139,8 +140,33 @@ export const validateAgainstSchema = (
   bundle?: unknown
 ): O.Option<NonEmptyArray<IPrismDiagnostic>> =>
   pipe(
-    O.tryCatch(() => getValidationFunction(assignAjvInstance(String(schema.$schema), coerce), schema, bundle)),
-    O.chainFirst(validateFn => O.tryCatch(() => validateFn(value))),
-    O.chain(validateFn => pipe(O.fromNullable(validateFn.errors), O.chain(fromArray))),
-    O.map(errors => convertAjvErrors(errors, DiagnosticSeverity.Error, context, prefix))
+    E.tryCatch(
+      () => getValidationFunction(assignAjvInstance(String(schema.$schema), coerce), schema, bundle),
+      err => err
+    ),
+    E.chain(validateFn =>
+      E.tryCatch(
+        () => {
+          validateFn(value);
+          return validateFn.errors;
+        },
+        err => err
+      )
+    ),
+    E.fold(
+      err =>
+        O.some<NonEmptyArray<IPrismDiagnostic>>([
+          {
+            message: `Prism encountered an error processing the schema: ${err instanceof Error ? err.message : String(err)}`,
+            code: 500,
+            severity: DiagnosticSeverity.Error,
+          },
+        ]),
+      errors =>
+        pipe(
+          O.fromNullable(errors),
+          O.chain(fromArray),
+          O.map(errors => convertAjvErrors(errors, DiagnosticSeverity.Error, context, prefix))
+        )
+    )
   );


### PR DESCRIPTION
Closes #2442. 

**What was the problem?**
When providing an invalid OpenAPI schema (e.g. `type: obj`), the validation proxy was silently swallowing the Ajv compilation error and proceeding to pass the request/response validation. The issue stems from the use of `O.tryCatch`, which caught the schema error but simply returned `O.none`, meaning 'no errors'.

**What changed?**
Refactored `validateAgainstSchema` to use `E.tryCatch` so we capture the error from Ajv compilation instead of losing it. The error is now correctly folded into an `IPrismDiagnostic` with a severity of `Error` and a generic code `500`. Also added a regression test for invalid schema objects.

**Why this approach was chosen?**
Using `E.tryCatch` keeps the functional programming approach consistent while exposing the error properly as an array of Prism Diagnostics, matching the expected return type and reporting to the user properly.