### PR TITLE
fix(cli): correct node:cluster import for multiprocess mode

### DIFF
--- a/packages/cli/src/util/createServer.ts
+++ b/packages/cli/src/util/createServer.ts
@@ -2,7 +2,11 @@ import { createLogger } from '@stoplight/prism-core';
 import { IHttpConfig, IHttpRequest } from '@stoplight/prism-http';
 import { createServer as createHttpServer } from '@stoplight/prism-http-server';
 import * as chalk from 'chalk';
-import cluster from 'node:cluster';
+// `@types/node` models node:cluster's API as the module's default export, but at runtime (CJS,
+// without esModuleInterop) the API lives on the module object itself. Import-equals gives the
+// correct runtime object; `.default ?? clusterModule` reconciles the typings with runtime.
+import clusterModule = require('node:cluster');
+const cluster = (clusterModule as typeof clusterModule & { default?: typeof clusterModule }).default ?? clusterModule;
 import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import * as pino from 'pino';


### PR DESCRIPTION
## Problem

Starting the CLI in multiprocess mode (`--multiprocess` / `-m`) crashes immediately with:

```
Cannot read properties of undefined (reading 'isPrimary')
```

`packages/cli/src/util/createServer.ts` imports `node:cluster` as a default import:

```ts
import cluster from 'node:cluster';
```

The project compiles to CommonJS without `esModuleInterop`, so this emits a `.default` property access. `node:cluster` exposes its API on the module object itself, so `.default` is `undefined` at runtime and every subsequent `cluster.*` access throws.

## Fix

Use an import-equals require so the runtime object is the module itself, and reconcile it with `@types/node` (which models the API as a default export):

```ts
import clusterModule = require('node:cluster');
const cluster = (clusterModule as typeof clusterModule & { default?: typeof clusterModule }).default ?? clusterModule;
```

This keeps type-checking happy under the current `tsconfig` while working correctly at runtime.

## Notes

- This commit is cherry-picked from #2807 (authorship preserved — thanks @Ignacio-Vidal). That PR bundles this bugfix together with the OpenTelemetry feature work; this PR extracts only the standalone `node:cluster` fix so it can be reviewed and merged independently.
- Single file changed, +5/-1. No behavior change outside multiprocess startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
