### PR TITLE
fix: make bearer token validation case-insensitive

### DIFF
--- a/packages/http/src/validator/validators/security/__tests__/security.spec.ts
+++ b/packages/http/src/validator/validators/security/__tests__/security.spec.ts
@@ -141,6 +141,15 @@ describe('validateSecurity', () => {
       );
     });
 
+    it('passes the validation with lowercase scheme', () => {
+      assertRight(
+        validateSecurity({
+          element: { ...baseRequest, headers: { authorization: 'bearer abc123' } },
+          resource: { security: securityScheme },
+        })
+      );
+    });
+
     it('fails with an invalid security scheme error', () => {
       assertLeft(
         validateSecurity({

--- a/packages/http/src/validator/validators/security/handlers/bearer.ts
+++ b/packages/http/src/validator/validators/security/handlers/bearer.ts
@@ -12,7 +12,7 @@ const bearerHandler = (msg: string, input: Pick<IHttpRequest, 'headers' | 'url'>
 function isBearerToken(inputHeaders: Dictionary<string>) {
   return pipe(
     fromNullable(get(inputHeaders, 'authorization')),
-    map(authorization => !!/^Bearer\s.+$/.exec(authorization)),
+    map(authorization => !!/^Bearer\s.+$/i.exec(authorization)),
     getOrElse(() => false)
   );
 }


### PR DESCRIPTION
Closes #2527.

**What was the problem?**
Prism's `bearerAuth` handler used a case-sensitive regex (`/^Bearer\s.+$/`) to match the `Bearer ` prefix in the `Authorization` header. If a client sent a valid token with a lowercase `bearer ` prefix (which is perfectly valid according to RFC 7235), Prism rejected it, returning a `401` with the error `Invalid security scheme used` instead of forwarding the request to the upstream server (which would then return the actual `403`).

**What changed?**
Updated the regex in `packages/http/src/validator/validators/security/handlers/bearer.ts` to be case-insensitive (`/^Bearer\s.+$/i`). Added a regression test to ensure lowercase prefixes are handled correctly.